### PR TITLE
[misc] Fix invalid argument sanity check on FlinkPravegaReader#setEventReadTimeout

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -202,7 +202,7 @@ public class FlinkPravegaReader<T>
      * @param eventReadTimeout The timeout, in milliseconds
      */
     public void setEventReadTimeout(long eventReadTimeout) {
-        Preconditions.checkArgument(checkpointInitiateTimeout > 0, "timeout must be >= 0");
+        Preconditions.checkArgument(eventReadTimeout > 0, "timeout must be >= 0");
         this.eventReadTimeout = eventReadTimeout;
     }
 


### PR DESCRIPTION
**Change log description**
Simple fix of an invalid argument sanity check, where the incorrect variable was verified in `FlinkPravegaReader.setEventReadTimeout`.
