### PR TITLE
Support for event time ordering of elements produced by the sink

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,12 @@ dependencies {
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jApiVersion
     compileOnly group: 'org.apache.flink', name: 'flink-streaming-java_2.11', version: flinkVersion
     testCompile group: 'junit', name: 'junit', version: junitVersion
+    testCompile group: 'org.mockito', name: 'mockito-all', version: mockitoVersion
     testCompile group: 'org.apache.flink', name: 'flink-tests_2.11', version: flinkVersion
     testCompile group: 'org.apache.flink', name: 'flink-test-utils_2.11', version: flinkVersion
     testCompile group: 'org.apache.flink', name: 'flink-streaming-contrib_2.11', version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-streaming-java_2.11', classifier: 'tests', version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-runtime_2.11', classifier: 'tests', version: flinkVersion
     testCompile group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion
 
     //  configuring the shaded pom dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@ twitterMvnRepoVersion=4.3.4-TWTTR
 shadowGradlePlugin=1.2.4
 slf4jApiVersion=1.7.14
 junitVersion=4.12
+mockitoVersion=1.10.19
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.1.0-SNAPSHOT

--- a/src/main/java/io/pravega/connectors/flink/EventTimeOrderingOperator.java
+++ b/src/main/java/io/pravega/connectors/flink/EventTimeOrderingOperator.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.PriorityQueue;
 
 /**
+ * Orders elements into event time order using the watermark and managed state to buffer elements.
+ *
  * @param <K>  Type of the keys
  * @param <IN> The input type of the operator
  */

--- a/src/main/java/io/pravega/connectors/flink/EventTimeOrderingOperator.java
+++ b/src/main/java/io/pravega/connectors/flink/EventTimeOrderingOperator.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+
+/**
+ * @param <K>  Type of the keys
+ * @param <IN> The input type of the operator
+ */
+public class EventTimeOrderingOperator<K, IN> extends AbstractStreamOperator<IN>
+        implements OneInputStreamOperator<IN, IN>, Triggerable<K, VoidNamespace>, InputTypeConfigurable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String EVENT_QUEUE_STATE_NAME = "eventQueue";
+
+    /**
+     * The input type serializer for buffering events to managed state.
+     */
+    private TypeSerializer<IN> inputSerializer;
+
+    /**
+     * The timer service.
+     */
+    private transient InternalTimerService<VoidNamespace> internalTimerService;
+
+    /**
+     * The queue of input elements keyed by event timestamp.
+     */
+    private transient MapState<Long, List<IN>> elementQueueState;
+
+    /**
+     * The last seen watermark. This will be used to
+     * decide if an incoming element is late or not.
+     */
+    @VisibleForTesting
+    long lastWatermark = Long.MIN_VALUE;
+
+    /**
+     * Creates an event time-based reordering operator.
+     */
+    public EventTimeOrderingOperator() {
+        chainingStrategy = ChainingStrategy.ALWAYS;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setInputType(TypeInformation<?> type, ExecutionConfig executionConfig) {
+        this.inputSerializer = (TypeSerializer<IN>) type.createSerializer(executionConfig);
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+
+        // create a map-based queue to buffer input elements
+        if (elementQueueState == null) {
+            elementQueueState = getRuntimeContext().getMapState(
+                    new MapStateDescriptor<>(
+                            EVENT_QUEUE_STATE_NAME,
+                            LongSerializer.INSTANCE,
+                            new ListSerializer<>(inputSerializer)
+                    )
+            );
+        }
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        internalTimerService = getInternalTimerService("ordering-timers", VoidNamespaceSerializer.INSTANCE, this);
+    }
+
+    @Override
+    public void processElement(StreamRecord<IN> element) throws Exception {
+        if (!element.hasTimestamp()) {
+            // elements with no time component are simply forwarded.
+            // likely cause: the time characteristic of the program is not event-time.
+            output.collect(element);
+            return;
+        }
+
+        // In event-time processing we assume correctness of the watermark.
+        // Events with timestamp smaller than (or equal to) the last seen watermark are considered late.
+        // FUTURE: emit late elements to a side output
+
+        if (element.getTimestamp() > lastWatermark) {
+            // we have an event with a valid timestamp, so
+            // we buffer it until we receive the proper watermark.
+            saveRegisterWatermarkTimer();
+            bufferEvent(element);
+        }
+    }
+
+    @Override
+    public void processWatermark(Watermark mark) throws Exception {
+        super.processWatermark(mark);
+        lastWatermark = mark.getTimestamp();
+    }
+
+    /**
+     * Buffers an element for future processing.
+     *
+     * @param element the element to buffer.
+     * @throws Exception if any error occurs.
+     */
+    private void bufferEvent(StreamRecord<IN> element) throws Exception {
+
+        assert (element.hasTimestamp());
+        long timestamp = element.getTimestamp();
+
+        List<IN> elementsForTimestamp = elementQueueState.get(timestamp);
+        if (elementsForTimestamp == null) {
+            elementsForTimestamp = new ArrayList<>(1);
+        }
+
+        if (getRuntimeContext().getExecutionConfig().isObjectReuseEnabled()) {
+            // copy the object so that the original object may be reused
+            elementsForTimestamp.add(inputSerializer.copy(element.getValue()));
+        } else {
+            elementsForTimestamp.add(element.getValue());
+        }
+        elementQueueState.put(timestamp, elementsForTimestamp);
+    }
+
+    /**
+     * Registers a timer for {@code current watermark + 1}, this means that we get triggered
+     * whenever the watermark advances, which is what we want for working off the queue of
+     * buffered elements.
+     */
+    private void saveRegisterWatermarkTimer() {
+        long currentWatermark = internalTimerService.currentWatermark();
+        // protect against overflow
+        if (currentWatermark + 1 > currentWatermark) {
+            internalTimerService.registerEventTimeTimer(VoidNamespace.INSTANCE, currentWatermark + 1);
+        }
+    }
+
+    /**
+     * Occurs when an event-time timer fires due to watermark progression.
+     *
+     * @param timer the timer details.
+     */
+    @Override
+    public void onEventTime(InternalTimer<K, VoidNamespace> timer) throws Exception {
+
+        long currentWatermark = internalTimerService.currentWatermark();
+
+        PriorityQueue<Long> sortedTimestamps = getSortedTimestamps();
+        while (!sortedTimestamps.isEmpty() && sortedTimestamps.peek() <= currentWatermark) {
+            long timestamp = sortedTimestamps.poll();
+            for (IN event : elementQueueState.get(timestamp)) {
+                output.collect(new StreamRecord<>(event, timestamp));
+            }
+            elementQueueState.remove(timestamp);
+        }
+
+        if (sortedTimestamps.isEmpty()) {
+            elementQueueState.clear();
+        }
+
+        if (!sortedTimestamps.isEmpty()) {
+            saveRegisterWatermarkTimer();
+        }
+    }
+
+    @Override
+    public void onProcessingTime(InternalTimer<K, VoidNamespace> timer) throws Exception {
+    }
+
+    /**
+     * Gets the sorted timestamps of any buffered events.
+     *
+     * @return a sorted list of timestamps that have at least one buffered event.
+     */
+    private PriorityQueue<Long> getSortedTimestamps() throws Exception {
+        PriorityQueue<Long> sortedTimestamps = new PriorityQueue<>();
+        for (Long timestamp : elementQueueState.keys()) {
+            sortedTimestamps.offer(timestamp);
+        }
+        return sortedTimestamps;
+    }
+}

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
@@ -100,6 +100,13 @@ public class FlinkPravegaWriter<T> extends RichSinkFunction<T> implements Checkp
     }
 
     /**
+     * Gets the associated event router.
+     */
+    public PravegaEventRouter<T> getEventRouter() {
+        return this.eventRouter;
+    }
+
+    /**
      * Set this writer's operating mode.
      *
      * @param writerMode    The mode of operation.

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -1,0 +1,34 @@
+package io.pravega.connectors.flink.util;
+
+import io.pravega.connectors.flink.EventTimeOrderingOperator;
+import io.pravega.connectors.flink.FlinkPravegaWriter;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+
+public class FlinkPravegaUtils {
+
+    /**
+     * Writes a stream of elements to a Pravega stream with event time ordering.
+     * <p>
+     * This method returns a sink that automatically reorders events by their event timestamp.  The ordering
+     * is preserved by Pravega using the associated routing key.
+     *
+     * @param stream      the stream to read.
+     * @param writer      the Pravega writer to use.
+     * @param parallelism the degree of parallelism for the writer.
+     * @param <T>         The type of the event.
+     * @return a sink.
+     */
+    public static <T> DataStreamSink<T> writeToPravegaInEventTimeOrder(DataStream<T> stream, FlinkPravegaWriter<T> writer, int parallelism) {
+        // a keyed stream is used to ensure that all elements for a given key are forwarded to the same writer instance.
+        // the parallelism must match between the ordering operator and the sink operator to ensure that
+        // a forwarding strategy (as opposed to a rebalancing strategy) is used by Flink between the two operators.
+        return stream
+                .keyBy(new PravegaEventRouterKeySelector<>(writer.getEventRouter()))
+                .transform("reorder", stream.getType(), new EventTimeOrderingOperator<>()).setParallelism(parallelism)
+                .addSink(writer).setParallelism(parallelism);
+    }
+
+    private FlinkPravegaUtils() {
+    }
+}

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.connectors.flink.util;
 
 import io.pravega.connectors.flink.EventTimeOrderingOperator;
