### PR TITLE
Setting a port for restserver.

### DIFF
--- a/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
@@ -68,6 +68,7 @@ public final class SetupUtils {
                 .isInMemStorage(true)
                 .isInProcController(true)
                 .controllerCount(1)
+                .restServerPort(8000)
                 .isInProcSegmentStore(true)
                 .segmentStoreCount(1)
                 .containerCount(4)

--- a/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
@@ -68,7 +68,7 @@ public final class SetupUtils {
                 .isInMemStorage(true)
                 .isInProcController(true)
                 .controllerCount(1)
-                .restServerPort(8000)
+                .restServerPort(TestUtils.getAvailableListenPort())
                 .isInProcSegmentStore(true)
                 .segmentStoreCount(1)
                 .containerCount(4)

--- a/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang3.RandomStringUtils;
 
 /**
  * Utility functions for creating the test setup.
@@ -45,7 +46,7 @@ public final class SetupUtils {
 
     // The test Scope name.
     @Getter
-    private final String scope = "scope";
+    private final String scope = RandomStringUtils.randomAlphabetic(20);;
 
     /**
      * Start all pravega related services required for the test deployment.
@@ -61,6 +62,8 @@ public final class SetupUtils {
         int zkPort = TestUtils.getAvailableListenPort();
         int controllerPort = TestUtils.getAvailableListenPort();
         int hostPort = TestUtils.getAvailableListenPort();
+        int restPort = TestUtils.getAvailableListenPort();
+
         this.inProcPravegaCluster = InProcPravegaCluster.builder()
                 .isInProcZK(true)
                 .zkUrl("localhost:" + zkPort)
@@ -68,7 +71,7 @@ public final class SetupUtils {
                 .isInMemStorage(true)
                 .isInProcController(true)
                 .controllerCount(1)
-                .restServerPort(TestUtils.getAvailableListenPort())
+                .restServerPort(restPort)
                 .isInProcSegmentStore(true)
                 .segmentStoreCount(1)
                 .containerCount(4)
@@ -77,6 +80,9 @@ public final class SetupUtils {
         this.inProcPravegaCluster.setSegmentStorePorts(new int[]{hostPort});
         this.inProcPravegaCluster.start();
         log.info("Initialized Pravega Cluster");
+        log.info("Controller port is {}", controllerPort);
+        log.info("Host port is {}", hostPort);
+        log.info("REST server port is {}", restPort);
     }
 
     /**


### PR DESCRIPTION
**Change log description**
Sets a port for the rest server.
**Purpose of the change**
This will fix errors when `InProcPravegaCluster` is instantiated during the tests.
**What the code does**
Sets a value for the port.
**How to verify it**
Unit tests do not fail at  `InProcPravegaCluster` initialization.