### PR TITLE
[issue-32] Table Connector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ configurations.all {
 }
 
 configurations {
+    testCompile.extendsFrom(compileOnly)
     testCompile.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     testCompile.exclude group: 'log4j', module: 'log4j'
 }
@@ -61,7 +62,10 @@ dependencies {
     compile group: 'io.pravega', name: 'pravega-shared-protocol', version: pravegaVersion
     compile group: 'io.pravega', name: 'pravega-shared-controller-api', version: pravegaVersion
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jApiVersion
-    compileOnly group: 'org.apache.flink', name: 'flink-streaming-java_2.11', version: flinkVersion
+    compileOnly group: 'org.apache.flink', name: 'flink-streaming-scala_2.11', version: flinkVersion // provided by application
+    compileOnly group: 'org.apache.flink', name: 'flink-table_2.11', version: flinkVersion // provided by application
+    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion // provided by flink-runtime
+
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.mockito', name: 'mockito-all', version: mockitoVersion
     testCompile group: 'org.apache.flink', name: 'flink-tests_2.11', version: flinkVersion

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -14,6 +14,7 @@
     <allow pkg="com.google"/>
     <allow pkg="io.pravega"/>
     <allow pkg="lombok"/>
+    <allow pkg="com.fasterxml.jackson"/>
     <allow pkg="org.apache"/>
 
     <!-- flink dependencies -->

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@
 # 3rd party Versions.
 checkstyleToolVersion=7.1
 flinkVersion=1.3.1
+jacksonVersion=2.7.4
 lombokVersion=1.16.10
 twitterMvnRepoVersion=4.3.4-TWTTR
 shadowGradlePlugin=1.2.4

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSink.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSink.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.connectors.flink;
+
+import io.pravega.connectors.flink.util.StreamId;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.util.serialization.SerializationSchema;
+import org.apache.flink.table.sinks.AppendStreamTableSink;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.function.Function;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An append-only table sink to emit a streaming table as a Pravaga stream.
+ */
+public class FlinkPravegaTableSink implements AppendStreamTableSink<Row> {
+
+    /** The Pravega controller endpoint. */
+    protected final URI controllerURI;
+
+    /** The Pravega stream to use. */
+    protected final StreamId stream;
+
+    protected SerializationSchema<Row> serializationSchema;
+    protected PravegaEventRouter<Row> eventRouter;
+    protected String[] fieldNames;
+    protected TypeInformation[] fieldTypes;
+
+    /** Serialization schema to use for Pravega stream events. */
+    private final Function<String[], SerializationSchema<Row>> serializationSchemaFactory;
+
+    private final String routingKeyFieldName;
+
+    /**
+     * Creates a Pravega {@link AppendStreamTableSink}.
+     *
+     * <p>The {@code serializationSchemaFactory} supplies a {@link SerializationSchema}
+     * based on the output field names.
+     *
+     * <p>Each row is written to a Pravega stream with a routing key based on the {@code routingKeyFieldName}.
+     * The specified field must of type {@code STRING}.
+     *
+     * @param controllerURI                The pravega controller endpoint address.
+     * @param stream                       The stream to write events to.
+     * @param serializationSchemaFactory   A factory for the serialization schema to use for stream events.
+     * @param routingKeyFieldName          The field name to use as a Pravega event routing key.
+     */
+    public FlinkPravegaTableSink(
+            URI controllerURI,
+            StreamId stream,
+            Function<String[], SerializationSchema<Row>> serializationSchemaFactory,
+            String routingKeyFieldName) {
+        this.controllerURI = controllerURI;
+        this.stream = stream;
+        this.serializationSchemaFactory = serializationSchemaFactory;
+        this.routingKeyFieldName = routingKeyFieldName;
+    }
+
+    /**
+     * Creates a copy of the sink for configuration purposes.
+     */
+    protected FlinkPravegaTableSink createCopy() {
+        return new FlinkPravegaTableSink(controllerURI, stream, serializationSchemaFactory, routingKeyFieldName);
+    }
+
+    /**
+     * Returns the low-level writer.
+     */
+    protected FlinkPravegaWriter<Row> createFlinkPravegaWriter() {
+        return new FlinkPravegaWriter<>(controllerURI, stream.getScope(), stream.getName(), serializationSchema, eventRouter);
+    }
+
+    /**
+     * NOTE: This method is for internal use only for defining a TableSink.
+     *       Do not use it in Table API programs.
+     */
+    @Override
+    public void emitDataStream(DataStream<Row> dataStream) {
+        checkState(fieldNames != null, "Table sink is not configured");
+        checkState(fieldTypes != null, "Table sink is not configured");
+        checkState(serializationSchema != null, "Table sink is not configured");
+        checkState(eventRouter != null, "Table sink is not configured");
+
+        FlinkPravegaWriter<Row> writer = createFlinkPravegaWriter();
+        dataStream.addSink(writer);
+    }
+
+    @Override
+    public TypeInformation<Row> getOutputType() {
+        return new RowTypeInfo(getFieldTypes());
+    }
+
+    public String[] getFieldNames() {
+        return fieldNames;
+    }
+
+    @Override
+    public TypeInformation<?>[] getFieldTypes() {
+        return fieldTypes;
+    }
+
+    @Override
+    public FlinkPravegaTableSink configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+
+        // called to configure the sink with a specific subset of fields
+
+        FlinkPravegaTableSink copy = createCopy();
+        copy.fieldNames = checkNotNull(fieldNames, "fieldNames");
+        copy.fieldTypes = checkNotNull(fieldTypes, "fieldTypes");
+        Preconditions.checkArgument(fieldNames.length == fieldTypes.length,
+                "Number of provided field names and types does not match.");
+
+        copy.serializationSchema = serializationSchemaFactory.apply(fieldNames);
+        copy.eventRouter = new RowBasedRouter(routingKeyFieldName, fieldNames, fieldTypes);
+
+        return copy;
+    }
+
+    /**
+     * An event router that extracts the routing key from a {@link Row} by field name.
+     */
+    private static class RowBasedRouter implements PravegaEventRouter<Row> {
+
+        private final int keyIndex;
+
+        public RowBasedRouter(String keyFieldName, String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+            checkArgument(fieldNames.length == fieldTypes.length,
+                    "Number of provided field names and types does not match.");
+            int keyIndex = Arrays.asList(fieldNames).indexOf(keyFieldName);
+            checkArgument(keyIndex >= 0,
+                    "Key field '" + keyFieldName + "' not found");
+            checkArgument(Types.STRING.equals(fieldTypes[keyIndex]),
+                    "Key field must be of type 'STRING'");
+            this.keyIndex = keyIndex;
+        }
+
+        @Override
+        public String getRoutingKey(Row event) {
+            return (String) event.getField(keyIndex);
+        }
+    }
+}

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.connectors.flink;
+
+import io.pravega.connectors.flink.util.StreamId;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.types.Row;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.function.Function;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A table source to produce a streaming table from a Pravega stream.
+ */
+public class FlinkPravegaTableSource implements StreamTableSource<Row> {
+
+    /** The Pravega controller endpoint. */
+    private final URI controllerURI;
+
+    /** The Pravega stream to use. */
+    private final StreamId stream;
+
+    /** The start time from when to read events from. */
+    private final long startTime;
+
+    /** Deserialization schema to use for Pravega stream events. */
+    private final DeserializationSchema<Row> deserializationSchema;
+
+    /** Type information describing the result type. */
+    private final TypeInformation<Row> typeInfo;
+
+    /**
+     * Creates a Pravega {@link StreamTableSource}.
+     *
+     * <p>The {@code deserializationSchemaFactory} supplies a {@link DeserializationSchema}
+     * based on the result type information.
+     *
+     * @param controllerURI                The pravega controller endpoint address.
+     * @param stream                       The stream to read events from.
+     * @param startTime                    The start time from when to read events from.
+     * @param deserializationSchemaFactory The deserialization schema to use for stream events.
+     * @param typeInfo                     The type information describing the result type.
+     */
+    public FlinkPravegaTableSource(
+            final URI controllerURI,
+            final StreamId stream,
+            final long startTime,
+            Function<TypeInformation<Row>, DeserializationSchema<Row>> deserializationSchemaFactory,
+            TypeInformation<Row> typeInfo) {
+        this.controllerURI = controllerURI;
+        this.stream = stream;
+        this.startTime = startTime;
+        checkNotNull(deserializationSchemaFactory, "Deserialization schema factory");
+        this.typeInfo = checkNotNull(typeInfo, "Type information");
+        this.deserializationSchema = deserializationSchemaFactory.apply(typeInfo);
+    }
+
+    /**
+     * NOTE: This method is for internal use only for defining a TableSource.
+     *       Do not use it in Table API programs.
+     */
+    @Override
+    public DataStream<Row> getDataStream(StreamExecutionEnvironment env) {
+        FlinkPravegaReader<Row> kafkaConsumer = createFlinkPravegaReader();
+        return env.addSource(kafkaConsumer);
+    }
+
+    @Override
+    public TypeInformation<Row> getReturnType() {
+        return typeInfo;
+    }
+
+    /**
+     * Returns the low-level reader.
+     */
+    protected FlinkPravegaReader<Row> createFlinkPravegaReader() {
+        return new FlinkPravegaReader<>(
+                controllerURI,
+                stream.getScope(), Collections.singleton(stream.getName()),
+                startTime,
+                deserializationSchema);
+    }
+
+    /**
+     * Returns the deserialization schema.
+     *
+     * @return The deserialization schema
+     */
+    protected DeserializationSchema<Row> getDeserializationSchema() {
+        return deserializationSchema;
+    }
+
+    @Override
+    public String explainSource() {
+        return "";
+    }
+}

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
@@ -77,8 +77,8 @@ public class FlinkPravegaTableSource implements StreamTableSource<Row> {
      */
     @Override
     public DataStream<Row> getDataStream(StreamExecutionEnvironment env) {
-        FlinkPravegaReader<Row> kafkaConsumer = createFlinkPravegaReader();
-        return env.addSource(kafkaConsumer);
+        FlinkPravegaReader<Row> reader = createFlinkPravegaReader();
+        return env.addSource(reader);
     }
 
     @Override

--- a/src/main/java/io/pravega/connectors/flink/serialization/JsonRowDeserializationSchema.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/JsonRowDeserializationSchema.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.connectors.flink.serialization;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * Deserialization schema from JSON to {@link Row}.
+ *
+ * <p>Deserializes the <code>byte[]</code> messages as a JSON object and reads
+ * the specified fields.
+ *
+ * <p>Failure during deserialization are forwarded as wrapped IOExceptions.
+ */
+public class JsonRowDeserializationSchema implements DeserializationSchema<Row> {
+
+    /** Type information describing the result type. */
+    private final TypeInformation<Row> typeInfo;
+
+    /** Field names to parse. Indices match fieldTypes indices. */
+    private final String[] fieldNames;
+
+    /** Types to parse fields as. Indices match fieldNames indices. */
+    private final TypeInformation<?>[] fieldTypes;
+
+    /** Object mapper for parsing the JSON. */
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Flag indicating whether to fail on a missing field. */
+    private boolean failOnMissingField;
+
+    /**
+     * Creates a JSON deserialization schema for the given fields and types.
+     *
+     * @param typeInfo   Type information describing the result type. The field names are used
+     *                   to parse the JSON file and so are the types.
+     */
+    public JsonRowDeserializationSchema(TypeInformation<Row> typeInfo) {
+        Preconditions.checkNotNull(typeInfo, "Type information");
+        this.typeInfo = typeInfo;
+
+        this.fieldNames = ((RowTypeInfo) typeInfo).getFieldNames();
+        this.fieldTypes = ((RowTypeInfo) typeInfo).getFieldTypes();
+    }
+
+    @Override
+    public Row deserialize(byte[] message) throws IOException {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+
+            Row row = new Row(fieldNames.length);
+            for (int i = 0; i < fieldNames.length; i++) {
+                JsonNode node = root.get(fieldNames[i]);
+
+                if (node == null) {
+                    if (failOnMissingField) {
+                        throw new IllegalStateException("Failed to find field with name '"
+                                + fieldNames[i] + "'.");
+                    } else {
+                        row.setField(i, null);
+                    }
+                } else {
+                    // Read the value as specified type
+                    Object value = objectMapper.treeToValue(node, fieldTypes[i].getTypeClass());
+                    row.setField(i, value);
+                }
+            }
+
+            return row;
+        } catch (Throwable t) {
+            throw new IOException("Failed to deserialize JSON object.", t);
+        }
+    }
+
+    @Override
+    public boolean isEndOfStream(Row nextElement) {
+        return false;
+    }
+
+    @Override
+    public TypeInformation<Row> getProducedType() {
+        return typeInfo;
+    }
+
+    /**
+     * Configures the failure behaviour if a JSON field is missing.
+     *
+     * <p>By default, a missing field is ignored and the field is set to null.
+     *
+     * @param failOnMissingField Flag indicating whether to fail or not on a missing field.
+     */
+    public void setFailOnMissingField(boolean failOnMissingField) {
+        this.failOnMissingField = failOnMissingField;
+    }
+
+}

