### PR TITLE
Use lang3.RandomStringUtils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,8 @@ dependencies {
     compile group: 'io.pravega', name: 'pravega-shared-protocol', version: pravegaVersion
     compile group: 'io.pravega', name: 'pravega-shared-controller-api', version: pravegaVersion
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jApiVersion
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: apacheCommonsVersion
+
     compileOnly group: 'org.apache.flink', name: 'flink-streaming-scala_2.11', version: flinkVersion // provided by application
     compileOnly group: 'org.apache.flink', name: 'flink-table_2.11', version: flinkVersion // provided by application
     compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion // provided by flink-runtime

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,6 @@ shadowJar {
         // 'include' specific dependencies in the shadow jar
         // IMPORTANT: transitive dependencies must be manually listed here!
         include dependency("com.google.guava:guava")
-        include dependency("commons-lang:commons-lang")
         include dependency("org.apache.commons:commons-lang3")
         include dependency("commons-io:commons-io")
         include dependency("io.netty:netty-common")

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ mockitoVersion=1.10.19
 # Version and base tags can be overridden at build time.
 connectorVersion=0.2.0-SNAPSHOT
 pravegaVersion=0.2.0-SNAPSHOT
+apacheCommonsVersion=3.7
 
 # These properties are only needed for publishing to maven central
 # Pravega Signing Key

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -18,6 +18,7 @@ import io.pravega.connectors.flink.FlinkPravegaWriter;
 import io.pravega.connectors.flink.serialization.WrappingSerializer;
 import lombok.SneakyThrows;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
@@ -76,7 +77,7 @@ public class FlinkPravegaUtils {
      * @return generated reader group name.
      */
     public static String generateRandomReaderGroupName() {
-        return "flink" + org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric(20).toLowerCase();
+        return "flink" + RandomStringUtils.randomAlphanumeric(20).toLowerCase();
     }
 
     /**

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -17,7 +17,7 @@ import io.pravega.connectors.flink.EventTimeOrderingOperator;
 import io.pravega.connectors.flink.FlinkPravegaWriter;
 import io.pravega.connectors.flink.serialization.WrappingSerializer;
 import lombok.SneakyThrows;
-import org.apache.commons.lang.RandomStringUtils;
+
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
@@ -26,7 +26,6 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 public class FlinkPravegaUtils {
 
     private FlinkPravegaUtils() {
@@ -76,8 +75,9 @@ public class FlinkPravegaUtils {
      *
      * @return generated reader group name.
      */
+    @SuppressWarnings( "deprecation" )
     public static String generateRandomReaderGroupName() {
-        return "flink" + RandomStringUtils.randomAlphanumeric(20).toLowerCase();
+        return "flink" + org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric(20).toLowerCase();
     }
 
     /**

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -75,7 +75,6 @@ public class FlinkPravegaUtils {
      *
      * @return generated reader group name.
      */
-    @SuppressWarnings( "deprecation" )
     public static String generateRandomReaderGroupName() {
         return "flink" + org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric(20).toLowerCase();
     }


### PR DESCRIPTION
I think we accidentally used lang(2)'s RandomStringUtils. This was being silently fetched into the uber jar because Pravega had it as a dependency. They've dropped it in on master.

This class is deprecated. Talking it over with Eron, we feel using a deprecated class is better than bringing the entire commons-text package.