### PR TITLE
[checkstyle] allow Scala imports in Flink connector

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -19,4 +19,7 @@
     <allow pkg="lombok"/>
     <allow pkg="org.apache"/>
 
+    <!-- flink dependencies -->
+    <allow pkg="scala"/>
+    
 </import-control>


### PR DESCRIPTION
**Change log description**
[checkstyle] allow Scala imports in Flink connector

**Purpose of the change**
A change to support #13 (integration test for savepoints), which necessitates importing certain Scala classes (`scala.Option`, etc).

**What the code does**
Allows importation of `scala.*` as we do `java.*`.

**How to verify it**
#13 should build without any checkstyle error.
