### PR TITLE
[ISSUE-35] Change Flink version to stable 1.3.1 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 
 # 3rd party Versions.
 checkstyleToolVersion=7.1
-flinkVersion=1.3-SNAPSHOT
+flinkVersion=1.3.1
 lombokVersion=1.16.10
 twitterMvnRepoVersion=4.3.4-TWTTR
 shadowGradlePlugin=1.2.4


### PR DESCRIPTION
Pull request for #35 

**Change log description**
Bumps the linked Flink version from `1.3-SNAPSHOT` to `1.3.1`.

**Verification**

Tests (`./gradlew test`) passes for the `1.3.1` dependency.