### PR TITLE
Usability improvements for PravegaDeserializationSchema

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -21,6 +21,7 @@ import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Serializer;
 
 import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
+import io.pravega.connectors.flink.serialization.WrappingSerializer;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -229,8 +230,9 @@ public class FlinkPravegaReader<T>
                 getRuntimeContext().getTaskNameWithSubtasks(), readerId, this.controllerURI);
 
         // create the adapter between Pravega's serializers and Flink's serializers
-        final Serializer<T> deserializer = this.deserializationSchema instanceof PravegaDeserializationSchema ?
-                ((PravegaDeserializationSchema) this.deserializationSchema).getSerializer() :
+        @SuppressWarnings("unchecked")
+        final Serializer<T> deserializer = this.deserializationSchema instanceof WrappingSerializer ?
+                ((WrappingSerializer<T>) this.deserializationSchema).getWrappedSerializer() :
                 new FlinkDeserializer<>(this.deserializationSchema);
 
         // build the reader

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -20,6 +20,7 @@ import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Serializer;
 
+import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -228,7 +229,9 @@ public class FlinkPravegaReader<T>
                 getRuntimeContext().getTaskNameWithSubtasks(), readerId, this.controllerURI);
 
         // create the adapter between Pravega's serializers and Flink's serializers
-        final Serializer<T> deserializer = new FlinkDeserializer<>(this.deserializationSchema);
+        final Serializer<T> deserializer = this.deserializationSchema instanceof PravegaDeserializationSchema ?
+                ((PravegaDeserializationSchema) this.deserializationSchema).getSerializer() :
+                new FlinkDeserializer<>(this.deserializationSchema);
 
         // build the reader
         try (EventStreamReader<T> pravegaReader = ClientFactory.withScope(this.scopeName, this.controllerURI)

--- a/src/main/java/io/pravega/connectors/flink/serialization/PravegaDeserializationSchema.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/PravegaDeserializationSchema.java
@@ -38,4 +38,8 @@ public class PravegaDeserializationSchema<T extends Serializable> extends Abstra
     public TypeInformation<T> getProducedType() {
         return TypeInformation.of(typeClass);
     }
+
+    public Serializer<T> getSerializer() {
+        return serializer;
+    }
 }

