### PR TITLE
[Issue #42] Add initial batch read support for Flink Pravega Connectors

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.connectors.flink;
+
+import com.google.common.base.Preconditions;
+
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.stream.EventRead;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroupConfig;
+
+import org.apache.flink.api.common.io.GenericInputFormat;
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.core.io.GenericInputSplit;
+import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Set;
+
+import static io.pravega.connectors.flink.util.FlinkPravegaUtils.createPravegaReader;
+import static io.pravega.connectors.flink.util.FlinkPravegaUtils.generateRandomReaderGroupName;
+
+/**
+ * A Flink {@link InputFormat} that can be added as a source to read from Pravega in a Flink batch job.
+ */
+public class FlinkPravegaInputFormat<T> extends GenericInputFormat<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final long DEFAULT_EVENT_READ_TIMEOUT = 1000;
+
+    // The supplied event deserializer.
+    private final DeserializationSchema<T> deserializationSchema;
+
+    // The pravega controller endpoint.
+    private final URI controllerURI;
+
+    // The scope name of the destination stream.
+    private final String scopeName;
+
+    // The readergroup name to coordinate the parallel readers. This should be unique for a Flink job.
+    private final String readerGroupName;
+
+    // The names of Pravega streams to read
+    private final Set<String> streamNames;
+
+    // The configured start time for the reader
+    private final long startTime;
+
+    // The event read timeout
+    private long eventReadTimeout = DEFAULT_EVENT_READ_TIMEOUT;
+
+    // The Pravega reader; a new reader will be opened for each input split
+    private transient EventStreamReader<T> pravegaReader;
+
+    // Read-ahead event; null indicates that end of input is reached
+    private transient EventRead<T> lastReadAheadEvent;
+
+    /**
+     * Creates a new Flink Pravega {@link InputFormat} which can be added as a source to a Flink batch job.
+     *
+     * <p>The number of created input splits is equivalent to the parallelism of the source. For each input split,
+     * a Pravega reader will be created to read from the specified Pravega streams. Each input split is closed when
+     * the next read event returns {@code null} on {@link EventRead#getEvent()}.
+     *
+     * @param controllerURI         The pravega controller endpoint address.
+     * @param scope                 The destination stream's scope name.
+     * @param streamNames           The list of stream names to read events from.
+     * @param startTime             The start time from when to read events from.
+     *                              Use 0 to read all stream events from the beginning.
+     * @param deserializationSchema The implementation to deserialize events from pravega streams.
+     */
+    public FlinkPravegaInputFormat(
+            final URI controllerURI,
+            final String scope,
+            final Set<String> streamNames,
+            final long startTime,
+            final DeserializationSchema<T> deserializationSchema) {
+
+        Preconditions.checkNotNull(controllerURI, "controllerURI");
+        Preconditions.checkNotNull(scope, "scope");
+        Preconditions.checkNotNull(streamNames, "streamNames");
+        Preconditions.checkArgument(startTime >= 0, "start time must be >= 0");
+        Preconditions.checkNotNull(deserializationSchema, "deserializationSchema");
+
+        this.controllerURI = controllerURI;
+        this.scopeName = scope;
+        this.deserializationSchema = deserializationSchema;
+        this.streamNames = streamNames;
+        this.startTime = startTime;
+        this.readerGroupName = generateRandomReaderGroupName();
+
+        // TODO: This will require the client to have access to the pravega controller and handle any temporary errors.
+        ReaderGroupManager.withScope(scopeName, controllerURI)
+                .createReaderGroup(this.readerGroupName, ReaderGroupConfig.builder().startingTime(startTime).build(),
+                        streamNames);
+    }
+
+    // ------------------------------------------------------------------------
+    //  User configurations
+    // ------------------------------------------------------------------------
+
+    /**
+     * Gets the timeout for the call to read events from Pravega. After the timeout
+     * expires (without an event being returned), another call will be made.
+     *
+     * <p>This timeout is passed to {@link EventStreamReader#readNextEvent(long)}.
+     *
+     * @param eventReadTimeout The timeout, in milliseconds
+     */
+    public void setEventReadTimeout(long eventReadTimeout) {
+        Preconditions.checkArgument(eventReadTimeout > 0, "timeout must be >= 0");
+        this.eventReadTimeout = eventReadTimeout;
+    }
+
+    /**
+     * Gets the timeout for the call to read events from Pravega.
+     *
+     * <p>This timeout is the value passed to {@link EventStreamReader#readNextEvent(long)}.
+     *
+     * @return The timeout, in milliseconds
+     */
+    public long getEventReadTimeout() {
+        return eventReadTimeout;
+    }
+
+    // ------------------------------------------------------------------------
+    //  Input split life cycle methods
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void open(GenericInputSplit split) throws IOException {
+        super.open(split);
+
+        // build a new reader for each input split
+        this.pravegaReader = createPravegaReader(
+                this.scopeName,
+                this.controllerURI,
+                getRuntimeContext().getTaskNameWithSubtasks(),
+                this.readerGroupName,
+                this.deserializationSchema,
+                ReaderConfig.builder().build());
+    }
+
+    @Override
+    public boolean reachedEnd() throws IOException {
+        // look ahead to see if we have reached the end of input
+        try {
+            this.lastReadAheadEvent = pravegaReader.readNextEvent(eventReadTimeout);
+        } catch (Exception e) {
+            throw new IOException("Failed to read next event.", e);
+        }
+
+        // TODO this "end of input" marker is too brittle, as the timeout could easily be a temporary hiccup;
+        // TODO to make this more robust, we could loop and try to fetch a few more times before concluding end of input
+        return lastReadAheadEvent.getEvent() == null;
+    }
+
+    @Override
+    public T nextRecord(T t) throws IOException {
+        // reachedEnd() will be checked first, so lastReadAheadEvent should never be null
+        return lastReadAheadEvent.getEvent();
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.pravegaReader.close();
+    }
+}

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -9,23 +9,16 @@
  */
 package io.pravega.connectors.flink;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
