### PR TITLE
[issue-63] FlinkPravegaReader must synchronize on checkpoint lock

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -248,7 +248,10 @@ public class FlinkPravegaReader<T>
                         log.info("Reached end of stream for reader: {}", readerId);
                         return;
                     }
-                    ctx.collect(event);
+
+                    synchronized (ctx.getCheckpointLock()) {
+                        ctx.collect(event);
+                    }
                 }
 
                 // if the read marks a checkpoint, trigger the checkpoint


### PR DESCRIPTION
**Change log description**
- `FlinkPravegaReader` acquire checkpoint lock as required by `SourceFunction`

**Purpose of the change**
- Avoid a potential concurrency issue.  Closes #63.

**How to verify it**
- Run existing integration test `FlinkPravegaReaderTest`