--- a/src/main/java/io/pravega/connectors/flink/serialization/JsonRowSerializationSchema.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/JsonRowSerializationSchema.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.connectors.flink.serialization;
+
+import org.apache.flink.streaming.util.serialization.SerializationSchema;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Serialization schema that serializes an object into a JSON bytes.
+ *
+ * <p>Serializes the input {@link Row} object into a JSON string and
+ * converts it into <code>byte[]</code>.
+ *
+ * <p>Result <code>byte[]</code> messages can be deserialized using
+ * {@link JsonRowDeserializationSchema}.
+ */
+public class JsonRowSerializationSchema implements SerializationSchema<Row> {
+
+    /**
+     * Object MAPPER that is used to create output JSON objects.
+     */
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Fields names in the input Row object.
+     */
+    private final String[] fieldNames;
+
+    /**
+     * Creates a JSON serialization schema for the given fields and types.
+     *
+     * @param fieldNames Names of JSON fields to parse.
+     */
+    public JsonRowSerializationSchema(String[] fieldNames) {
+        this.fieldNames = Preconditions.checkNotNull(fieldNames);
+    }
+
+    @Override
+    public byte[] serialize(Row row) {
+        if (row.getArity() != fieldNames.length) {
+            throw new IllegalStateException(String.format(
+                    "Number of elements in the row %s is different from number of field names: %d", row, fieldNames.length));
+        }
+
+        ObjectNode objectNode = MAPPER.createObjectNode();
+
+        for (int i = 0; i < row.getArity(); i++) {
+            JsonNode node = MAPPER.valueToTree(row.getField(i));
+            objectNode.set(fieldNames[i], node);
+        }
+
+        try {
+            return MAPPER.writeValueAsBytes(objectNode);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize row", e);
+        }
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/FlinkTableITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkTableITCase.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.connectors.flink;
+
+import io.pravega.connectors.flink.serialization.JsonRowDeserializationSchema;
+import io.pravega.connectors.flink.serialization.JsonRowSerializationSchema;
+import io.pravega.connectors.flink.util.StreamId;
+import io.pravega.connectors.flink.utils.SetupUtils;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Integration tests for {@link FlinkPravegaTableSource} and {@link FlinkPravegaTableSink}.
+ */
+@Slf4j
+public class FlinkTableITCase {
+
+    /**
+     * Sample data.
+     */
+    private static final List<SampleRecord> SAMPLES = Arrays.asList(
+            new SampleRecord("A", 1), new SampleRecord("A", 2), new SampleRecord("A", 3),
+            new SampleRecord("B", 1), new SampleRecord("B", 2), new SampleRecord("B", 3)
+    );
+
+    /**
+     * A sample POJO to be written as a Row (category,value).
+     */
+    @Data
+    public static class SampleRecord implements Serializable {
+        public String category;
+        public int value;
+
+        public SampleRecord() {}
+
+        public SampleRecord(String category, int value) {
+            this.category = category;
+            this.value = value;
+        }
+    }
+
+    // The relational schema associated with SampleRecord.
+    private static final RowTypeInfo SAMPLE_SCHEMA = Types.ROW_NAMED(
+            new String[]{"category", "value"},
+            Types.STRING, Types.INT);
+
+    // Ensure each test completes within 120 seconds.
+    @Rule
+    public Timeout globalTimeout = new Timeout(120, TimeUnit.SECONDS);
+
+    // Setup utility.
+    private SetupUtils setupUtils = new SetupUtils();
+
+    @Before
+    public void setup() throws Exception {
+        this.setupUtils.startAllServices();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        this.setupUtils.stopAllServices();
+    }
+
+    /**
+     * Tests the end-to-end functionality of table source & sink.
+     *
+     * <p>This test uses the {@link FlinkPravegaTableSink} to emit an in-memory table
+     * containing sample data as a Pravega stream of 'append' events (i.e. as a changelog).
+     * The test then uses the {@link FlinkPravegaTableSource} to absorb the changelog as a new table.
+     *
+     * <p>Flink's ability to convert POJOs (e.g. {@link SampleRecord}) to/from table rows is also demonstrated.
+     *
+     * <p>Because the source is unbounded, the test must throw an exception to deliberately terminate the job.
+     *
+     * @throws Exception on exception
+     */
+    @Test
+    public void testEndToEnd() throws Exception {
+
+        // create a Pravega stream for test purposes
+        StreamId stream = new StreamId(setupUtils.getScope(), "FlinkTableITCase.testEndToEnd");
+        this.setupUtils.createTestStream(stream.getName(), 1);
+
+        // create a Flink Table environment
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment().setParallelism(1);
+        StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+
+        // define a table of sample data from a collection of POJOs.  Schema:
+        // root
+        //  |-- category: String
+        //  |-- value: Integer
+        Table table = tableEnv.fromDataStream(env.fromCollection(SAMPLES));
+
+        // write the table to a Pravega stream (using the 'category' column as a routing key)
+        FlinkPravegaTableSink sink = new FlinkPravegaTableSink(
+                this.setupUtils.getControllerUri(), stream, JsonRowSerializationSchema::new, "category");
+        table.writeToSink(sink);
+
+        // register the Pravega stream as a table called 'samples'
+        FlinkPravegaTableSource source = new FlinkPravegaTableSource(
+                this.setupUtils.getControllerUri(), stream, 0, JsonRowDeserializationSchema::new, SAMPLE_SCHEMA);
+        tableEnv.registerTableSource("samples", source);
+
+        // select some sample data from the Pravega-backed table, as a view
+        Table view = tableEnv.sql("SELECT * FROM samples WHERE category IN ('A','B')");
+
+        // write the view to a test sink that verifies the data for test purposes
+        tableEnv.toAppendStream(view, SampleRecord.class).addSink(new TestSink(SAMPLES));
+
+        // execute the topology
+        try {
+            env.execute();
+            Assert.fail("expected an exception");
+        } catch (JobExecutionException e) {
+            // we expect the job to fail because the test sink throws a deliberate exception.
+            Assert.assertTrue(e.getCause() instanceof TestCompletionException);
+        }
+    }
+
+    private static class TestSink extends RichSinkFunction<SampleRecord> {
+        private final LinkedList<SampleRecord> remainingSamples;
+
+        public TestSink(List<SampleRecord> allSamples) {
+            remainingSamples = new LinkedList<>(allSamples);
+        }
+
+        @Override
+        public void invoke(SampleRecord value) throws Exception {
+            remainingSamples.remove(value);
+            log.info("processed: {}", value);
+
+            if (remainingSamples.size() == 0) {
+                throw new TestCompletionException();
+            }
+        }
+    }
+
+    private static class TestCompletionException extends RuntimeException {
+
+    }
+}


### PR DESCRIPTION
**Change log description**
- add `FlinkPravegaTableSource`
- add `FlinkPravegaTableSink`
- add `FlinkTableITCase`
- add JSON serialization schema
- add jackson as a 'provided' (by Flink) dependency

**Purpose of the change**
Introduces Flink Table API support, including a table source and append-only table sink.  Closes #32 .

**How to verify it**
Execute integration test `FlinkTableITCase`.
