### PR TITLE
Issue 8: Remove standalone project from the shaded artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,6 @@ shadowJar {
         include dependency("io.pravega:pravega-shared-metrics")
         include dependency("io.pravega:pravega-shared-protocol")
         include dependency("io.pravega:pravega-shared-controller")
-        include dependency("io.pravega:pravega-standalone")
     }
 
     // Shading the libraries which could cause potential version conflicts with flink.


### PR DESCRIPTION
**Change log description**
Removed standalone project from the shaded artifact since its only used internally for unit testing.

**Purpose of the change**
Fixes #8 

**What the code does**
Remove unnecessary jar from the shaded artifact

**How to verify it**
./gradlew install and verify the jar contents
