### PR TITLE
[issue-25] added logback configuration for tests to write to both file and stdout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,13 @@ configurations {
     testCompile.exclude group: 'log4j', module: 'log4j'
 }
 
+test {
+    testLogging {
+        events = ["passed", "failed", "skipped"]
+        showStandardStreams = false
+    }
+}
+
 dependencies {
     compile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
     compile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion

--- a/build.gradle
+++ b/build.gradle
@@ -67,8 +67,13 @@ configurations {
 
 test {
     testLogging {
-        events = ["passed", "failed", "skipped"]
-        showStandardStreams = false
+        onOutput { descriptor, event ->
+            if (project.hasProperty('logOutput')) {
+                events = ["passed", "failed", "skipped"]
+                showStandardStreams = true
+                logger.lifecycle(event.message)
+            }
+        }
     }
 }
 

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true">
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>connector-test.log</file>
+        <append>false</append>
+        <encoder>
+            <charset>UTF-8</charset>
+            <Pattern>%d %-4relative [%thread] %-5level %logger{35} - %msg%n</Pattern>
+        </encoder>
+    </appender>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
@@ -7,7 +17,8 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE" />
     </root>
 </configuration>


### PR DESCRIPTION
**Change log description**
Added file based logging option for the connector test module

**Purpose of the change**
To support file based logging in addition to the stdout logging. Closes #25 .

**What the code does**
when the connector test module is running, the test logs are recorded in `connector-test.log` file under the root project location.

**How to verify it**
run `./gradlew clean build` and it will generate `connector-test.log` file under the root project location which will have the test outputs.