### PR TITLE
[issue-74] added scope/stream context to checkpoint state for recovering right context

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/util/StreamId.java
+++ b/src/main/java/io/pravega/connectors/flink/util/StreamId.java
@@ -11,6 +11,8 @@ package io.pravega.connectors.flink.util;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Objects;
+
 /**
  * Captures the fully qualified name of a stream. The convention to represent this as a
  * single string is using [scope]/[stream].
@@ -28,6 +30,26 @@ public class StreamId {
 
     public String getScope() {
         return scope;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        StreamId streamId = (StreamId) o;
+        return Objects.equals(scope, streamId.scope) &&
+                Objects.equals(name, streamId.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scope, name);
     }
 
     public String getName() {

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -533,7 +533,7 @@ public class FlinkPravegaWriterTest {
                         testHarness.setup();
                         Transaction<Integer> trans = context.prepareTransaction();
                         when(trans.checkStatus()).thenReturn(status);
-                        context.sinkFunction.restoreState(Collections.singletonList(new FlinkPravegaWriter.PravegaState(trans.getTxnId(), MOCK_SCOPE_NAME, MOCK_STREAM_NAME)));
+                        context.sinkFunction.restoreState(Collections.singletonList(new FlinkPravegaWriter.PendingTransaction(trans.getTxnId(), MOCK_SCOPE_NAME, MOCK_STREAM_NAME)));
                         verify(trans).checkStatus();
                         return trans;
                     }

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -533,7 +533,7 @@ public class FlinkPravegaWriterTest {
                         testHarness.setup();
                         Transaction<Integer> trans = context.prepareTransaction();
                         when(trans.checkStatus()).thenReturn(status);
-                        context.sinkFunction.restoreState(Collections.singletonList(trans.getTxnId()));
+                        context.sinkFunction.restoreState(Collections.singletonList(new FlinkPravegaWriter.PravegaState(trans.getTxnId(), MOCK_SCOPE_NAME, MOCK_STREAM_NAME)));
                         verify(trans).checkStatus();
                         return trans;
                     }


### PR DESCRIPTION
**Change log description**
Modified checkpoint state for the `FlinkPravegaWriter` to include scope and stream along with the transaction id.

**Purpose of the change**
To recover right context/state information during `restoreState` API call.  Closes #74 .

**What the code does**
Earlier only transaction ID was stored as checkpoint state and now the state information will have both scope and stream name along with the transaction id.

**How to verify it**
Running the `FlinkPravegaWriterITCase->testExactlyOnceWriter` should trigger restoreState and the writer instance should be created using stream/scope information from the state object and will be used to commit any pending transactions.