### PR TITLE
[Issue 16] modified reader id to use a meaningful name for log readability

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -221,7 +221,7 @@ public class FlinkPravegaReader<T>
 
     @Override
     public void run(SourceContext<T> ctx) throws Exception {
-        // the reader ID is random unique per source task
+
         final String readerId = getRuntimeContext().getTaskNameWithSubtasks();
 
         log.info("{} : Creating Pravega reader with ID '{}' for controller URI: {}",

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -38,7 +38,6 @@ import org.apache.flink.util.FlinkException;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
@@ -223,7 +222,7 @@ public class FlinkPravegaReader<T>
     @Override
     public void run(SourceContext<T> ctx) throws Exception {
         // the reader ID is random unique per source task
-        final String readerId = "flink-reader-" + UUID.randomUUID();
+        final String readerId = getRuntimeContext().getTaskNameWithSubtasks();
 
         log.info("{} : Creating Pravega reader with ID '{}' for controller URI: {}",
                 getRuntimeContext().getTaskNameWithSubtasks(), readerId, this.controllerURI);


### PR DESCRIPTION
**Change log description**
Minor change to provide a meaningful name to `readerId`.  Closes #16.

**Purpose of the change**
To improve the log readability.

**What the code does**
It uses a combination of task name + subtask indicator to derive the reader name.

**How to verify it**
The task manager log should dump the reader id information with the above mentioned format when the reader is created.