### PR TITLE
Add netty and netty-all to dependency list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,8 @@ shadowJar {
         include dependency("com.google.guava:guava")
         include dependency("org.apache.commons:commons-lang3")
         include dependency("commons-io:commons-io")
+        include dependency("io.netty:netty")
+        include dependency("io.netty:netty-all")
         include dependency("io.netty:netty-common")
         include dependency("io.netty:netty-buffer")
         include dependency("io.netty:netty-resolver")


### PR DESCRIPTION
Similar to #80. A dependency is using a class from netty or netty-all that we're not including in the uber jar. This is causing a ClassDefNotFound. (Note: in shadowjars we need to include transitive dependencies explicitly. Both netty and netty-all are transitive dependencies.)