### PR TITLE
[issue-65] Rework FlinkPravegaInputFormat to use batch client

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/PravegaInputSplit.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaInputSplit.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.connectors.flink;
+
+import com.google.common.base.Preconditions;
+import io.pravega.client.segment.impl.Segment;
+import org.apache.flink.core.io.InputSplit;
+
+/**
+ * A {@link PravegaInputSplit} corresponds to a Pravega {@link Segment}.
+ */
+public class PravegaInputSplit implements InputSplit {
+
+    private final int splitId;
+
+    private final Segment segment;
+
+    private final long startOffset;
+
+    private final long endOffset;
+
+    public PravegaInputSplit(int splitId, Segment segment, long startOffset, long endOffset) {
+        Preconditions.checkArgument(splitId >= 0, "The splitId is not recognizable.");
+        Preconditions.checkNotNull(segment, "segment");
+        Preconditions.checkArgument(
+                startOffset >= 0,
+                "The start offset is not recognizable.");
+        Preconditions.checkArgument(
+                startOffset <= endOffset,
+                "The end offset must be larger than the start offset.");
+
+        this.splitId = splitId;
+        this.segment = segment;
+        this.startOffset = startOffset;
+        this.endOffset = endOffset;
+    }
+
+    @Override
+    public int getSplitNumber() {
+        return splitId;
+    }
+
+    public Segment getSegment() {
+        return segment;
+    }
+
+    public long getStartOffset() {
+        return startOffset;
+    }
+
+    public long getEndOffset() {
+        return endOffset;
+    }
+}

