### PR TITLE
[issue-28] Remove workaround code

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -280,15 +280,8 @@ public class FlinkPravegaReader<T>
 
     @Override
     public MasterTriggerRestoreHook<Checkpoint> createMasterTriggerRestoreHook() {
-        //Issue-24
-        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
-        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
-        try {
-            return new ReaderCheckpointHook(this.readerName, this.readerGroupName,
-                    this.scopeName, this.controllerURI, this.checkpointInitiateTimeout);
-        } finally {
-            Thread.currentThread().setContextClassLoader(originalClassLoader);
-        }
+        return new ReaderCheckpointHook(this.readerName, this.readerGroupName,
+                this.scopeName, this.controllerURI, this.checkpointInitiateTimeout);
     }
 
     @Override


### PR DESCRIPTION
**Change log description**
- remove obsolete code

**Purpose of the change**
Removes workaround code related to checkpoint hooks during development of Flink 1.3.  
Closes #28.

**How to verify it**
- test that a job w/ checkpoints enabled is runnable on a Flink 1.3+ cluster.