### PR TITLE
[Issue 19] Use a stable default readerName 

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -340,7 +340,7 @@ public class FlinkPravegaReader<T>
     /*
      * Helper method that derives default reader name from stream and scope name
      */
-    private String getDefaultReaderName(final String scope, final Set<String> streamNames) {
+    private static String getDefaultReaderName(final String scope, final Set<String> streamNames) {
         final String delimiter = "-";
         final String reader = streamNames.stream().collect(Collectors.joining(delimiter)) + delimiter + scope;
         int hash = 0;

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -40,6 +40,7 @@ import java.nio.ByteBuffer;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 
 /**
  * Flink source implementation for reading from pravega storage.
@@ -110,7 +111,7 @@ public class FlinkPravegaReader<T>
     public FlinkPravegaReader(final URI controllerURI, final String scope, final Set<String> streamNames,
                               final long startTime, final DeserializationSchema<T> deserializationSchema) {
 
-        this(controllerURI, scope, streamNames, startTime, deserializationSchema, UUID.randomUUID().toString());
+        this(controllerURI, scope, streamNames, startTime, deserializationSchema, null);
     }
 
     /**
@@ -142,13 +143,16 @@ public class FlinkPravegaReader<T>
         Preconditions.checkNotNull(streamNames, "streamNames");
         Preconditions.checkArgument(startTime >= 0, "start time must be >= 0");
         Preconditions.checkNotNull(deserializationSchema, "deserializationSchema");
-        Preconditions.checkNotNull(readerName, "readerName");
+        if (readerName == null) {
+            this.readerName = getDefaultReaderName(scope, streamNames);
+        } else {
+            this.readerName = readerName;
+        }
 
         this.controllerURI = controllerURI;
         this.scopeName = scope;
         this.deserializationSchema = deserializationSchema;
         this.readerGroupName = "flink" + RandomStringUtils.randomAlphanumeric(20).toLowerCase();
-        this.readerName = readerName;
 
         // TODO: This will require the client to have access to the pravega controller and handle any temporary errors.
         //       See https://github.com/pravega/pravega/issues/553.
@@ -331,5 +335,18 @@ public class FlinkPravegaReader<T>
         public T deserialize(ByteBuffer serializedValue) {
             return deserializationSchema.deserialize(serializedValue.array());
         }
+    }
+
+    /*
+     * Helper method that derives default reader name from stream and scope name
+     */
+    private String getDefaultReaderName(final String scope, final Set<String> streamNames) {
+        final String delimiter = "-";
+        final String reader = streamNames.stream().collect(Collectors.joining(delimiter)) + delimiter + scope;
+        int hash = 0;
+        for (int i = 0; i < reader.length(); i++) {
+            hash = reader.charAt(i) + (31 * hash);
+        }
+        return Integer.toString(hash);
     }
 }


### PR DESCRIPTION
Closes #19
 
**Change log description**
Replaced default reader name from using UUID to a stable reader name using stream and scope names

**Purpose of the change**
Since `readerName` is used as checkpoint identifier, a random UUID default value will cause the job to fail when recovering from savepoint
 
**What the code does**
It derives a stable reader name using stream/scope name combination when reader name is not supplied

**How to verify it**
Run a Flink job which uses FlinkPragevaReader as a source (do not pass readerName to the pravega reader class). While the job is running, create a savepoint and try to restart the job from the savepoint. The job will fail to run since the reader name does not match with the previous run. With this fix, the job can be recovered with savepoint.