### PR TITLE
[issue-58] Make explicit the 'forwarding' partitioning strategy

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -50,7 +50,7 @@ public class FlinkPravegaUtils {
         // a forwarding strategy (as opposed to a rebalancing strategy) is used by Flink between the two operators.
         return stream
                 .keyBy(new PravegaEventRouterKeySelector<>(writer.getEventRouter()))
-                .transform("reorder", stream.getType(), new EventTimeOrderingOperator<>()).setParallelism(parallelism)
+                .transform("reorder", stream.getType(), new EventTimeOrderingOperator<>()).setParallelism(parallelism).forward()
                 .addSink(writer).setParallelism(parallelism);
     }
 


### PR DESCRIPTION
…for event time-ordered sink.
Closes #58.

**Change log description**
- Make explicit the 'forwarding' partitioning strategy.  Was implicit before.

**Purpose of the change**
- Code cleanup to better express the intent.

**What the code does**

**How to verify it**
Added a manual test `FlinkPravegaWriterTest::testEventTimeOrderedWriter`.  Observe the execution plan to note that a forward strategy is used.