@@ -6,6 +15,9 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 
 public class FlinkPravegaUtils {
+
+    private FlinkPravegaUtils() {
+    }
 
     /**
      * Writes a stream of elements to a Pravega stream with event time ordering.
@@ -27,8 +39,5 @@ public class FlinkPravegaUtils {
                 .keyBy(new PravegaEventRouterKeySelector<>(writer.getEventRouter()))
                 .transform("reorder", stream.getType(), new EventTimeOrderingOperator<>()).setParallelism(parallelism)
                 .addSink(writer).setParallelism(parallelism);
-    }
-
-    private FlinkPravegaUtils() {
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/util/PravegaEventRouterKeySelector.java
+++ b/src/main/java/io/pravega/connectors/flink/util/PravegaEventRouterKeySelector.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink.util;
+
+import io.pravega.connectors.flink.PravegaEventRouter;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+/**
+ * Implements a Flink {@link KeySelector} based on a Pravega {@link PravegaEventRouter}.  The event router
+ * must implement {@link Serializable}.
+ *
+ * @param <T> The type of the event.
+ */
+class PravegaEventRouterKeySelector<T> implements KeySelector<T, String>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final PravegaEventRouter<T> eventRouter;
+
+    /**
+     * Creates a new key selector.
+     *
+     * @param eventRouter the event router to use.
+     */
+    public PravegaEventRouterKeySelector(PravegaEventRouter<T> eventRouter) {
+        this.eventRouter = Preconditions.checkNotNull(eventRouter);
+    }
+
+    @Override
+    public String getKey(T value) throws Exception {
+        return this.eventRouter.getRoutingKey(value);
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/EventTimeOrderingOperatorTest.java
+++ b/src/test/java/io/pravega/connectors/flink/EventTimeOrderingOperatorTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.junit.Assert.assertEquals;
+
+@Slf4j
+public class EventTimeOrderingOperatorTest {
+
+    private static final String K1 = "K1";
+
+    private EventTimeOrderingOperator<String, Tuple2<String, Long>> operator;
+    private KeyedOneInputStreamOperatorTestHarness<String, Tuple2<String, Long>, Tuple2<String, Long>> testHarness;
+
+    @Before
+    public void before() throws Exception {
+        operator = new EventTimeOrderingOperator<>();
+        operator.setInputType(TypeInformation.of(new TypeHint<Tuple2<String, Long>>() {
+        }), new ExecutionConfig());
+        testHarness = new KeyedOneInputStreamOperatorTestHarness<>(
+                operator, in -> in.f0, TypeInformation.of(String.class));
+        testHarness.setTimeCharacteristic(TimeCharacteristic.EventTime);
+        testHarness.open();
+    }
+
+    @After
+    public void after() throws Exception {
+        testHarness.close();
+        operator.close();
+    }
+
+    @Test
+    public void testOrdering() throws Exception {
+
+        // emit some out of order events for a given key.
+        // numerous events are emitted for timestamp 2 to validate support for having
+        // more than one event at a given timestamp.
+        testHarness.processElement(record(K1, 1L));
+        testHarness.processElement(record(K1, 3L));
+        testHarness.processElement(record(K1, 2L));
+        testHarness.processElement(record(K1, 2L));
+        testHarness.processElement(record(K1, 4L));
+
+        // advance to timestamp 3, expecting a subset of elements to be emitted.
+        {
+            testHarness.processWatermark(3L);
+            Queue<Object> actual = testHarness.getOutput();
+            Queue<Object> expected = new ConcurrentLinkedQueue<>();
+            expected.add(record(K1, 1L));
+            expected.add(record(K1, 2L));
+            expected.add(record(K1, 2L));
+            expected.add(record(K1, 3L));
+            expected.add(watermark(3L));
+            TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
+            actual.clear();
+        }
+
+        // advance to timestamp 4, expecting the final element to be emitted.
+        {
+            testHarness.processWatermark(4L);
+            Queue<Object> actual = testHarness.getOutput();
+            Queue<Object> expected = new ConcurrentLinkedQueue<>();
+            expected.add(record(K1, 4L));
+            expected.add(watermark(4L));
+            TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
+            actual.clear();
+        }
+
+        // advance to timestamp 5, expecting no elements to be emitted.
+        {
+            testHarness.processWatermark(5L);
+            Queue<Object> actual = testHarness.getOutput();
+            Queue<Object> expected = new ConcurrentLinkedQueue<>();
+            expected.add(watermark(5L));
+            TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
+            actual.clear();
+        }
+    }
+
+    @Test
+    public void testLateElements() throws Exception {
+        testHarness.processWatermark(1L);
+        assertEquals(1L, operator.lastWatermark);
+        testHarness.processElement(record(K1, 0L));
+        testHarness.processElement(record(K1, 1L));
+        testHarness.processWatermark(2L);
+        assertEquals(2L, operator.lastWatermark);
+
+        Queue<Object> actual = testHarness.getOutput();
+        Queue<Object> expected = new ConcurrentLinkedQueue<>();
+        expected.add(watermark(1L));
+        expected.add(watermark(2L));
+        TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
+    }
+
+    @Test
+    public void testProcessingTime() throws Exception {
+        testHarness.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
+        testHarness.processElement(new StreamRecord<>(new Tuple2<>(K1, 0L)));
+        Queue<Object> actual = testHarness.getOutput();
+        Queue<Object> expected = new ConcurrentLinkedQueue<>();
+        expected.add(new StreamRecord<>(new Tuple2<>(K1, 0L)));
+        TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
+    }
+
+    // ------ utility methods
+
+    private static StreamRecord<Tuple2<String, Long>> record(String key, long timestamp) {
+        return new StreamRecord<>(new Tuple2<>(key, timestamp), timestamp);
+    }
+
+    private static Watermark watermark(long timestamp) {
+        return new Watermark(timestamp);
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/EventTimeOrderingOperatorTest.java
+++ b/src/test/java/io/pravega/connectors/flink/EventTimeOrderingOperatorTest.java
@@ -56,6 +56,9 @@ public class EventTimeOrderingOperatorTest {
     @Test
     public void testOrdering() throws Exception {
 
+        Queue<Object> actual;
+        Queue<Object> expected;
+
         // emit some out of order events for a given key.
         // numerous events are emitted for timestamp 2 to validate support for having
         // more than one event at a given timestamp.
@@ -66,39 +69,33 @@ public class EventTimeOrderingOperatorTest {
         testHarness.processElement(record(K1, 4L));
 
         // advance to timestamp 3, expecting a subset of elements to be emitted.
-        {
-            testHarness.processWatermark(3L);
-            Queue<Object> actual = testHarness.getOutput();
-            Queue<Object> expected = new ConcurrentLinkedQueue<>();
-            expected.add(record(K1, 1L));
-            expected.add(record(K1, 2L));
-            expected.add(record(K1, 2L));
-            expected.add(record(K1, 3L));
-            expected.add(watermark(3L));
-            TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
-            actual.clear();
-        }
+        testHarness.processWatermark(3L);
+        actual = testHarness.getOutput();
+        expected = new ConcurrentLinkedQueue<>();
+        expected.add(record(K1, 1L));
+        expected.add(record(K1, 2L));
+        expected.add(record(K1, 2L));
+        expected.add(record(K1, 3L));
+        expected.add(watermark(3L));
+        TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
+        actual.clear();
 
         // advance to timestamp 4, expecting the final element to be emitted.
-        {
-            testHarness.processWatermark(4L);
-            Queue<Object> actual = testHarness.getOutput();
-            Queue<Object> expected = new ConcurrentLinkedQueue<>();
-            expected.add(record(K1, 4L));
-            expected.add(watermark(4L));
-            TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
-            actual.clear();
-        }
+        testHarness.processWatermark(4L);
+        actual = testHarness.getOutput();
+        expected = new ConcurrentLinkedQueue<>();
+        expected.add(record(K1, 4L));
+        expected.add(watermark(4L));
+        TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
+        actual.clear();
 
         // advance to timestamp 5, expecting no elements to be emitted.
-        {
-            testHarness.processWatermark(5L);
-            Queue<Object> actual = testHarness.getOutput();
-            Queue<Object> expected = new ConcurrentLinkedQueue<>();
-            expected.add(watermark(5L));
-            TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
-            actual.clear();
-        }
+        testHarness.processWatermark(5L);
+        actual = testHarness.getOutput();
+        expected = new ConcurrentLinkedQueue<>();
+        expected.add(watermark(5L));
+        TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
+        actual.clear();
     }
 
     @Test


### PR DESCRIPTION
**Change log description**
Support for event time ordering of elements produced by the sink.
Closes issue #45.

**Purpose of the change**
This PR provides a facility for reordering a program's output events into event time order, in combination with the natural ordering guarantee of Pravega routing keys.   It works by combining a keyed stream, a custom operator that reorders elements, and a forwarding strategy to the normal sink.

**What the code does**
The code provides three new classes:
- `EventTimeOrderingOperator` - a generic operator that reorders events into event time (using the watermark to flush event buffers).
- `PravegaEventRouterKeySelector` - a helper class to use a pravega event router as the key selector for a Flink keyed stream.
- `FlinkPravegaUtils` - a convenience method to assemble the topology.

**How to verify it**
Unit tests are provided - `EventTimeOrderingOperatorTest`.