--- a/src/main/java/io/pravega/connectors/flink/serialization/PravegaDeserializationSchema.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/PravegaDeserializationSchema.java
@@ -13,20 +13,90 @@ import io.pravega.client.stream.Serializer;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+
+import org.apache.flink.api.common.functions.InvalidTypesException;
+import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.AbstractDeserializationSchema;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A deserialization schema adapter for a Pravega serializer.
+ * 
+ * <p>This adapter exposes the Pravega serializer as a Flink Deserialization schema and
+ * exposes the produced type (TypeInformation) to allow Flink to configure its internal
+ * serialization and persistence stack.
  */
 public class PravegaDeserializationSchema<T extends Serializable> extends AbstractDeserializationSchema<T> {
-    private final Class<T> typeClass;
+
+    // The TypeInformation of the produced type
+    private final TypeInformation<T> typeInfo;
+
+    // The Pravega serializer that backs this Flink DeserializationSchema
     private final Serializer<T> serializer;
 
+    /**
+     * Creates a new PravegaDeserializationSchema using the given Pravega serializer, and the
+     * type described by the type class.
+     *
+     * <p>Use this constructor if the produced type is not generic and can be fully described by
+     * a class. If the type is generic, use the {@link #PravegaDeserializationSchema(TypeHint, Serializer)}
+     * constructor instead.
+     * 
+     * @param typeClass  The class describing the deserialized type.
+     * @param serializer The serializer to deserialize the byte messages.
+     */
     public PravegaDeserializationSchema(Class<T> typeClass, Serializer<T> serializer) {
-        this.typeClass = typeClass;
+        checkNotNull(typeClass);
+        checkSerializer(serializer);
+
+        this.serializer = serializer;
+
+        try {
+            this.typeInfo = TypeInformation.of(typeClass);
+        } catch (InvalidTypesException e) {
+            throw new IllegalArgumentException("Cannot Due to Java's type erasure, the generic type information cannot Cannot determine generric runtime");
+        }
+    }
+
+    /**
+     * Creates a new PravegaDeserializationSchema using the given Pravega serializer, and the
+     * type described by the type hint.
+     * 
+     * <p>Use this constructor if the produced type is generic and cannot be fully described by
+     * a class alone. The type hint instantiation captures generic type information to make it
+     * available at runtime.
+     * 
+     * <pre>{@code
+     * DeserializationSchema<Tuple2<String, String>> schema = 
+     *     new PravegaDeserializationSchema(new TypeHint<Tuple2<String, String>>(){}, serializer);
+     * }</pre>
+     * 
+     * @param typeHint The Type Hint describing the deserialized type.
+     * @param serializer The serializer to deserialize the byte messages.
+     */
+    public PravegaDeserializationSchema(TypeHint<T> typeHint, Serializer<T> serializer) {
+        this(TypeInformation.of(typeHint), serializer);
+    }
+
+    /**
+     * Creates a new PravegaDeserializationSchema using the given Pravega serializer, and the
+     * given TypeInformation.
+     * 
+     * @param typeInfo The TypeInformation describing the deserialized type.
+     * @param serializer The serializer to deserialize the byte messages.
+     */
+    public PravegaDeserializationSchema(TypeInformation<T> typeInfo, Serializer<T> serializer) {
+        checkNotNull(typeInfo, "typeInfo");
+        checkSerializer(serializer);
+
+        this.typeInfo = typeInfo;
         this.serializer = serializer;
     }
+
+    // ------------------------------------------------------------------------
 
     @Override
     public T deserialize(byte[] message) throws IOException {
@@ -36,10 +106,18 @@ public class PravegaDeserializationSchema<T extends Serializable> extends Abstra
 
     @Override
     public TypeInformation<T> getProducedType() {
-        return TypeInformation.of(typeClass);
+        return typeInfo;
     }
 
     public Serializer<T> getSerializer() {
         return serializer;
+    }
+
+    // ------------------------------------------------------------------------
+
+    private static void checkSerializer(Serializer<?> serializer) {
+        checkNotNull(serializer, "serializer");
+        checkArgument(serializer instanceof Serializable,
+                "The serializer class must be serializable (java.io.Serializable).");
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/serialization/PravegaSerializationSchema.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/PravegaSerializationSchema.java
@@ -29,8 +29,14 @@ public class PravegaSerializationSchema<T>
     @Override
     public byte[] serialize(T element) {
         ByteBuffer buf = serializer.serialize(element);
-        assert buf.hasArray();
-        return buf.array();
+        
+        if (buf.hasArray() && buf.arrayOffset() == 0 && buf.position() == 0 && buf.limit() == buf.capacity()) {
+            return buf.array();
+        } else {
+            byte[] bytes = new byte[buf.remaining()];
+            buf.get(bytes);
+            return bytes;
+        }
     }
 
     @Override

--- a/src/main/java/io/pravega/connectors/flink/serialization/PravegaSerializationSchema.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/PravegaSerializationSchema.java
@@ -10,14 +10,16 @@
 package io.pravega.connectors.flink.serialization;
 
 import io.pravega.client.stream.Serializer;
-import java.io.Serializable;
 import java.nio.ByteBuffer;
 import org.apache.flink.streaming.util.serialization.SerializationSchema;
 
 /**
  * A serialization schema adapter for a Pravega serializer.
  */
-public class PravegaSerializationSchema<T extends Serializable> implements SerializationSchema<T> {
+public class PravegaSerializationSchema<T> 
+        implements SerializationSchema<T>, WrappingSerializer<T> {
+
+    // the Pravega serializer
     private final Serializer<T> serializer;
 
     public PravegaSerializationSchema(Serializer<T> serializer) {
@@ -29,5 +31,10 @@ public class PravegaSerializationSchema<T extends Serializable> implements Seria
         ByteBuffer buf = serializer.serialize(element);
         assert buf.hasArray();
         return buf.array();
+    }
+
+    @Override
+    public Serializer<T> getWrappedSerializer() {
+        return serializer;
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/serialization/WrappingSerializer.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/WrappingSerializer.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink.serialization;
+
+import io.pravega.client.stream.Serializer;
+
+/**
+ * Interface for serializers that wrap Pravega's {@link Serializer}.
+ */
+public interface WrappingSerializer<T>  {
+
+    /**
+     * Gets the wrapped Pravega Serializer.
+     */
+    Serializer<T> getWrappedSerializer();
+}

--- a/src/test/java/io/pravega/connectors/flink/FlinkSerializerWrapperTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkSerializerWrapperTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink;
+
+import io.pravega.client.stream.Serializer;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+public class FlinkSerializerWrapperTest {
+
+    @Test
+    public void testNotFullyWrappingByteBuffer() throws IOException {
+        for (boolean direct : new boolean[] { false, true} ) {
+            runBufferLargerThanEventTest(8, 0, 8, direct);
+            runBufferLargerThanEventTest(32, 0, 32, direct);
+            runBufferLargerThanEventTest(16, 2, 11, direct);
+            runBufferLargerThanEventTest(24, 1, 19, direct);
+            runBufferLargerThanEventTest(15, 3, 8, direct);
+        }
+
+    }
+
+    private void runBufferLargerThanEventTest(int capacity, int offset, int size, boolean direct) throws IOException {
+        final DeserializationSchema<Long> flinkDeserializer = new LongDeserializationSchema();
+        final Serializer<Long> wrappingSerializer = new FlinkPravegaReader.FlinkDeserializer<>(flinkDeserializer);
+
+        // we create some sliced byte buffers that do not always the first
+        // bytes or all bytes of the backing array;
+        final ByteBuffer rawBuffer = direct ? ByteBuffer.allocateDirect(capacity) :
+                ByteBuffer.allocate(capacity);
+        final ByteBuffer buffer;
+
+        if (size == capacity && offset == 0) {
+            buffer = rawBuffer;
+        } else {
+            rawBuffer.position(offset);
+            rawBuffer.limit(offset + size);
+            buffer = rawBuffer.slice();
+        }
+        
+        final Random rnd = new Random();
+
+        for (int num = 100; num > 0; --num) {
+            final long value = rnd.nextLong();
+            buffer.clear();
+            buffer.putLong(value);
+            buffer.flip();
+
+            long deserialized = wrappingSerializer.deserialize(buffer);
+            assertEquals(value, deserialized);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    private static class LongDeserializationSchema implements DeserializationSchema<Long> {
+
+        @Override
+        public Long deserialize(byte[] message) throws IOException {
+            return ByteBuffer.wrap(message).getLong();
+        }
+
+        @Override
+        public boolean isEndOfStream(Long nextElement) {
+            return false;
+        }
+
+        @Override
+        public TypeInformation<Long> getProducedType() {
+            // not relevant for this test
+            throw new UnsupportedOperationException("not implemented");
+        }
+    }
+}


### PR DESCRIPTION
**Change log description**

Adds various small improvements to the `PravegaDeserializationSchema`:

  - Avoid redundant double-wrapping of serializers in FlinkPraveaReader
  - Adds a check that the Pavega serializer is serializable (otherwise this gives an exception on execution).
  - Fully support Flink's type information spectrum (also generic types that need to be captured)
  - Add more convenience constructors

**How to verify it**

Checkstyle and unit tests pass.