--- a/src/main/java/io/pravega/connectors/flink/PravegaInputSplit.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaInputSplit.java
@@ -65,12 +65,7 @@ public class PravegaInputSplit implements InputSplit {
     @Override
     public int hashCode() {
         int result = splitId;
-
-        // Pravega's Segment does not have hashCode implemented
-        result = 31 * result + segment.getScope().hashCode();
-        result = 31 * result + segment.getStreamName().hashCode();
-        result = 31 * result + segment.getSegmentNumber();
-
+        result = 31 * result + segment.hashCode();
         result = 31 * result + Long.hashCode(startOffset);
         result = 31 * result + Long.hashCode(endOffset);
 
@@ -85,7 +80,7 @@ public class PravegaInputSplit implements InputSplit {
             PravegaInputSplit other = (PravegaInputSplit) obj;
 
             return this.splitId == other.splitId &&
-                    this.segment.compareTo(other.segment) == 0 &&
+                    this.segment.equals(other.segment) &&
                     this.startOffset == other.startOffset &&
                     this.endOffset == other.endOffset;
         } else {

--- a/src/main/java/io/pravega/connectors/flink/PravegaInputSplit.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaInputSplit.java
@@ -59,4 +59,46 @@ public class PravegaInputSplit implements InputSplit {
     public long getEndOffset() {
         return endOffset;
     }
+
+    // --------------------------------------------------------------------
+
+    @Override
+    public int hashCode() {
+        int result = splitId;
+
+        // Pravega's Segment does not have hashCode implemented
+        result = 31 * result + segment.getScope().hashCode();
+        result = 31 * result + segment.getStreamName().hashCode();
+        result = 31 * result + segment.getSegmentNumber();
+
+        result = 31 * result + Long.hashCode(startOffset);
+        result = 31 * result + Long.hashCode(endOffset);
+
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (obj instanceof PravegaInputSplit) {
+            PravegaInputSplit other = (PravegaInputSplit) obj;
+
+            return this.splitId == other.splitId &&
+                    this.segment.compareTo(other.segment) == 0 &&
+                    this.startOffset == other.startOffset &&
+                    this.endOffset == other.endOffset;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "PravegaInputSplit {" +
+                "splitId = " + splitId +
+                ", segment = " + segment.toString() +
+                ", startOffset = " + startOffset +
+                ", endOffset = " + endOffset +  "}";
+    }
 }

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatITCase.java
@@ -39,7 +39,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
-public class FlinkPravegaInputFormatTest extends StreamingMultipleProgramsTestBase {
+public class FlinkPravegaInputFormatITCase extends StreamingMultipleProgramsTestBase {
 
     /** Setup utility */
     private static final SetupUtils SETUP_UTILS = new SetupUtils();

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatTest.java
@@ -15,7 +15,10 @@ import io.pravega.connectors.flink.utils.SetupUtils;
 import io.pravega.connectors.flink.utils.ThrottledIntegerWriter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
 import org.apache.flink.streaming.util.serialization.AbstractDeserializationSchema;
@@ -28,8 +31,11 @@ import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -53,8 +59,79 @@ public class FlinkPravegaInputFormatTest extends StreamingMultipleProgramsTestBa
         SETUP_UTILS.stopAllServices();
     }
 
+    /**
+     * Verifies that the input format:
+     *  - correctly reads all records in a given set of multiple Pravega streams
+     *  - allows multiple executions
+     */
     @Test
     public void testBatchInput() throws Exception {
+        final int numElements1 = 100;
+        final int numElements2 = 300;
+
+        // set up the stream
+        final String streamName1 = RandomStringUtils.randomAlphabetic(20);
+        final String streamName2 = RandomStringUtils.randomAlphabetic(20);
+
+        final Set<String> streams = new HashSet<>();
+        streams.add(streamName1);
+        streams.add(streamName2);
+
+        SETUP_UTILS.createTestStream(streamName1, 3);
+        SETUP_UTILS.createTestStream(streamName2, 5);
+
+        try (
+                final EventStreamWriter<Integer> eventWriter1 = SETUP_UTILS.getIntegerWriter(streamName1);
+                final EventStreamWriter<Integer> eventWriter2 = SETUP_UTILS.getIntegerWriter(streamName2);
+
+                // create the producer that writes to the stream
+                final ThrottledIntegerWriter producer1 = new ThrottledIntegerWriter(
+                        eventWriter1,
+                        numElements1,
+                        numElements1 + 1, // no need to block writer for a batch test
+                        0
+                );
+
+                final ThrottledIntegerWriter producer2 = new ThrottledIntegerWriter(
+                        eventWriter2,
+                        numElements2,
+                        numElements2 + 1, // no need to block writer for a batch test
+                        0
+                )
+        ) {
+            // write batch input
+            producer1.start();
+            producer2.start();
+
+            producer1.sync();
+            producer2.sync();
+
+            final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+            env.setParallelism(3);
+
+            // simple pipeline that reads from Pravega and collects the events
+            DataSet<Integer> integers = env.createInput(
+                    new FlinkPravegaInputFormat<>(
+                            SETUP_UTILS.getControllerUri(),
+                            SETUP_UTILS.getScope(),
+                            streams,
+                            new IntDeserializer()),
+                    BasicTypeInfo.INT_TYPE_INFO
+            );
+
+            // verify that all events were read
+            Assert.assertEquals(numElements1 + numElements2, integers.collect().size());
+
+            // this verifies that the input format allows multiple passes
+            Assert.assertEquals(numElements1 + numElements2, integers.collect().size());
+        }
+    }
+
+    /**
+     * Verifies that the input format reads all records exactly-once in the presence of job failures.
+     */
+    @Test
+    public void testBatchInputWithFailure() throws Exception {
         final int numElements = 100;
 
         // set up the stream
@@ -77,6 +154,7 @@ public class FlinkPravegaInputFormatTest extends StreamingMultipleProgramsTestBa
             producer.sync();
 
             final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1000L));
             env.setParallelism(3);
 
             // simple pipeline that reads from Pravega and collects the events
@@ -85,13 +163,44 @@ public class FlinkPravegaInputFormatTest extends StreamingMultipleProgramsTestBa
                             SETUP_UTILS.getControllerUri(),
                             SETUP_UTILS.getScope(),
                             Collections.singleton(streamName),
-                            0,
                             new IntDeserializer()),
                     BasicTypeInfo.INT_TYPE_INFO
-            ).collect();
+            ).map(new FailOnceMapper(numElements / 2)).collect();
 
-            // verify that all events were read
+            // verify that the job did fail, and all events were still read
+            Assert.assertTrue(FailOnceMapper.hasFailed());
             Assert.assertEquals(numElements, integers.size());
+
+            FailOnceMapper.reset();
+        }
+    }
+
+    private static class FailOnceMapper extends RichMapFunction<Integer, Integer> {
+
+        private static boolean failedOnce;
+
+        static void reset() {
+            failedOnce = false;
+        }
+
+        static boolean hasFailed() {
+            return failedOnce;
+        }
+
+        private final int failCount;
+
+        FailOnceMapper(int failCount) {
+            this.failCount = failCount;
+        }
+
+        @Override
+        public Integer map(Integer value) throws Exception {
+            if (!failedOnce && value.equals(failCount)) {
+                failedOnce = true;
+                throw new RuntimeException("Artificial failure");
+            }
+
+            return value;
         }
     }
 


### PR DESCRIPTION
**Change log description**

- Reworks the `FlinkPravegaInputFormat` to use the experimental Pravega batch client.
- Expand current IT tests for the input format. The tests now additionally cover the following verifications: 1) reading multiple streams with batch, 2) multiple passes, and 3) rewinds input format in case of failures.
- Previous configuration of the input format such as `startReadTimestamp` and `eventReadTimeout` is removed, since they are no longer relevant / useful after switching to the batch client.

**Purpose of the change**

This PR closes #65 and #56.

As discussed in #65 and #56, the use of reader groups / the `EventStreamReader` API does not work well in batch scenarios, which only allows Pravega segments to be read sequentially. There's also the problem that residual reader group states does not (gracefully) allow the input format to have multiple passes, or even re-executions on job failures.

This PR reworks the input format to use the experimental batch client instead.

**How to verify it**

- The original `FlinkPravegaInputFormatTest.testBatchInput()` is expanded to verify multiple passes of the input format, as well as reading a set of multiple input streams.
- A new `FlinkPravegaInputFormatTest.testBatchInputWithFailure()` is added to verify the behaviour in the presence of failures.

The above tests all fail without the rework in `FlinkPravegaInputFormat`.