### PR TITLE
[issue-56] Reset reader group on every execution attempt in FlinkPravegaInputFormat

### DIFF
--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatTest.java
@@ -15,6 +15,8 @@ import io.pravega.connectors.flink.utils.SetupUtils;
 import io.pravega.connectors.flink.utils.ThrottledIntegerWriter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
@@ -95,6 +97,52 @@ public class FlinkPravegaInputFormatTest extends StreamingMultipleProgramsTestBa
         }
     }
 
+    @Test
+    public void testBatchInputWithFailure() throws Exception {
+        final int numElements = 100;
+
+        // set up the stream
+        final String streamName = RandomStringUtils.randomAlphabetic(20);
+        SETUP_UTILS.createTestStream(streamName, 3);
+
+        try (
+                final EventStreamWriter<Integer> eventWriter = SETUP_UTILS.getIntegerWriter(streamName);
+
+                // create the producer that writes to the stream
+                final ThrottledIntegerWriter producer = new ThrottledIntegerWriter(
+                        eventWriter,
+                        numElements,
+                        numElements + 1, // no need to block writer for a batch test
+                        0
+                )
+        ) {
+            // write batch input
+            producer.start();
+            producer.sync();
+
+            final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1000L));
+            env.setParallelism(3);
+
+            // simple pipeline that reads from Pravega and collects the events
+            List<Integer> integers = env.createInput(
+                    new FlinkPravegaInputFormat<>(
+                            SETUP_UTILS.getControllerUri(),
+                            SETUP_UTILS.getScope(),
+                            Collections.singleton(streamName),
+                            0,
+                            new IntDeserializer()),
+                    BasicTypeInfo.INT_TYPE_INFO
+            ).map(new FailOnceMapper(numElements / 2)).collect();
+
+            // verify that the job did fail, and all events were still read
+            Assert.assertTrue(FailOnceMapper.hasFailed());
+            Assert.assertEquals(numElements, integers.size());
+
+            FailOnceMapper.reset();
+        }
+    }
+
     private static class IntDeserializer extends AbstractDeserializationSchema<Integer> {
 
         @Override
@@ -105,6 +153,35 @@ public class FlinkPravegaInputFormatTest extends StreamingMultipleProgramsTestBa
         @Override
         public boolean isEndOfStream(Integer nextElement) {
             return false;
+        }
+    }
+
+    private static class FailOnceMapper extends RichMapFunction<Integer, Integer> {
+
+        private static boolean failedOnce;
+
+        private final int failCount;
+
+        static void reset() {
+            failedOnce = false;
+        }
+
+        static boolean hasFailed() {
+            return failedOnce;
+        }
+
+        FailOnceMapper(int failCount) {
+            this.failCount = failCount;
+        }
+
+        @Override
+        public Integer map(Integer value) throws Exception {
+            if (!failedOnce && value.equals(failCount)) {
+                failedOnce = true;
+                throw new RuntimeException("Artificial failure");
+            }
+
+            return value;
         }
     }
 }


### PR DESCRIPTION
**Change log description**

This PR addresses #56.

- Recreate a new Pravega reader group on every execution attempt. This is done in the `openInputFormat` method, which is called on every execution attempt (i.e., including failovers).
- Add a new batch read integration test case, which verifies all records are still read if the batch read fails and the job is restarted.

**How to verify it**

The fix is verified with the new test `FlinkPravegaInputFormatTest#testBatchReadWithFailure()`.
That test fails without this fix.
