### PR TITLE
Issue 24 - ReaderCheckpointHook failure

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -154,9 +154,18 @@ public class FlinkPravegaReader<T>
         //       See https://github.com/pravega/pravega/issues/553.
         log.info("Creating reader group: {} for the Flink job", this.readerGroupName);
 
-        ReaderGroupManager.withScope(scope, controllerURI)
-                .createReaderGroup(this.readerGroupName, ReaderGroupConfig.builder().startingTime(startTime).build(),
-                        streamNames);
+        //Issue-24 Reader Group uses grpc which uses thread context loader that causes some dependencies not getting
+        //loaded properly https://github.com/grpc/grpc-java/blob/v1.3.0/core/src/main/java/io/grpc/ManagedChannelProvider.java#L132
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+
+        try {
+            ReaderGroupManager.withScope(scope, controllerURI)
+                    .createReaderGroup(this.readerGroupName, ReaderGroupConfig.builder().startingTime(startTime).build(),
+                            streamNames);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
     }
 
     // ------------------------------------------------------------------------
@@ -279,8 +288,15 @@ public class FlinkPravegaReader<T>
 
     @Override
     public MasterTriggerRestoreHook<Checkpoint> createMasterTriggerRestoreHook() {
-        return new ReaderCheckpointHook(this.readerName, this.readerGroupName,
-                this.scopeName, this.controllerURI, this.checkpointInitiateTimeout);
+        //Issue-24
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+        try {
+            return new ReaderCheckpointHook(this.readerName, this.readerGroupName,
+                    this.scopeName, this.controllerURI, this.checkpointInitiateTimeout);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
     }
 
     @Override

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -154,18 +154,9 @@ public class FlinkPravegaReader<T>
         //       See https://github.com/pravega/pravega/issues/553.
         log.info("Creating reader group: {} for the Flink job", this.readerGroupName);
 
-        //Issue-24 Reader Group uses grpc which uses thread context loader that causes some dependencies not getting
-        //loaded properly https://github.com/grpc/grpc-java/blob/v1.3.0/core/src/main/java/io/grpc/ManagedChannelProvider.java#L132
-        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
-        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
-
-        try {
-            ReaderGroupManager.withScope(scope, controllerURI)
-                    .createReaderGroup(this.readerGroupName, ReaderGroupConfig.builder().startingTime(startTime).build(),
-                            streamNames);
-        } finally {
-            Thread.currentThread().setContextClassLoader(originalClassLoader);
-        }
+        ReaderGroupManager.withScope(scope, controllerURI)
+                .createReaderGroup(this.readerGroupName, ReaderGroupConfig.builder().startingTime(startTime).build(),
+                        streamNames);
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
**Change log description**
Addressed classloader issue when master invokes reader checkpoint hook.  Closes #24 

**Purpose of the change**
Reader Group makes use of grpc package which uses thread context classloader that causes some of its dependencies not getting loaded properly when the master hook is invoked.

**What the code does**
Uses appropriate classloader while invoking Reader group class in `ReaderCheckpointHook

**How to verify it**
Running a sample code that uses `FlinkPravegaReader` to read from Pravega stream on a Flink cluster will throw below exception without this fix.
```
io.pravega.shaded.io.grpc.ManagedChannelProvider$ProviderNotFoundException: No functional channel service provider found. Try adding a dependency on the grpc-okhttp or grpc-netty artifact
```