-import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.Serializer;
-import io.pravega.connectors.flink.serialization.WrappingSerializer;
 
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-
-import org.apache.commons.lang3.RandomStringUtils;
 
 import org.apache.flink.api.common.functions.StoppableFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -38,10 +31,12 @@ import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.util.FlinkException;
 
 import java.net.URI;
-import java.nio.ByteBuffer;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.stream.Collectors;
+
+import static io.pravega.connectors.flink.util.FlinkPravegaUtils.createPravegaReader;
+import static io.pravega.connectors.flink.util.FlinkPravegaUtils.generateRandomReaderGroupName;
+import static io.pravega.connectors.flink.util.FlinkPravegaUtils.getDefaultReaderName;
 
 /**
  * Flink source implementation for reading from pravega storage.
@@ -153,7 +148,7 @@ public class FlinkPravegaReader<T>
         this.controllerURI = controllerURI;
         this.scopeName = scope;
         this.deserializationSchema = deserializationSchema;
-        this.readerGroupName = "flink" + RandomStringUtils.randomAlphanumeric(20).toLowerCase();
+        this.readerGroupName = generateRandomReaderGroupName();
 
         // TODO: This will require the client to have access to the pravega controller and handle any temporary errors.
         //       See https://github.com/pravega/pravega/issues/553.
@@ -229,15 +224,13 @@ public class FlinkPravegaReader<T>
         log.info("{} : Creating Pravega reader with ID '{}' for controller URI: {}",
                 getRuntimeContext().getTaskNameWithSubtasks(), readerId, this.controllerURI);
 
-        // create the adapter between Pravega's serializers and Flink's serializers
-        @SuppressWarnings("unchecked")
-        final Serializer<T> deserializer = this.deserializationSchema instanceof WrappingSerializer ?
-                ((WrappingSerializer<T>) this.deserializationSchema).getWrappedSerializer() :
-                new FlinkDeserializer<>(this.deserializationSchema);
-
-        // build the reader
-        try (EventStreamReader<T> pravegaReader = ClientFactory.withScope(this.scopeName, this.controllerURI)
-                .createReader(readerId, this.readerGroupName, deserializer, ReaderConfig.builder().build())) {
+        try (EventStreamReader<T> pravegaReader = createPravegaReader(
+                this.scopeName,
+                this.controllerURI,
+                readerId,
+                this.readerGroupName,
+                this.deserializationSchema,
+                ReaderConfig.builder().build())) {
 
             log.info("Starting Pravega reader '{}' for controller URI {}", readerId, this.controllerURI);
 
@@ -322,51 +315,5 @@ public class FlinkPravegaReader<T>
         }
 
         checkpointTrigger.triggerCheckpoint(checkpointId);
-    }
-
-    // ------------------------------------------------------------------------
-    //  serializer
-    // ------------------------------------------------------------------------
-
-    @VisibleForTesting
-    static final class FlinkDeserializer<T> implements Serializer<T> {
-
-        private final DeserializationSchema<T> deserializationSchema;
-
-        FlinkDeserializer(DeserializationSchema<T> deserializationSchema) {
-            this.deserializationSchema = deserializationSchema;
-        }
-
-        @Override
-        public ByteBuffer serialize(T value) {
-            throw new IllegalStateException("serialize() called within a deserializer");
-        }
-
-        @Override
-        @SneakyThrows
-        public T deserialize(ByteBuffer buffer) {
-            byte[] array;
-            if (buffer.hasArray() && buffer.arrayOffset() == 0 && buffer.position() == 0 && buffer.limit() == buffer.capacity()) {
-                array = buffer.array();
-            } else {
-                array = new byte[buffer.remaining()];
-                buffer.get(array);
-            }
-
-            return deserializationSchema.deserialize(array);
-        }
-    }
-
-    /*
-     * Helper method that derives default reader name from stream and scope name
-     */
-    private static String getDefaultReaderName(final String scope, final Set<String> streamNames) {
-        final String delimiter = "-";
-        final String reader = streamNames.stream().collect(Collectors.joining(delimiter)) + delimiter + scope;
-        int hash = 0;
-        for (int i = 0; i < reader.length(); i++) {
-            hash = reader.charAt(i) + (31 * hash);
-        }
-        return Integer.toString(hash);
     }
 }

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.connectors.flink;
+
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.connectors.flink.utils.SetupUtils;
+import io.pravega.connectors.flink.utils.ThrottledIntegerWriter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
+import org.apache.flink.streaming.util.serialization.AbstractDeserializationSchema;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class FlinkPravegaInputFormatTest extends StreamingMultipleProgramsTestBase {
+
+    /** Setup utility */
+    private static final SetupUtils SETUP_UTILS = new SetupUtils();
+
+    @Rule
+    public final Timeout globalTimeout = new Timeout(120, TimeUnit.SECONDS);
+
+    // ------------------------------------------------------------------------
+
+    @BeforeClass
+    public static void setupPravega() throws Exception {
+        SETUP_UTILS.startAllServices();
+    }
+
+    @AfterClass
+    public static void tearDownPravega() throws Exception {
+        SETUP_UTILS.stopAllServices();
+    }
+
+    @Test
+    public void testBatchInput() throws Exception {
+        final int numElements = 100;
+
+        // set up the stream
+        final String streamName = RandomStringUtils.randomAlphabetic(20);
+        SETUP_UTILS.createTestStream(streamName, 3);
+
+        try (
+                final EventStreamWriter<Integer> eventWriter = SETUP_UTILS.getIntegerWriter(streamName);
+
+                // create the producer that writes to the stream
+                final ThrottledIntegerWriter producer = new ThrottledIntegerWriter(
+                        eventWriter,
+                        numElements,
+                        numElements + 1, // no need to block writer for a batch test
+                        0
+                )
+        ) {
+            // write batch input
+            producer.start();
+            producer.sync();
+
+            final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+            env.setParallelism(3);
+
+            // simple pipeline that reads from Pravega and collects the events
+            List<Integer> integers = env.createInput(
+                    new FlinkPravegaInputFormat<>(
+                            SETUP_UTILS.getControllerUri(),
+                            SETUP_UTILS.getScope(),
+                            Collections.singleton(streamName),
+                            0,
+                            new IntDeserializer()),
+                    BasicTypeInfo.INT_TYPE_INFO
+            ).collect();
+
+            // verify that all events were read
+            Assert.assertEquals(numElements, integers.size());
+        }
+    }
+
+    private static class IntDeserializer extends AbstractDeserializationSchema<Integer> {
+
+        @Override
+        public Integer deserialize(byte[] message) throws IOException {
+            return ByteBuffer.wrap(message).getInt();
+        }
+
+        @Override
+        public boolean isEndOfStream(Integer nextElement) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/FlinkSerializerWrapperTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkSerializerWrapperTest.java
@@ -11,6 +11,7 @@ package io.pravega.connectors.flink;
 
 import io.pravega.client.stream.Serializer;
 
+import io.pravega.connectors.flink.util.FlinkPravegaUtils;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 
@@ -38,7 +39,7 @@ public class FlinkSerializerWrapperTest {
 
     private void runBufferLargerThanEventTest(int capacity, int offset, int size, boolean direct) throws IOException {
         final DeserializationSchema<Long> flinkDeserializer = new LongDeserializationSchema();
-        final Serializer<Long> wrappingSerializer = new FlinkPravegaReader.FlinkDeserializer<>(flinkDeserializer);
+        final Serializer<Long> wrappingSerializer = new FlinkPravegaUtils.FlinkDeserializer<>(flinkDeserializer);
 
         // we create some sliced byte buffers that do not always the first
         // bytes or all bytes of the backing array;

--- a/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
@@ -105,7 +105,7 @@ public final class SetupUtils {
      * @return URI The controller endpoint to connect to this cluster.
      */
     public URI getControllerUri() {
-        return URI.create("tcp://" + this.inProcPravegaCluster.getControllerURI());
+        return URI.create(this.inProcPravegaCluster.getControllerURI());
     }
 
     /**


### PR DESCRIPTION
**Change log description**
- 2fe0e92 preliminary fix for #53 
- 12a2fe3 introduce `FlinkPravegaInputFormat`

**Purpose of the change**
Add batch support to the connector. Users can add the `FlinkPravegaInputFormat` as a source to Flink batch jobs.

**Known pitfalls / limitations**
- Reader group creation is performed on the client. Apparently, Flink's `InitializeOnMaster` and `FinalizeOnMaster` hooks only currently works for `OutputFormat`s, so we can't use them for the one-time reader group creation / deletion.
- The "end of input" marker is quite brittle at the moment. The PR simply uses a return of `null` on of the last read event `EventRead.getEvent()` as an indicator. We might want to add some retry logic there to strengthen that, and avoid cases where the `null` return was just caused by some timeout caused by temporary read hiccups.

**How to verify it**
Added integration test: `FlinkPravegaInputFormatTest`. The test basically writes some events to Pravega, and uses a batch Flink job to read all written events and verifies that everything is properly read when the batch job finishes.
