### PR TITLE
[issue-120] updated pravega submodule version and fixed breaking API changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,9 +95,6 @@ dependencies {
         // pravega-shared pulls in curator which isn't needed on the client
         exclude group: 'org.apache.curator', module: 'curator-recipes'
     }
-    compile(group: 'io.pravega', name: 'pravega-authplugin', version: pravegaVersion) {
-        exclude group:  'org.slf4j', module: 'slf4j-api'
-    }
     compileOnly group: 'org.slf4j', name: 'slf4j-api', version: slf4jApiVersion // provided by flink-runtime
     compile group: 'org.apache.commons', name: 'commons-lang3', version: apacheCommonsVersion
     compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion // not needed at runtime

--- a/src/main/java/io/pravega/connectors/flink/PravegaInputSplit.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaInputSplit.java
@@ -64,8 +64,8 @@ public class PravegaInputSplit implements InputSplit {
             return false;
         }
 
-        String thisScope = segmentRange.getScopeName();
-        String thatScope = that.getSegmentRange().getScopeName();
+        String thisScope = segmentRange.getScope();
+        String thatScope = that.getSegmentRange().getScope();
         if (thisScope == null ? thatScope != null : !thisScope.equals(thatScope)) {
             return false;
         }
@@ -93,7 +93,7 @@ public class PravegaInputSplit implements InputSplit {
         result = result * prime + Long.hashCode(getSegmentRange().getStartOffset());
         result = result * prime + Long.hashCode(getSegmentRange().getEndOffset());
 
-        String scope = getSegmentRange().getScopeName();
+        String scope = getSegmentRange().getScope();
         String stream = getSegmentRange().getStreamName();
 
         result = result * prime + (scope == null ? 43 : scope.hashCode());


### PR DESCRIPTION
**Change log description**
Updated connector build to use latest Pravega and resolved the minor API changes introduced in Pravega that was causing connector build to fail

**Purpose of the change**
To fix the build error

**How to verify it**
Tested `./gradlew clean build` for both direct dependency (submodule) and indirect reference (by passing a specific Pravega artifact reference `-PpravegaVersion` that was published recently) and confirmed that build is passing