### PR TITLE
License header fix for ALv2

### DIFF
--- a/HEADER
+++ b/HEADER
@@ -1,0 +1,8 @@
+Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.		
+		
+Licensed under the Apache License, Version 2.0 (the "License");		
+you may not use this file except in compliance with the License.		
+You may obtain a copy of the License at		
+		
+    http://www.apache.org/licenses/LICENSE-2.0
+    

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,19 @@
 buildscript {
     repositories {
         jcenter()
+
+        // License plugin repo
+        maven {
+            name = 'gradle-plugins'
+            url = 'https://plugins.gradle.org/m2'
+        }
     }
     dependencies {
         classpath group: 'com.github.jengelman.gradle.plugins', name:'shadow', version: shadowGradlePlugin
+
+
+        // License plugin
+        classpath 'gradle.plugin.net.minecrell:licenser:0.2.1'
     }
 }
 
@@ -23,6 +33,22 @@ apply from: 'gradle/checkstyle.gradle'
 apply from: 'gradle/findbugs.gradle'
 apply from: 'gradle/jacoco.gradle'
 apply from: 'gradle/maven.gradle'
+
+   // license plugin
+    apply plugin: 'net.minecrell.licenser'
+
+
+    // License header formatting
+    license {
+        header = new File(rootDir, "HEADER")
+        style {
+            java = 'JAVADOC' // Sets Java license header style to JAVADOC (/**)
+        }
+        exclude  "**/generated/**";
+        include '**/*.java'
+        newLine = false
+    }
+
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-/**
+/*
  *
  *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
  *

--- a/build.gradle
+++ b/build.gradle
@@ -7,19 +7,9 @@
 buildscript {
     repositories {
         jcenter()
-
-        // License plugin repo
-        maven {
-            name = 'gradle-plugins'
-            url = 'https://plugins.gradle.org/m2'
-        }
     }
     dependencies {
         classpath group: 'com.github.jengelman.gradle.plugins', name:'shadow', version: shadowGradlePlugin
-
-
-        // License plugin
-        classpath 'gradle.plugin.net.minecrell:licenser:0.2.1'
     }
 }
 
@@ -33,22 +23,6 @@ apply from: 'gradle/checkstyle.gradle'
 apply from: 'gradle/findbugs.gradle'
 apply from: 'gradle/jacoco.gradle'
 apply from: 'gradle/maven.gradle'
-
-   // license plugin
-    apply plugin: 'net.minecrell.licenser'
-
-
-    // License header formatting
-    license {
-        header = new File(rootDir, "HEADER")
-        style {
-            java = 'JAVADOC' // Sets Java license header style to JAVADOC (/**)
-        }
-        exclude  "**/generated/**";
-        include '**/*.java'
-        newLine = false
-    }
-
 
 repositories {
     jcenter()

--- a/src/main/java/io/pravega/connectors/flink/CheckpointSerializer.java
+++ b/src/main/java/io/pravega/connectors/flink/CheckpointSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/io/pravega/connectors/flink/CheckpointSerializer.java
+++ b/src/main/java/io/pravega/connectors/flink/CheckpointSerializer.java
@@ -1,5 +1,12 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink;
 

--- a/src/main/java/io/pravega/connectors/flink/FlinkExactlyOncePravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkExactlyOncePravegaWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/io/pravega/connectors/flink/FlinkExactlyOncePravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkExactlyOncePravegaWriter.java
@@ -1,5 +1,12 @@
 /**
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink;
 

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -1,5 +1,12 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink;
 

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
@@ -1,6 +1,11 @@
 /**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  */
 package io.pravega.connectors.flink;

--- a/src/main/java/io/pravega/connectors/flink/PravegaEventRouter.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaEventRouter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/io/pravega/connectors/flink/PravegaEventRouter.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaEventRouter.java
@@ -1,6 +1,11 @@
 /**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  */
 package io.pravega.connectors.flink;

--- a/src/main/java/io/pravega/connectors/flink/PravegaWriterMode.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaWriterMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/io/pravega/connectors/flink/PravegaWriterMode.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaWriterMode.java
@@ -1,6 +1,11 @@
 /**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  */
 package io.pravega.connectors.flink;

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -1,7 +1,13 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
-
 package io.pravega.connectors.flink;
 
 import io.pravega.client.admin.ReaderGroupManager;

--- a/src/test/java/io/pravega/connectors/flink/FlinkExactlyOncePravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkExactlyOncePravegaWriterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/io/pravega/connectors/flink/FlinkExactlyOncePravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkExactlyOncePravegaWriterTest.java
@@ -1,5 +1,12 @@
 /**
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink;
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointTest.java
@@ -1,5 +1,12 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink;
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -1,5 +1,12 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink;
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -1,6 +1,11 @@
 /**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  */
 package io.pravega.connectors.flink;

--- a/src/test/java/io/pravega/connectors/flink/ThrottledIntegerGeneratingSource.java
+++ b/src/test/java/io/pravega/connectors/flink/ThrottledIntegerGeneratingSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/io/pravega/connectors/flink/ThrottledIntegerGeneratingSource.java
+++ b/src/test/java/io/pravega/connectors/flink/ThrottledIntegerGeneratingSource.java
@@ -1,5 +1,12 @@
 /**
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink;
 

--- a/src/test/java/io/pravega/connectors/flink/utils/FailingMapper.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/FailingMapper.java
@@ -1,7 +1,13 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
-
 package io.pravega.connectors.flink.utils;
 
 import org.apache.flink.api.common.functions.MapFunction;

--- a/src/test/java/io/pravega/connectors/flink/utils/FlinkMiniClusterWithSavepointCommand.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/FlinkMiniClusterWithSavepointCommand.java
@@ -1,5 +1,12 @@
 /**
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink.utils;
 

--- a/src/test/java/io/pravega/connectors/flink/utils/IntSequenceExactlyOnceValidator.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/IntSequenceExactlyOnceValidator.java
@@ -1,5 +1,12 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink.utils;
 

--- a/src/test/java/io/pravega/connectors/flink/utils/IntegerGeneratingSource.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/IntegerGeneratingSource.java
@@ -1,6 +1,11 @@
 /**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  */
 package io.pravega.connectors.flink.utils;

--- a/src/test/java/io/pravega/connectors/flink/utils/IntegerSerializer.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/IntegerSerializer.java
@@ -1,5 +1,12 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink.utils;
 

--- a/src/test/java/io/pravega/connectors/flink/utils/IntentionalException.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/IntentionalException.java
@@ -1,5 +1,12 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink.utils;
 

--- a/src/test/java/io/pravega/connectors/flink/utils/NotifyingMapper.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/NotifyingMapper.java
@@ -1,5 +1,12 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink.utils;
 

--- a/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
@@ -1,5 +1,12 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink.utils;
 

--- a/src/test/java/io/pravega/connectors/flink/utils/SuccessException.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SuccessException.java
@@ -1,5 +1,12 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink.utils;
 

--- a/src/test/java/io/pravega/connectors/flink/utils/TestUtils.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/TestUtils.java
@@ -1,5 +1,12 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink.utils;
 

--- a/src/test/java/io/pravega/connectors/flink/utils/ThrottledIntegerWriter.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/ThrottledIntegerWriter.java
@@ -1,5 +1,12 @@
 /**
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  */
 package io.pravega.connectors.flink.utils;
 


### PR DESCRIPTION
Now that we have finalized to license under Apache 2.0, here are the changes that are requested before we open source the repo. 
 
