### PR TITLE
[issue-48] Builder API

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/AbstractReaderBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractReaderBuilder.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink;
+
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamCut;
+import io.pravega.connectors.flink.util.StreamWithBoundaries;
+import lombok.Data;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A base builder for connectors that consume a Pravega stream.
+ * @param <B> the builder class.
+ */
+public abstract class AbstractReaderBuilder<B extends AbstractReaderBuilder> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<StreamSpec> streams;
+
+    private PravegaConfig pravegaConfig;
+
+    protected AbstractReaderBuilder() {
+        this.streams = new ArrayList<>(1);
+        this.pravegaConfig = PravegaConfig.fromDefaults();
+    }
+
+    /**
+     * Set the Pravega client configuration, which includes connection info, security info, and a default scope.
+     *
+     * The default client configuration is obtained from {@code PravegaConfig.fromDefaults()}.
+     * @param pravegaConfig the configuration to use.
+     */
+    public B withPravegaConfig(PravegaConfig pravegaConfig) {
+        this.pravegaConfig = pravegaConfig;
+        return builder();
+    }
+
+    /**
+     * Add a stream and its associated start {@link StreamCut} to be read by the readers of a ReaderGroup.
+     * @param streamSpec the unqualified or qualified name of the stream.
+     * @param startStreamCut Start {@link StreamCut}
+     * @return A builder to configure and create a reader.
+     */
+    public B forStream(final String streamSpec, final StreamCut startStreamCut) {
+        streams.add(StreamSpec.of(streamSpec, startStreamCut, StreamCut.UNBOUNDED));
+        return builder();
+    }
+
+    /**
+     * Add a stream that needs to be read by the readers of a ReaderGroup. The current starting position of the stream
+     * will be used as the starting StreamCut.
+     * @param streamSpec the unqualified or qualified name of the stream.
+     * @return A builder to configure and create a reader.
+     */
+    public B forStream(final String streamSpec) {
+        return forStream(streamSpec, StreamCut.UNBOUNDED);
+    }
+
+    /**
+     * Add a stream and its associated start {@link StreamCut} to be read by the readers of a ReaderGroup.
+     * @param stream Stream.
+     * @param startStreamCut Start {@link StreamCut}
+     * @return A builder to configure and create a reader.
+     */
+    public B forStream(final Stream stream, final StreamCut startStreamCut) {
+        streams.add(StreamSpec.of(stream, startStreamCut, StreamCut.UNBOUNDED));
+        return builder();
+    }
+
+    /**
+     * Add a stream that needs to be read by the readers of a ReaderGroup. The current starting position of the stream
+     * will be used as the starting StreamCut.
+     * @param stream Stream.
+     * @return A builder to configure and create a reader.
+     */
+    public B forStream(final Stream stream) {
+        return forStream(stream, StreamCut.UNBOUNDED);
+    }
+
+    /**
+     * Gets the Pravega configuration.
+     */
+    protected PravegaConfig getPravegaConfig() {
+        Preconditions.checkState(pravegaConfig != null, "A Pravega configuration must be supplied.");
+        return pravegaConfig;
+    }
+
+    /**
+     * Resolves the streams to be provided to the reader, based on the configured default scope.
+     */
+    protected List<StreamWithBoundaries> resolveStreams() {
+        Preconditions.checkState(!streams.isEmpty(), "At least one stream must be supplied.");
+        PravegaConfig pravegaConfig = getPravegaConfig();
+        return streams.stream()
+                .map(s -> StreamWithBoundaries.of(pravegaConfig.resolve(s.streamSpec), s.from, s.to))
+                .collect(Collectors.toList());
+    }
+
+    protected abstract B builder();
+
+    /**
+     * A Pravega stream with optional boundaries based on stream cuts.
+     */
+    @Data
+    public static class StreamSpec implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String streamSpec;
+        private final StreamCut from;
+        private final StreamCut to;
+
+        public static StreamSpec of(String streamSpec, StreamCut from, StreamCut to) {
+            Preconditions.checkNotNull(streamSpec, "streamSpec");
+            Preconditions.checkNotNull(streamSpec, "from");
+            Preconditions.checkNotNull(streamSpec, "to");
+            return new StreamSpec(streamSpec, from, to);
+        }
+
+        public static StreamSpec of(Stream stream, StreamCut from, StreamCut to) {
+            Preconditions.checkNotNull(stream, "stream");
+            Preconditions.checkNotNull(stream, "from");
+            Preconditions.checkNotNull(stream, "to");
+            return new StreamSpec(stream.getScopedName(), from, to);
+        }
+    }
+
+}

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
@@ -12,16 +12,17 @@ package io.pravega.connectors.flink;
 
 import com.google.common.base.Preconditions;
 
+import io.pravega.client.ClientConfig;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.batch.BatchClient;
 import io.pravega.client.batch.SegmentIterator;
 import io.pravega.client.batch.SegmentRange;
-import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.Serializer;
-import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamCut;
 import io.pravega.connectors.flink.serialization.WrappingSerializer;
 import io.pravega.connectors.flink.util.FlinkPravegaUtils;
 
+import io.pravega.connectors.flink.util.StreamWithBoundaries;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.io.DefaultInputSplitAssigner;
 import org.apache.flink.api.common.io.InputFormat;
@@ -32,11 +33,9 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.core.io.InputSplitAssigner;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 /**
  * A Flink {@link InputFormat} that can be added as a source to read from Pravega in a Flink batch job.
@@ -46,17 +45,19 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
 
     private static final long serialVersionUID = 1L;
 
-    // The supplied event deserializer.
-    private final DeserializationSchema<T> deserializationSchema;
+    private static final String DEFAULT_CLIENT_SCOPE_NAME = "__NOT_USED";
 
-    // The pravega controller endpoint.
-    private final URI controllerURI;
+    // The Pravega client configuration.
+    private final ClientConfig clientConfig;
 
-    // The scope name of the destination stream.
-    private final String scopeName;
+    // The scope name to use to construct the Pravega client.
+    private final String clientScope;
 
     // The names of Pravega streams to read.
-    private final Set<String> streamNames;
+    private final List<StreamWithBoundaries> streams;
+
+    // The supplied event deserializer.
+    private final DeserializationSchema<T> deserializationSchema;
 
     // The factory used to create Pravega clients; closing this will also close all Pravega connections.
     private transient ClientFactory clientFactory;
@@ -70,30 +71,18 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
     /**
      * Creates a new Flink Pravega {@link InputFormat} which can be added as a source to a Flink batch job.
      *
-     * <p>The number of created input splits is equivalent to the parallelism of the source. For each input split,
-     * a Pravega reader will be created to read from the specified Pravega streams. Each input split is closed when
-     * the next read event returns {@code null} on {@link EventRead#getEvent()}.
-     *
-     * @param controllerURI         The pravega controller endpoint address.
-     * @param scope                 The destination stream's scope name.
-     * @param streamNames           The list of stream names to read events from.
+     * @param clientConfig          The pravega client configuration.
+     * @param streams               The list of streams to read events from.
      * @param deserializationSchema The implementation to deserialize events from pravega streams.
      */
-    public FlinkPravegaInputFormat(
-            final URI controllerURI,
-            final String scope,
-            final Set<String> streamNames,
-            final DeserializationSchema<T> deserializationSchema) {
-
-        Preconditions.checkNotNull(controllerURI, "controllerURI");
-        Preconditions.checkNotNull(scope, "scope");
-        Preconditions.checkNotNull(streamNames, "streamNames");
-        Preconditions.checkNotNull(deserializationSchema, "deserializationSchema");
-
-        this.controllerURI = controllerURI;
-        this.scopeName = scope;
-        this.deserializationSchema = deserializationSchema;
-        this.streamNames = streamNames;
+    protected FlinkPravegaInputFormat(
+            ClientConfig clientConfig,
+            List<StreamWithBoundaries> streams,
+            DeserializationSchema<T> deserializationSchema) {
+        this.clientConfig = Preconditions.checkNotNull(clientConfig, "clientConfig");
+        this.clientScope = DEFAULT_CLIENT_SCOPE_NAME;
+        this.streams = Preconditions.checkNotNull(streams, "streams");
+        this.deserializationSchema = Preconditions.checkNotNull(deserializationSchema, "deserializationSchema");
     }
 
     // ------------------------------------------------------------------------
@@ -104,7 +93,7 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
     public void openInputFormat() throws IOException {
         super.openInputFormat();
 
-        this.clientFactory = ClientFactory.withScope(scopeName, controllerURI);
+        this.clientFactory = ClientFactory.withScope(clientScope, clientConfig);
         this.batchClient = clientFactory.createBatchClient();
     }
 
@@ -131,20 +120,22 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
 
         // createInputSplits() is called in the JM, so we have to establish separate
         // short-living connections to Pravega here to retrieve the segments list
-        try (ClientFactory clientFactory = ClientFactory.withScope(scopeName, controllerURI)) {
+        try (ClientFactory clientFactory = ClientFactory.withScope(clientScope, clientConfig)) {
             BatchClient batchClient = clientFactory.createBatchClient();
 
-            for (String stream : streamNames) {
-
+            for (StreamWithBoundaries stream : streams) {
+                // ISSUE: pravega/pravega#2518
+                StreamCut from = !stream.getFrom().equals(StreamCut.UNBOUNDED) ? stream.getFrom() : null;
+                StreamCut to = !stream.getTo().equals(StreamCut.UNBOUNDED) ? stream.getTo() : null;
                 Iterator<SegmentRange> segmentRangeIterator =
-                        batchClient.getSegments(Stream.of(scopeName, stream), null, null).getIterator();
+                        batchClient.getSegments(stream.getStream(), from, to).getIterator();
                 while (segmentRangeIterator.hasNext()) {
-                    splits.add(new PravegaInputSplit(splits.size(),
-                            segmentRangeIterator.next()));
+                    splits.add(new PravegaInputSplit(splits.size(), segmentRangeIterator.next()));
                 }
             }
         }
 
+        log.info("Prepared {} input splits", splits.size());
         return splits.toArray(new PravegaInputSplit[splits.size()]);
     }
 
@@ -182,5 +173,46 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
     @Override
     public void close() throws IOException {
         this.segmentIterator.close();
+    }
+
+    /**
+     * Gets a builder {@link FlinkPravegaInputFormat} to read Pravega streams using the Flink batch API.
+     * @param <T> the element type.
+     */
+    public static <T> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    /**
+     * A builder for {@link FlinkPravegaInputFormat} to read Pravega streams using the Flink batch API.
+     *
+     * @param <T> the element type.
+     */
+    public static class Builder<T> extends AbstractReaderBuilder<FlinkPravegaInputFormat.Builder<T>> {
+
+        private DeserializationSchema<T> deserializationSchema;
+
+        protected Builder<T> builder() {
+            return this;
+        }
+
+        /**
+         * Sets the deserialization schema.
+         *
+         * @param deserializationSchema The deserialization schema
+         */
+        public Builder<T> withDeserializationSchema(DeserializationSchema<T> deserializationSchema) {
+            this.deserializationSchema = deserializationSchema;
+            return builder();
+        }
+
+        protected DeserializationSchema<T> getDeserializationSchema() {
+            Preconditions.checkState(deserializationSchema != null, "Deserialization schema must not be null.");
+            return deserializationSchema;
+        }
+
+        public FlinkPravegaInputFormat<T> build() {
+            return new FlinkPravegaInputFormat<>(getPravegaConfig().getClientConfig(), resolveStreams(), getDeserializationSchema());
+        }
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaJsonTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaJsonTableSource.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink;
+
+import io.pravega.connectors.flink.serialization.JsonRowDeserializationSchema;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.types.Row;
+
+import java.util.function.Supplier;
+
+/**
+ * A {@link TableSource} to read JSON-formatted Pravega streams using the Flink Table API.
+ */
+public class FlinkPravegaJsonTableSource extends FlinkPravegaTableSource {
+
+    protected FlinkPravegaJsonTableSource(
+            Supplier<FlinkPravegaReader<Row>> readerFactory,
+            Supplier<FlinkPravegaInputFormat<Row>> inputFormatFactory,
+            TableSchema tableSchema) {
+        super(readerFactory, inputFormatFactory, tableSchema, jsonSchemaToReturnType(tableSchema));
+    }
+
+    @Override
+    public String explainSource() {
+        return "FlinkPravegaJsonTableSource";
+    }
+
+    /**
+     * A builder for {@link FlinkPravegaJsonTableSource} to read Pravega streams using the Flink Table API.
+     */
+    public static FlinkPravegaJsonTableSource.Builder builder() {
+        return new Builder();
+    }
+
+    /** Converts the JSON schema into into the return type. */
+    private static RowTypeInfo jsonSchemaToReturnType(TableSchema jsonSchema) {
+        return new RowTypeInfo(jsonSchema.getTypes(), jsonSchema.getColumnNames());
+    }
+
+    /**
+     * A builder for {@link FlinkPravegaJsonTableSource} to read JSON-formatted Pravega streams using the Flink Table API.
+     */
+    public static class Builder
+            extends FlinkPravegaTableSource.BuilderBase<FlinkPravegaJsonTableSource, Builder> {
+
+        private boolean failOnMissingField = false;
+
+        @Override
+        protected Builder builder() {
+            return this;
+        }
+
+        /**
+         * Sets flag whether to fail if a field is missing.
+         *
+         * @param failOnMissingField If set to true, the TableSource fails if a missing fields.
+         *                           If set to false, a missing field is set to null.
+         * @return The builder.
+         */
+        public Builder failOnMissingField(boolean failOnMissingField) {
+            this.failOnMissingField = failOnMissingField;
+            return builder();
+        }
+
+        @Override
+        protected JsonRowDeserializationSchema getDeserializationSchema() {
+            JsonRowDeserializationSchema deserSchema = new JsonRowDeserializationSchema(jsonSchemaToReturnType(getTableSchema()));
+            deserSchema.setFailOnMissingField(failOnMissingField);
+            return deserSchema;
+        }
+
+        /**
+         * Builds a {@link FlinkPravegaReader} based on the configuration.
+         *
+         * @throws IllegalStateException if the configuration is invalid.
+         */
+        public FlinkPravegaJsonTableSource build() {
+            FlinkPravegaJsonTableSource tableSource = new FlinkPravegaJsonTableSource(
+                    this::buildSourceFunction,
+                    this::buildInputFormat,
+                    getTableSchema());
+            configureTableSource(tableSource);
+            return tableSource;
+        }
+    }
+}

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -10,7 +10,7 @@
 package io.pravega.connectors.flink;
 
 import com.google.common.base.Preconditions;
-
+import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.EventRead;
@@ -18,30 +18,22 @@ import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
-
-import io.pravega.client.stream.Stream;
-import io.pravega.client.stream.StreamCut;
+import io.pravega.connectors.flink.util.FlinkPravegaUtils;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.flink.api.common.functions.StoppableFunction;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
 import org.apache.flink.streaming.api.checkpoint.ExternallyInducedSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.util.FlinkException;
 
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.Optional;
 
 import static io.pravega.connectors.flink.util.FlinkPravegaUtils.createPravegaReader;
-import static io.pravega.connectors.flink.util.FlinkPravegaUtils.generateRandomReaderGroupName;
-import static io.pravega.connectors.flink.util.FlinkPravegaUtils.getDefaultReaderName;
 
 /**
  * Flink source implementation for reading from pravega storage.
@@ -55,68 +47,43 @@ public class FlinkPravegaReader<T>
 
     private static final long serialVersionUID = 1L;
 
-    private static final long DEFAULT_EVENT_READ_TIMEOUT = 1000;
-
-    private static final long DEFAULT_CHECKPOINT_INITIATE_TIMEOUT = 5000;
-
     // ----- configuration fields -----
 
-    // The supplied event deserializer.
-    private final DeserializationSchema<T> deserializationSchema;
+    // the uuid of the checkpoint hook, used to store state and resume existing state from savepoints
+    final String hookUid;
 
-    // The pravega controller endpoint.
-    private final URI controllerURI;
+    // The Pravega client config.
+    final ClientConfig clientConfig;
 
-    // The scope name of the destination stream.
-    private final String scopeName;
+    // The Pravega reader group config.
+    final ReaderGroupConfig readerGroupConfig;
+
+    // The scope name of the reader group.
+    final String readerGroupScope;
 
     // The readergroup name to coordinate the parallel readers. This should be unique for a Flink job.
-    private final String readerGroupName;
+    final String readerGroupName;
 
-    // The stream names of the associated scope
-    private final Set<String> streamNames;
-
-    // the name of the reader, used to store state and resume existing state from savepoints
-    private final String readerName;
+    // The supplied event deserializer.
+    final DeserializationSchema<T> deserializationSchema;
 
     // the timeout for reading events from Pravega 
-    private long eventReadTimeout = DEFAULT_EVENT_READ_TIMEOUT;
+    final Time eventReadTimeout;
 
     // the timeout for call that initiates the Pravega checkpoint 
-    private long checkpointInitiateTimeout = DEFAULT_CHECKPOINT_INITIATE_TIMEOUT;
+    final Time checkpointInitiateTimeout;
 
     // ----- runtime fields -----
 
     // Flag to terminate the source. volatile, because 'stop()' and 'cancel()' 
     // may be called asynchronously 
-    private volatile boolean running = true;
+    volatile boolean running = true;
 
     // checkpoint trigger callback, invoked when a checkpoint event is received.
     // no need to be volatile, the source is driven by only one thread
     private transient CheckpointTrigger checkpointTrigger;
 
     // ------------------------------------------------------------------------
-
-    /**
-     * Creates a new Flink Pravega reader instance which can be added as a source to a Flink job.
-     *
-     * <p>The reader will use a random name under which it stores its state in a checkpoint. While
-     * checkpoints still work, this means that matching the state into another Flink jobs
-     * (when resuming from a savepoint) will not be possible. Thus it is generally recommended
-     * to give a reader name to each reader.
-     *
-     * @param controllerURI         The pravega controller endpoint address.
-     * @param scope                 The destination stream's scope name.
-     * @param streamNames           The list of stream names to read events from.
-     * @param startTime             The start time from when to read events from.
-     *                              Use 0 to read all stream events from the beginning.
-     * @param deserializationSchema The implementation to deserialize events from pravega streams.
-     */
-    public FlinkPravegaReader(final URI controllerURI, final String scope, final Set<String> streamNames,
-                              final long startTime, final DeserializationSchema<T> deserializationSchema) {
-
-        this(controllerURI, scope, streamNames, startTime, deserializationSchema, null);
-    }
 
     /**
      * Creates a new Flink Pravega reader instance which can be added as a source to a Flink job.
@@ -129,95 +96,37 @@ public class FlinkPravegaReader<T>
      * <p>Without specifying a {@code readerName}, the job will correctly checkpoint and recover,
      * but new instances of the job can typically not resume this reader's state (positions).
      *
-     * @param controllerURI         The pravega controller endpoint address.
-     * @param scope                 The destination stream's scope name.
-     * @param streamNames           The list of stream names to read events from.
-     * @param startTime             The start time from when to read events from.
-     *                              Use 0 to read all stream events from the beginning.
-     * @param deserializationSchema The implementation to deserialize events from pravega streams.
-     * @param readerName            The name of the reader, used to store state and resume existing
-     *                              state from savepoints.
+     * @param hookUid                   The UID of the source hook in the job graph.
+     * @param clientConfig              The Pravega client configuration.
+     * @param readerGroupConfig         The Pravega reader group configuration.
+     * @param readerGroupScope          The reader group scope name.
+     * @param readerGroupName           The reader group name.
+     * @param deserializationSchema     The implementation to deserialize events from Pravega streams.
+     * @param eventReadTimeout          The event read timeout.
+     * @param checkpointInitiateTimeout The checkpoint initiation timeout.
      */
-    public FlinkPravegaReader(final URI controllerURI, final String scope, final Set<String> streamNames,
-                              final long startTime, final DeserializationSchema<T> deserializationSchema,
-                              final String readerName) {
+    protected FlinkPravegaReader(String hookUid, ClientConfig clientConfig,
+                                 ReaderGroupConfig readerGroupConfig, String readerGroupScope, String readerGroupName,
+                                 DeserializationSchema<T> deserializationSchema, Time eventReadTimeout, Time checkpointInitiateTimeout) {
 
-        Preconditions.checkNotNull(controllerURI, "controllerURI");
-        Preconditions.checkNotNull(scope, "scope");
-        Preconditions.checkNotNull(streamNames, "streamNames");
-        Preconditions.checkArgument(startTime >= 0, "start time must be >= 0");
-        Preconditions.checkNotNull(deserializationSchema, "deserializationSchema");
-        if (readerName == null) {
-            this.readerName = getDefaultReaderName(scope, streamNames);
-        } else {
-            this.readerName = readerName;
-        }
+        this.hookUid = Preconditions.checkNotNull(hookUid, "hookUid");
+        this.clientConfig = Preconditions.checkNotNull(clientConfig, "clientConfig");
+        this.readerGroupConfig = Preconditions.checkNotNull(readerGroupConfig, "readerGroupConfig");
+        this.readerGroupScope = Preconditions.checkNotNull(readerGroupScope, "readerGroupScope");
+        this.readerGroupName = Preconditions.checkNotNull(readerGroupName, "readerGroupName");
+        this.deserializationSchema = Preconditions.checkNotNull(deserializationSchema, "deserializationSchema");
+        this.eventReadTimeout = Preconditions.checkNotNull(eventReadTimeout, "eventReadTimeout");
+        this.checkpointInitiateTimeout = Preconditions.checkNotNull(checkpointInitiateTimeout, "checkpointInitiateTimeout");
+    }
 
-        this.controllerURI = controllerURI;
-        this.scopeName = scope;
-        this.deserializationSchema = deserializationSchema;
-        this.readerGroupName = generateRandomReaderGroupName();
-        this.streamNames = streamNames;
-
+    /**
+     * Initializes the reader.
+     */
+    void initialize() {
         // TODO: This will require the client to have access to the pravega controller and handle any temporary errors.
         //       See https://github.com/pravega/pravega/issues/553.
-        log.info("Creating reader group: {} for the Flink job", this.readerGroupName);
-
+        log.info("Creating reader group: {}/{} for the Flink job", this.readerGroupScope, this.readerGroupName);
         createReaderGroup();
-
-    }
-
-    // ------------------------------------------------------------------------
-    //  properties
-    // ------------------------------------------------------------------------
-
-    /**
-     * Sets the timeout for initiating a checkpoint in Pravega.
-     *
-     * <p>This timeout if applied to the future returned by
-     * {@link io.pravega.client.stream.ReaderGroup#initiateCheckpoint(String, ScheduledExecutorService)}.
-     *
-     * @param checkpointInitiateTimeout The timeout, in milliseconds
-     */
-    public void setCheckpointInitiateTimeout(long checkpointInitiateTimeout) {
-        Preconditions.checkArgument(checkpointInitiateTimeout > 0, "timeout must be >= 0");
-        this.checkpointInitiateTimeout = checkpointInitiateTimeout;
-    }
-
-    /**
-     * Gets the timeout for initiating a checkpoint in Pravega.
-     *
-     * <p>This timeout if applied to the future returned by
-     * {@link io.pravega.client.stream.ReaderGroup#initiateCheckpoint(String, ScheduledExecutorService)}.
-     *
-     * @return The timeout, in milliseconds
-     */
-    public long getCheckpointInitiateTimeout() {
-        return checkpointInitiateTimeout;
-    }
-
-    /**
-     * Gets the timeout for the call to read events from Pravega. After the timeout
-     * expires (without an event being returned), another call will be made.
-     * 
-     * <p>This timeout is passed to {@link EventStreamReader#readNextEvent(long)}.
-     * 
-     * @param eventReadTimeout The timeout, in milliseconds
-     */
-    public void setEventReadTimeout(long eventReadTimeout) {
-        Preconditions.checkArgument(eventReadTimeout > 0, "timeout must be >= 0");
-        this.eventReadTimeout = eventReadTimeout;
-    }
-
-    /**
-     * Gets the timeout for the call to read events from Pravega.
-     * 
-     * <p>This timeout is the value passed to {@link EventStreamReader#readNextEvent(long)}.
-     * 
-     * @return The timeout, in milliseconds
-     */
-    public long getEventReadTimeout() {
-        return eventReadTimeout;
     }
 
     // ------------------------------------------------------------------------
@@ -230,21 +139,15 @@ public class FlinkPravegaReader<T>
         final String readerId = getRuntimeContext().getTaskNameWithSubtasks();
 
         log.info("{} : Creating Pravega reader with ID '{}' for controller URI: {}",
-                getRuntimeContext().getTaskNameWithSubtasks(), readerId, this.controllerURI);
+                getRuntimeContext().getTaskNameWithSubtasks(), readerId, this.clientConfig.getControllerURI());
 
-        try (EventStreamReader<T> pravegaReader = createPravegaReader(
-                this.scopeName,
-                this.controllerURI,
-                readerId,
-                this.readerGroupName,
-                this.deserializationSchema,
-                ReaderConfig.builder().build())) {
+        try (EventStreamReader<T> pravegaReader = createEventStreamReader(readerId)) {
 
-            log.info("Starting Pravega reader '{}' for controller URI {}", readerId, this.controllerURI);
+            log.info("Starting Pravega reader '{}' for controller URI {}", readerId, this.clientConfig.getControllerURI());
 
             // main work loop, which this task is running
             while (this.running) {
-                final EventRead<T> eventRead = pravegaReader.readNextEvent(eventReadTimeout);
+                final EventRead<T> eventRead = pravegaReader.readNextEvent(eventReadTimeout.toMilliseconds());
                 final T event = eventRead.getEvent();
 
                 // emit the event, if one was carried
@@ -291,7 +194,7 @@ public class FlinkPravegaReader<T>
 
     @Override
     public MasterTriggerRestoreHook<Checkpoint> createMasterTriggerRestoreHook() {
-        return new ReaderCheckpointHook(this.readerName, createReaderGroup(), this.checkpointInitiateTimeout);
+        return new ReaderCheckpointHook(this.hookUid, createReaderGroup(), this.checkpointInitiateTimeout);
     }
 
     @Override
@@ -320,23 +223,240 @@ public class FlinkPravegaReader<T>
         checkpointTrigger.triggerCheckpoint(checkpointId);
     }
 
-    /*
-     * create reader group for the associated stream names and scope
+    // ------------------------------------------------------------------------
+    //  utility
+    // ------------------------------------------------------------------------
+
+    /**
+     * Create the {@link ReaderGroup} for the current configuration.
      */
-    private ReaderGroup createReaderGroup() {
-        Map<Stream, StreamCut> streamConfigMap = new HashMap<>();
-        for (String stream: streamNames) {
-            streamConfigMap.put(Stream.of(scopeName, stream), StreamCut.UNBOUNDED);
+    protected ReaderGroup createReaderGroup() {
+        ReaderGroupManager readerGroupManager = createReaderGroupManager();
+        readerGroupManager.createReaderGroup(this.readerGroupName, readerGroupConfig);
+        return readerGroupManager.getReaderGroup(this.readerGroupName);
+    }
+
+    /**
+     * Create the {@link ReaderGroupManager} for the current configuration.
+     */
+    protected ReaderGroupManager createReaderGroupManager() {
+        return ReaderGroupManager.withScope(readerGroupScope, clientConfig);
+    }
+
+    /**
+     * Create the {@link EventStreamReader} for the current configuration.
+     * @param readerId the readerID to use.
+     */
+    protected EventStreamReader<T> createEventStreamReader(String readerId) {
+        return createPravegaReader(
+                this.clientConfig,
+                readerId,
+                this.readerGroupScope,
+                this.readerGroupName,
+                this.deserializationSchema,
+                ReaderConfig.builder().build());
+    }
+
+    // ------------------------------------------------------------------------
+    //  configuration
+    // ------------------------------------------------------------------------
+
+    /**
+     * Gets a builder for {@link FlinkPravegaReader} to read Pravega streams using the Flink streaming API.
+     * @param <T> the element type.
+     */
+    public static <T> FlinkPravegaReader.Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    /**
+     * An abstract streaming reader builder.
+     *
+     * The builder is abstracted to act as the base for both the {@link FlinkPravegaReader} and {@link FlinkPravegaTableSource} builders.
+     *
+     * @param <T> the element type.
+     * @param <B> the builder type.
+     */
+    static abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStreamingReaderBuilder> extends AbstractReaderBuilder<B> {
+
+        private static final Time DEFAULT_EVENT_READ_TIMEOUT = Time.seconds(1);
+        private static final Time DEFAULT_CHECKPOINT_INITIATE_TIMEOUT = Time.seconds(5);
+
+        protected String uid;
+        protected String readerGroupScope;
+        protected String readerGroupName;
+        protected Time readerGroupRefreshTime;
+        protected Time checkpointInitiateTimeout;
+        protected Time eventReadTimeout;
+
+        protected AbstractStreamingReaderBuilder() {
+            this.checkpointInitiateTimeout = DEFAULT_CHECKPOINT_INITIATE_TIMEOUT;
+            this.eventReadTimeout = DEFAULT_EVENT_READ_TIMEOUT;
         }
 
-        ReaderGroupConfig groupConfig = ReaderGroupConfig.builder()
-                .disableAutomaticCheckpoints()
-                .startFromStreamCuts(streamConfigMap)
-                .build();
+        /**
+         * Configures the source uid to identify the checkpoint state of this source.
+         * <p>
+         * The default value is generated based on other inputs.
+         *
+         * @param uid the uid to use.
+         */
+        public B uid(String uid) {
+            this.uid = uid;
+            return builder();
+        }
 
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scopeName, controllerURI);
-        readerGroupManager.createReaderGroup(this.readerGroupName, groupConfig);
+        /**
+         * Configures the reader group scope for synchronization purposes.
+         * <p>
+         * The default value is taken from the {@link PravegaConfig} {@code defaultScope} property.
+         *
+         * @param scope the scope name.
+         */
+        public B withReaderGroupScope(String scope) {
+            this.readerGroupScope = Preconditions.checkNotNull(scope);
+            return builder();
+        }
 
-        return readerGroupManager.getReaderGroup(this.readerGroupName);
+        /**
+         * Configures the reader group name.
+         *
+         * @param readerGroupName the reader group name.
+         */
+        public B withReaderGroupName(String readerGroupName) {
+            this.readerGroupName = Preconditions.checkNotNull(readerGroupName);
+            return builder();
+        }
+
+        /**
+         * Sets the group refresh time, with a default of 1 second.
+         *
+         * @param groupRefreshTime The group refresh time
+         */
+        public B withReaderGroupRefreshTime(Time groupRefreshTime) {
+            this.readerGroupRefreshTime = groupRefreshTime;
+            return builder();
+        }
+
+        /**
+         * Sets the timeout for initiating a checkpoint in Pravega.
+         *
+         * @param checkpointInitiateTimeout The timeout
+         */
+        public B withCheckpointInitiateTimeout(Time checkpointInitiateTimeout) {
+            Preconditions.checkArgument(checkpointInitiateTimeout.getSize() > 0, "timeout must be > 0");
+            this.checkpointInitiateTimeout = checkpointInitiateTimeout;
+            return builder();
+        }
+
+        /**
+         * Sets the timeout for the call to read events from Pravega. After the timeout
+         * expires (without an event being returned), another call will be made.
+         *
+         * @param eventReadTimeout The timeout
+         */
+        public B withEventReadTimeout(Time eventReadTimeout) {
+            Preconditions.checkArgument(eventReadTimeout.getSize() > 0, "timeout must be > 0");
+            this.eventReadTimeout = eventReadTimeout;
+            return builder();
+        }
+
+        protected abstract DeserializationSchema<T> getDeserializationSchema();
+
+        /**
+         * Builds a {@link FlinkPravegaReader} based on the configuration.
+         *
+         * Note that the {@link FlinkPravegaTableSource} supports both the batch and streaming API, and so creates both
+         * a source function and an input format and then uses one or the other.
+         *
+         * Be sure to call {@code initialize()} before returning the reader to user code.
+         *
+         * @throws IllegalStateException if the configuration is invalid.
+         * @return an uninitiailized reader as a source function.
+         */
+        FlinkPravegaReader<T> buildSourceFunction() {
+
+            // rgConfig
+            ReaderGroupConfig.ReaderGroupConfigBuilder rgConfigBuilder = ReaderGroupConfig
+                    .builder()
+                    .disableAutomaticCheckpoints();
+            if (this.readerGroupRefreshTime != null) {
+                rgConfigBuilder.groupRefreshTimeMillis(this.readerGroupRefreshTime.toMilliseconds());
+            }
+            resolveStreams().forEach(s -> rgConfigBuilder.stream(s.getStream(), s.getFrom() /*, s.getTo() */));
+            final ReaderGroupConfig rgConfig = rgConfigBuilder.build();
+
+            // rgScope
+            final String rgScope = Optional.ofNullable(this.readerGroupScope).orElseGet(() -> {
+                Preconditions.checkState(getPravegaConfig().getDefaultScope() != null,  "A reader group scope or default scope must be configured");
+                return getPravegaConfig().getDefaultScope();
+            });
+
+            // rgName
+            final String rgName = Optional.ofNullable(this.readerGroupName).orElseGet(FlinkPravegaUtils::generateRandomReaderGroupName);
+
+            return new FlinkPravegaReader<>(
+                    Optional.ofNullable(this.uid).orElseGet(this::generateUid),
+                    getPravegaConfig().getClientConfig(),
+                    rgConfig,
+                    rgScope,
+                    rgName,
+                    getDeserializationSchema(),
+                    this.eventReadTimeout,
+                    this.checkpointInitiateTimeout);
+        }
+
+        /**
+         * Generate a UID for the source, to distinguish the state associated with the checkpoint hook.  A good generated UID will:
+         * 1. be stable across savepoints for the same inputs
+         * 2. disambiguate one source from another (e.g. in a program that uses numerous instances of {@link FlinkPravegaReader})
+         * 3. allow for reconfiguration of the timeouts
+         */
+        String generateUid() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(readerGroupScope).append('\n');
+            resolveStreams().forEach(s -> sb.append(s.getStream().getScopedName()).append('/').append(s.getFrom()).append('/').append(s.getTo()).append('\n'));
+            return Integer.toString(sb.toString().hashCode());
+        }
+    }
+
+    /**
+     * A builder for {@link FlinkPravegaReader}.
+     *
+     * @param <T> the element type.
+     */
+    public static class Builder<T> extends AbstractStreamingReaderBuilder<T, Builder<T>> {
+
+        private DeserializationSchema<T> deserializationSchema;
+
+        protected Builder<T> builder() {
+            return this;
+        }
+
+        /**
+         * Sets the deserialization schema.
+         *
+         * @param deserializationSchema The deserialization schema
+         */
+        public Builder<T> withDeserializationSchema(DeserializationSchema<T> deserializationSchema) {
+            this.deserializationSchema = deserializationSchema;
+            return builder();
+        }
+
+        @Override
+        protected DeserializationSchema<T> getDeserializationSchema() {
+            Preconditions.checkState(deserializationSchema != null, "Deserialization schema must not be null.");
+            return deserializationSchema;
+        }
+
+        /**
+         * Builds a {@link FlinkPravegaReader} based on the configuration.
+         * @throws IllegalStateException if the configuration is invalid.
+         */
+        public FlinkPravegaReader<T> build() {
+            FlinkPravegaReader<T> reader = buildSourceFunction();
+            reader.initialize();
+            return reader;
+        }
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSink.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSink.java
@@ -10,7 +10,7 @@
 
 package io.pravega.connectors.flink;
 
-import io.pravega.connectors.flink.util.StreamId;
+import io.pravega.client.stream.Stream;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
@@ -37,7 +37,7 @@ public class FlinkPravegaTableSink implements AppendStreamTableSink<Row> {
     protected final URI controllerURI;
 
     /** The Pravega stream to use. */
-    protected final StreamId stream;
+    protected final Stream stream;
 
     protected SerializationSchema<Row> serializationSchema;
     protected PravegaEventRouter<Row> eventRouter;
@@ -65,7 +65,7 @@ public class FlinkPravegaTableSink implements AppendStreamTableSink<Row> {
      */
     public FlinkPravegaTableSink(
             URI controllerURI,
-            StreamId stream,
+            Stream stream,
             Function<String[], SerializationSchema<Row>> serializationSchemaFactory,
             String routingKeyFieldName) {
         this.controllerURI = controllerURI;
@@ -85,7 +85,7 @@ public class FlinkPravegaTableSink implements AppendStreamTableSink<Row> {
      * Returns the low-level writer.
      */
     protected FlinkPravegaWriter<Row> createFlinkPravegaWriter() {
-        return new FlinkPravegaWriter<>(controllerURI, stream.getScope(), stream.getName(), serializationSchema, eventRouter);
+        return new FlinkPravegaWriter<>(controllerURI, stream.getScope(), stream.getStreamName(), serializationSchema, eventRouter);
     }
 
     /**

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
@@ -10,66 +10,58 @@
 
 package io.pravega.connectors.flink;
 
-import io.pravega.connectors.flink.util.StreamId;
-
+import io.pravega.client.ClientConfig;
+import io.pravega.connectors.flink.util.StreamWithBoundaries;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.BatchTableSource;
 import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 
-import java.net.URI;
-import java.util.Collections;
-import java.util.function.Function;
+import java.util.List;
+import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * A table source to produce a streaming table from a Pravega stream.
+ * A {@link TableSource} to read Pravega streams using the Flink Table API.
+ *
+ * Supports both stream and batch environments.
  */
-public class FlinkPravegaTableSource implements StreamTableSource<Row> {
+public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>, BatchTableSource<Row> {
 
-    /** The Pravega controller endpoint. */
-    private final URI controllerURI;
+    private final Supplier<FlinkPravegaReader<Row>> sourceFunctionFactory;
 
-    /** The Pravega stream to use. */
-    private final StreamId stream;
+    private final Supplier<FlinkPravegaInputFormat<Row>> inputFormatFactory;
 
-    /** The start time from when to read events from. */
-    private final long startTime;
-
-    /** Deserialization schema to use for Pravega stream events. */
-    private final DeserializationSchema<Row> deserializationSchema;
+    private final TableSchema schema;
 
     /** Type information describing the result type. */
-    private final TypeInformation<Row> typeInfo;
+    private final TypeInformation<Row> returnType;
 
     /**
-     * Creates a Pravega {@link StreamTableSource}.
-     *
-     * <p>The {@code deserializationSchemaFactory} supplies a {@link DeserializationSchema}
-     * based on the result type information.
-     *
-     * @param controllerURI                The pravega controller endpoint address.
-     * @param stream                       The stream to read events from.
-     * @param startTime                    The start time from when to read events from.
-     * @param deserializationSchemaFactory The deserialization schema to use for stream events.
-     * @param typeInfo                     The type information describing the result type.
+     * Creates a Pravega {@link TableSource}.
+     * @param sourceFunctionFactory a factory for the {@link FlinkPravegaReader} to implement {@link StreamTableSource}
+     * @param inputFormatFactory a factory for the {@link FlinkPravegaInputFormat} to implement {@link BatchTableSource}
+     * @param schema the table schema
+     * @param returnType the return type based on the table schema
      */
-    public FlinkPravegaTableSource(
-            final URI controllerURI,
-            final StreamId stream,
-            final long startTime,
-            Function<TypeInformation<Row>, DeserializationSchema<Row>> deserializationSchemaFactory,
-            TypeInformation<Row> typeInfo) {
-        this.controllerURI = controllerURI;
-        this.stream = stream;
-        this.startTime = startTime;
-        checkNotNull(deserializationSchemaFactory, "Deserialization schema factory");
-        this.typeInfo = checkNotNull(typeInfo, "Type information");
-        this.deserializationSchema = deserializationSchemaFactory.apply(typeInfo);
+    protected FlinkPravegaTableSource(
+            Supplier<FlinkPravegaReader<Row>> sourceFunctionFactory,
+            Supplier<FlinkPravegaInputFormat<Row>> inputFormatFactory,
+            TableSchema schema,
+            TypeInformation<Row> returnType) {
+        this.sourceFunctionFactory = checkNotNull(sourceFunctionFactory, "sourceFunctionFactory");
+        this.inputFormatFactory = checkNotNull(inputFormatFactory, "inputFormatFactory");
+        this.schema = checkNotNull(schema, "schema");
+        this.returnType = checkNotNull(returnType, "returnType");
     }
 
     /**
@@ -78,42 +70,84 @@ public class FlinkPravegaTableSource implements StreamTableSource<Row> {
      */
     @Override
     public DataStream<Row> getDataStream(StreamExecutionEnvironment env) {
-        FlinkPravegaReader<Row> reader = createFlinkPravegaReader();
+        FlinkPravegaReader<Row> reader = sourceFunctionFactory.get();
+        reader.initialize();
         return env.addSource(reader);
+    }
+
+    /**
+     * NOTE: This method is for internal use only for defining a TableSource.
+     *       Do not use it in Table API programs.
+     */
+    @Override
+    public DataSet<Row> getDataSet(ExecutionEnvironment env) {
+        FlinkPravegaInputFormat<Row> inputFormat = inputFormatFactory.get();
+        return env.createInput(inputFormat);
     }
 
     @Override
     public TypeInformation<Row> getReturnType() {
-        return typeInfo;
+        return returnType;
     }
 
     @Override
     public TableSchema getTableSchema() {
-        return TableSchema.fromTypeInfo(typeInfo);
+        return schema;
     }
 
     /**
-     * Returns the low-level reader.
-     */
-    protected FlinkPravegaReader<Row> createFlinkPravegaReader() {
-        return new FlinkPravegaReader<>(
-                controllerURI,
-                stream.getScope(), Collections.singleton(stream.getName()),
-                startTime,
-                deserializationSchema);
-    }
-
-    /**
-     * Returns the deserialization schema.
+     * A base builder for {@link FlinkPravegaTableSource} to read Pravega streams using the Flink Table API.
      *
-     * @return The deserialization schema
+     * @param <T> the table source type.
+     * @param <B> the builder type.
      */
-    protected DeserializationSchema<Row> getDeserializationSchema() {
-        return deserializationSchema;
-    }
+    public abstract static class BuilderBase<T extends FlinkPravegaTableSource, B extends FlinkPravegaReader.AbstractStreamingReaderBuilder>
+            extends FlinkPravegaReader.AbstractStreamingReaderBuilder<Row, B> {
 
-    @Override
-    public String explainSource() {
-        return "";
+        private TableSchema schema;
+
+        /**
+         * Sets the schema of the produced table.
+         *
+         * @param schema The schema of the produced table.
+         * @return The builder.
+         */
+        public B withSchema(TableSchema schema) {
+            Preconditions.checkNotNull(schema, "Schema must not be null.");
+            Preconditions.checkArgument(this.schema == null, "Schema has already been set.");
+            this.schema = schema;
+            return builder();
+        }
+
+        /**
+         * Returns the configured table schema.
+         *
+         * @return the configured table schema.
+         */
+        protected TableSchema getTableSchema() {
+            Preconditions.checkState(this.schema != null, "Schema hasn't been set.");
+            return this.schema;
+        }
+
+        /**
+         * Applies a configuration to the table source.
+         * @param source the table source.
+         */
+        protected void configureTableSource(T source) {
+        }
+
+        /**
+         * Gets a factory to build an {@link FlinkPravegaInputFormat} for using the Table API in a Flink batch environment.
+         *
+         * @return a supplier to eagerly validate the configuration and lazily construct the input format.
+         */
+        FlinkPravegaInputFormat<Row> buildInputFormat() {
+
+            final List<StreamWithBoundaries> streams = resolveStreams();
+            final ClientConfig clientConfig = getPravegaConfig().getClientConfig();
+            final DeserializationSchema<Row> deserializationSchema = getDeserializationSchema();
+
+            return new FlinkPravegaInputFormat<>(clientConfig, streams, deserializationSchema);
+        }
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/PravegaConfig.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaConfig.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink;
+
+import io.pravega.client.ClientConfig;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.impl.Credentials;
+import lombok.Data;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * The Pravega client configuration.
+ */
+public class PravegaConfig implements Serializable {
+
+    public static final PravegaParameter CONTROLLER_PARAM = new PravegaParameter("controller", "pravega.controller.uri", "PRAVEGA_CONTROLLER_URI");
+    public static final PravegaParameter SCOPE_PARAM = new PravegaParameter("scope", "pravega.scope", "PRAVEGA_SCOPE");
+
+    private static final long serialVersionUID = 1L;
+
+    private URI controllerURI;
+    private String defaultScope;
+    private Credentials credentials;
+    private boolean validateHostname = true;
+
+    // region Factory methods
+    PravegaConfig(Properties properties, Map<String, String> env, ParameterTool params) {
+        this.controllerURI = CONTROLLER_PARAM.resolve(params, properties, env).map(URI::create).orElse(null);
+        this.defaultScope = SCOPE_PARAM.resolve(params, properties, env).orElse(null);
+    }
+
+    public static PravegaConfig fromDefaults() {
+        return new PravegaConfig(System.getProperties(), System.getenv(), ParameterTool.fromMap(Collections.emptyMap()));
+    }
+
+    public static PravegaConfig fromParams(ParameterTool params) {
+        return new PravegaConfig(System.getProperties(), System.getenv(), params);
+    }
+
+    // endregion
+
+    /**
+     * Gets the {@link ClientConfig} to use with the Pravega client.
+     */
+    public ClientConfig getClientConfig() {
+        ClientConfig.ClientConfigBuilder builder = ClientConfig.builder()
+                .validateHostName(validateHostname);
+        if (controllerURI != null) {
+            builder.controllerURI(controllerURI);
+        }
+        if (credentials != null) {
+            builder.credentials(credentials);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Resolves the given stream name.
+     *
+     * The scope name is resolved in the following order:
+     * 1. from the stream name (if fully-qualified)
+     * 2. from the program argument {@code --scope} (if program arguments were provided to the {@link PravegaConfig})
+     * 3. from the system property {@code pravega.scope}
+     * 4. from the system environment variable {@code PRAVEGA_SCOPE}
+     *
+     * @param streamSpec a qualified or unqualified stream name
+     * @return a fully-qualified stream name
+     * @throws IllegalStateException if an unqualified stream name is supplied but the scope is not configured.
+     */
+    public Stream resolve(String streamSpec) {
+        Preconditions.checkNotNull(streamSpec, "streamSpec");
+        String[] split = streamSpec.split("/", 2);
+        if (split.length == 1) {
+            // unqualified
+            Preconditions.checkState(defaultScope != null, "The default scope is not configured.");
+            return Stream.of(defaultScope, split[0]);
+        } else {
+            // qualified
+            assert split.length == 2;
+            return Stream.of(split[0], split[1]);
+        }
+    }
+
+    // region Discovery
+
+    /**
+     * Configures the Pravega controller RPC URI.
+     * @param controllerURI The URI.
+     */
+    public PravegaConfig withControllerURI(URI controllerURI) {
+        this.controllerURI = controllerURI;
+        return this;
+    }
+
+    /**
+     * Configures the default Pravega scope, to resolve unqualified stream names and to support reader groups.
+     * @param scope The scope to use.
+     */
+    public PravegaConfig withDefaultScope(String scope) {
+        this.defaultScope = scope;
+        return this;
+    }
+
+    /**
+     * Gets the default Pravega scope.
+     */
+    @Nullable
+    public String getDefaultScope() {
+        return defaultScope;
+    }
+
+    // endregion
+
+    // region Security
+
+    public PravegaConfig withCredentials(Credentials credentials) {
+        this.credentials = credentials;
+        return this;
+    }
+
+    public PravegaConfig withHostnameValidation(boolean validateHostname) {
+        this.validateHostname = validateHostname;
+        return this;
+    }
+
+    // endregion
+
+    /**
+     * A configuration parameter resolvable via command-line parameters, system properties, or OS environment variables.
+     */
+    @Data
+    static class PravegaParameter implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String parameterName;
+        private final String propertyName;
+        private final String variableName;
+
+        public Optional<String> resolve(ParameterTool parameters, Properties properties, Map<String, String> variables) {
+            if (parameters != null && parameters.has(parameterName)) {
+                return Optional.of(parameters.get(parameterName));
+            }
+            if (properties != null && properties.containsKey(propertyName)) {
+                return Optional.of(properties.getProperty(propertyName));
+            }
+            if (variables != null && variables.containsKey(variableName)) {
+                return Optional.of(variables.get(variableName));
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -14,6 +14,7 @@ import io.pravega.client.stream.ReaderGroup;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
 
@@ -41,7 +42,7 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
     /** The logical name of the operator. This is different from the (randomly generated)
      * reader group name, because it is used to identify the state in a checkpoint/savepoint
      * when resuming the checkpoint/savepoint with another job. */
-    private final String readerName;
+    private final String hookUid;
 
     /** The serializer for Pravega checkpoints, to store them in Flink checkpoints */
     private final CheckpointSerializer checkpointSerializer;
@@ -50,12 +51,12 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
     private final ReaderGroup readerGroup;
 
     /** The timeout on the future returned by the 'initiateCheckpoint()' call */
-    private final long triggerTimeout;
+    private final Time triggerTimeout;
 
 
-    ReaderCheckpointHook(String readerName, ReaderGroup readerGroup, long triggerTimeout) {
+    ReaderCheckpointHook(String hookUid, ReaderGroup readerGroup, Time triggerTimeout) {
 
-        this.readerName = checkNotNull(readerName);
+        this.hookUid = checkNotNull(hookUid);
         this.readerGroup = checkNotNull(readerGroup);
         this.triggerTimeout = triggerTimeout;
         this.checkpointSerializer = new CheckpointSerializer();
@@ -65,7 +66,7 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
 
     @Override
     public String getIdentifier() {
-        return this.readerName;
+        return this.hookUid;
     }
 
     @Override
@@ -86,7 +87,7 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
                 this.readerGroup.initiateCheckpoint(checkpointName, scheduledExecutorService);
 
         // Add a timeout to the future, to prevent long blocking calls
-        scheduledExecutorService.schedule(() -> checkpointResult.cancel(false), triggerTimeout, TimeUnit.MILLISECONDS);
+        scheduledExecutorService.schedule(() -> checkpointResult.cancel(false), triggerTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 
         // we make sure the executor is shut down after the future completes
         checkpointResult.handle((success, failure) -> scheduledExecutorService.shutdownNow());

--- a/src/main/java/io/pravega/connectors/flink/serialization/JsonRowDeserializationSchema.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/JsonRowDeserializationSchema.java
@@ -110,4 +110,10 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
         this.failOnMissingField = failOnMissingField;
     }
 
+    /**
+     * Gets the failure behavior if a JSON field is missing.
+     */
+    public boolean getFailOnMissingField() {
+        return this.failOnMissingField;
+    }
 }

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaParams.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaParams.java
@@ -9,12 +9,13 @@
  */
 package io.pravega.connectors.flink.util;
 
-import com.google.common.collect.Sets;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.connectors.flink.FlinkPravegaReader;
 import io.pravega.connectors.flink.FlinkPravegaWriter;
+import io.pravega.connectors.flink.PravegaConfig;
 import io.pravega.connectors.flink.PravegaEventRouter;
 import io.pravega.connectors.flink.serialization.PravegaSerialization;
 import java.io.Serializable;
@@ -32,7 +33,9 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
  * parameters.
  *
  * @see StreamId
+ * @deprecated use {@link PravegaConfig} and the {@code builder()} methods.
  */
+@Deprecated
 public class FlinkPravegaParams {
     public static final String DEFAULT_CONTROLLER_URI = "tcp://127.0.0.1:9090";
     public static final String CONTROLLER_PARAM_NAME = "controller";
@@ -89,8 +92,13 @@ public class FlinkPravegaParams {
     public <T extends Serializable> FlinkPravegaReader<T> newReader(final StreamId stream,
                                                                     final long startTime,
                                                                     final DeserializationSchema<T> deserializationSchema) {
-        return new FlinkPravegaReader<>(getControllerUri(), stream.getScope(), Sets.newHashSet(stream.getName()),
-                startTime, deserializationSchema);
+        PravegaConfig pravegaConfig = PravegaConfig.fromParams(params);
+
+        return FlinkPravegaReader.<T>builder()
+                .forStream(Stream.of(stream.getScope(), stream.getName()))
+                .withPravegaConfig(pravegaConfig)
+                .withDeserializationSchema(deserializationSchema)
+                .build();
     }
 
     /**

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.connectors.flink.util;
 
+import io.pravega.client.ClientConfig;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.ReaderConfig;
@@ -23,7 +24,6 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 
-import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -83,9 +83,9 @@ public class FlinkPravegaUtils {
     /**
      * Creates a Pravga {@link EventStreamReader}.
      *
-     * @param scopeName The destination stream's scope name.
-     * @param controllerURI The Pravega controller endpoint address.
+     * @param clientConfig The Pravega client configuration.
      * @param readerId The id of the Pravega reader.
+     * @param readerGroupScopeName The reader group scope name.
      * @param readerGroupName The reader group name.
      * @param deserializationSchema The implementation to deserialize events from pravega streams.
      * @param readerConfig The reader configuration.
@@ -93,9 +93,9 @@ public class FlinkPravegaUtils {
      * @return the create Pravega reader.
      */
     public static <T> EventStreamReader<T> createPravegaReader(
-            String scopeName,
-            URI controllerURI,
+            ClientConfig clientConfig,
             String readerId,
+            String readerGroupScopeName,
             String readerGroupName,
             DeserializationSchema<T> deserializationSchema,
             ReaderConfig readerConfig) {
@@ -106,7 +106,7 @@ public class FlinkPravegaUtils {
                 ? ((WrappingSerializer<T>) deserializationSchema).getWrappedSerializer()
                 : new FlinkDeserializer<>(deserializationSchema);
 
-        return ClientFactory.withScope(scopeName, controllerURI)
+        return ClientFactory.withScope(readerGroupScopeName, clientConfig)
                 .createReader(readerId, readerGroupName, deserializer, readerConfig);
     }
 

--- a/src/main/java/io/pravega/connectors/flink/util/StreamId.java
+++ b/src/main/java/io/pravega/connectors/flink/util/StreamId.java
@@ -16,7 +16,10 @@ import java.util.Objects;
 /**
  * Captures the fully qualified name of a stream. The convention to represent this as a
  * single string is using [scope]/[stream].
+ *
+ * @deprecated Use {@link io.pravega.client.stream.Stream}
  */
+@Deprecated
 public class StreamId {
     public static final char STREAM_SPEC_SEPARATOR = '/';
 

--- a/src/main/java/io/pravega/connectors/flink/util/StreamWithBoundaries.java
+++ b/src/main/java/io/pravega/connectors/flink/util/StreamWithBoundaries.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink.util;
+
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamCut;
+import lombok.Data;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+
+/**
+ * A Pravega stream with optional boundaries based on stream cuts.
+ */
+@Data
+@Internal
+public class StreamWithBoundaries implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Stream stream;
+    private final StreamCut from;
+    private final StreamCut to;
+
+    public static StreamWithBoundaries of(Stream stream, StreamCut from, StreamCut to) {
+        Preconditions.checkNotNull(stream, "stream");
+        Preconditions.checkNotNull(stream, "from");
+        Preconditions.checkNotNull(stream, "to");
+        return new StreamWithBoundaries(stream, from, to);
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/EventTimeOrderingOperatorTest.java
+++ b/src/test/java/io/pravega/connectors/flink/EventTimeOrderingOperatorTest.java
@@ -28,6 +28,9 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Unit tests for {@link EventTimeOrderingOperator}.
+ */
 @Slf4j
 public class EventTimeOrderingOperatorTest {
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaJsonTableSourceTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaJsonTableSourceTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink;
+
+import io.pravega.connectors.flink.serialization.JsonRowDeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.types.Row;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link FlinkPravegaJsonTableSource} and its builder.
+ */
+public class FlinkPravegaJsonTableSourceTest {
+
+    private static final TableSchema SAMPLE_SCHEMA = TableSchema.builder()
+            .field("category", Types.STRING)
+            .field("value", Types.INT)
+            .build();
+
+    @Test
+    public void testReturnType() {
+        FlinkPravegaJsonTableSource source = FlinkPravegaJsonTableSource.builder()
+                .withReaderGroupScope("scope")
+                .forStream("scope/stream")
+                .withSchema(SAMPLE_SCHEMA)
+                .build();
+        TypeInformation<Row> expected = new RowTypeInfo(SAMPLE_SCHEMA.getTypes(), SAMPLE_SCHEMA.getColumnNames());
+        assertEquals(expected, source.getReturnType());
+    }
+
+    @Test
+    public void testGetDeserializationSchema() {
+        FlinkPravegaJsonTableSource.Builder builder = new FlinkPravegaJsonTableSource.Builder();
+        builder
+                .withSchema(SAMPLE_SCHEMA)
+                .failOnMissingField(true);
+        JsonRowDeserializationSchema deserializer = builder.getDeserializationSchema();
+        assertTrue(deserializer.getFailOnMissingField());
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderITCase.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink;
+
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.connectors.flink.utils.FailingMapper;
+import io.pravega.connectors.flink.utils.IntSequenceExactlyOnceValidator;
+import io.pravega.connectors.flink.utils.IntegerDeserializationSchema;
+import io.pravega.connectors.flink.utils.NotifyingMapper;
+import io.pravega.connectors.flink.utils.SetupUtils;
+import io.pravega.connectors.flink.utils.SuccessException;
+import io.pravega.connectors.flink.utils.ThrottledIntegerWriter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Integration tests for {@link FlinkPravegaReader}.
+ */
+@Slf4j
+public class FlinkPravegaReaderITCase extends StreamingMultipleProgramsTestBase {
+
+    // Number of events to produce into the test stream.
+    private static final int NUM_STREAM_ELEMENTS = 10000;
+
+    // Setup utility.
+    private static final SetupUtils SETUP_UTILS = new SetupUtils();
+
+    //Ensure each test completes within 120 seconds.
+    @Rule
+    public final Timeout globalTimeout = new Timeout(120, TimeUnit.SECONDS);
+    
+    @BeforeClass
+    public static void setupPravega() throws Exception {
+        SETUP_UTILS.startAllServices();
+    }
+
+    @AfterClass
+    public static void tearDownPravega() throws Exception {
+        SETUP_UTILS.stopAllServices();
+    }
+
+    @Test
+    public void testOneSourceOneSegment() throws Exception {
+        runTest(1, 1, NUM_STREAM_ELEMENTS);
+    }
+
+    @Test
+    public void testOneSourceMultipleSegments() throws Exception {
+        runTest(1, 4, NUM_STREAM_ELEMENTS);
+    }
+
+    // this test currently does ot work, see https://github.com/pravega/pravega/issues/1152
+    //@Test
+    //public void testMultipleSourcesOneSegment() throws Exception {
+    //    runTest(4, 1, NUM_STREAM_ELEMENTS);
+    //}
+
+    @Test
+    public void testMultipleSourcesMultipleSegments() throws Exception {
+        runTest(4, 4, NUM_STREAM_ELEMENTS);
+    }
+
+
+    private static void runTest(
+            final int sourceParallelism,
+            final int numPravegaSegments,
+            final int numElements) throws Exception {
+
+        // set up the stream
+        final String streamName = RandomStringUtils.randomAlphabetic(20);
+        SETUP_UTILS.createTestStream(streamName, numPravegaSegments);
+
+        try (
+                final EventStreamWriter<Integer> eventWriter = SETUP_UTILS.getIntegerWriter(streamName);
+
+                // create the producer that writes to the stream
+                final ThrottledIntegerWriter producer = new ThrottledIntegerWriter(
+                        eventWriter,
+                        numElements,
+                        numElements / 2,  // the latest when a checkpoint must have happened
+                        1                 // the initial sleep time per element
+                )
+
+        ) {
+            producer.start();
+
+            // the producer is throttled so that we don't run the (whatever small) risk of pumping
+            // all elements through before completing the first checkpoint (that would make the test senseless)
+
+            // to speed the test up, we un-throttle the producer as soon as the first checkpoint
+            // has gone through. Rather than implementing a complicated observer that polls the status
+            // from Flink, we simply forward the 'checkpoint complete' notification from the user functions
+            // the thr throttler, via a static variable
+            NotifyingMapper.TO_CALL_ON_COMPLETION.set(producer::unthrottle);
+
+            final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+            env.setParallelism(sourceParallelism);
+            env.enableCheckpointing(100);
+            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0L));
+
+            // we currently need this to work around the case where tasks are
+            // started too late, a checkpoint was already triggered, and some tasks
+            // never see the checkpoint event
+            env.getCheckpointConfig().setCheckpointTimeout(2000);
+
+            // the Pravega reader
+            final FlinkPravegaReader<Integer> pravegaSource = FlinkPravegaReader.<Integer>builder()
+                    .forStream(streamName)
+                    .withPravegaConfig(SETUP_UTILS.getPravegaConfig())
+                    .withDeserializationSchema(new IntegerDeserializationSchema())
+                    .build();
+
+            env
+                    .addSource(pravegaSource)
+
+                    // this mapper throws an exception at 2/3rd of the data stream,
+                    // which is strictly after the checkpoint happened (the latest at 1/2 of the stream)
+
+                    // to make sure that this is not affected by how fast subtasks of the source
+                    // manage to pull data from pravega, we make this task non-parallel
+                    .map(new FailingMapper<>(numElements * 2 / 3))
+                    .setParallelism(1)
+
+                    // hook in the notifying mapper
+                    .map(new NotifyingMapper<>())
+                    .setParallelism(1)
+
+                    // the sink validates that the exactly-once semantics hold
+                    // it must be non-parallel so that it sees all elements and can trivially
+                    // check for duplicates
+                    .addSink(new IntSequenceExactlyOnceValidator(numElements))
+                    .setParallelism(1);
+
+            final long executeStart = System.nanoTime();
+
+            // if these calls complete without exception, then the test passes
+            try {
+                env.execute();
+            } catch (Exception e) {
+                if (!(ExceptionUtils.getRootCause(e) instanceof SuccessException)) {
+                    throw e;
+                }
+            }
+
+            // this method forwards exception thrown in the data generator thread
+            producer.sync();
+
+            final long executeEnd = System.nanoTime();
+            System.out.println(String.format("Test execution took %d ms", (executeEnd - executeStart) / 1_000_000));
+        }
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableSourceTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableSourceTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink;
+
+import io.pravega.client.stream.Stream;
+import io.pravega.connectors.flink.serialization.JsonRowDeserializationSchema;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.types.Row;
+import org.junit.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link FlinkPravegaTableSource} and its builder.
+ */
+public class FlinkPravegaTableSourceTest {
+
+    private static final Stream SAMPLE_STREAM = Stream.of("scope", "stream");
+
+    private static final TableSchema SAMPLE_SCHEMA = TableSchema.builder()
+            .field("category", Types.STRING)
+            .field("value", Types.INT)
+            .build();
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testStreamTableSource() {
+        FlinkPravegaReader<Row> reader = mock(FlinkPravegaReader.class);
+        FlinkPravegaInputFormat<Row> inputFormat = mock(FlinkPravegaInputFormat.class);
+
+        TestableFlinkPravegaTableSource tableSource = new TestableFlinkPravegaTableSource(
+                () -> reader,
+                () -> inputFormat,
+                SAMPLE_SCHEMA,
+                jsonSchemaToReturnType(SAMPLE_SCHEMA)
+        );
+        StreamExecutionEnvironment streamEnv = mock(StreamExecutionEnvironment.class);
+        tableSource.getDataStream(streamEnv);
+        verify(reader).initialize();
+        verify(streamEnv).addSource(reader);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testBatchTableSource() {
+        FlinkPravegaReader<Row> reader = mock(FlinkPravegaReader.class);
+        FlinkPravegaInputFormat<Row> inputFormat = mock(FlinkPravegaInputFormat.class);
+
+        TestableFlinkPravegaTableSource tableSource = new TestableFlinkPravegaTableSource(
+                () -> reader,
+                () -> inputFormat,
+                SAMPLE_SCHEMA,
+                jsonSchemaToReturnType(SAMPLE_SCHEMA)
+        );
+        ExecutionEnvironment batchEnv = mock(ExecutionEnvironment.class);
+        tableSource.getDataSet(batchEnv);
+        verify(batchEnv).createInput(inputFormat);
+    }
+
+    @Test
+    public void testBuildInputFormat() {
+        TestableFlinkPravegaTableSource.TestableBuilder builder = new TestableFlinkPravegaTableSource.TestableBuilder()
+                .forStream(SAMPLE_STREAM)
+                .withSchema(SAMPLE_SCHEMA);
+        assertEquals(SAMPLE_SCHEMA, builder.getTableSchema());
+        FlinkPravegaInputFormat<Row> inputFormat = builder.buildInputFormat();
+        assertNotNull(inputFormat);
+    }
+
+    /** Converts the JSON schema into into the return type. */
+    private static RowTypeInfo jsonSchemaToReturnType(TableSchema jsonSchema) {
+        return new RowTypeInfo(jsonSchema.getTypes(), jsonSchema.getColumnNames());
+    }
+
+    private static class TestableFlinkPravegaTableSource extends FlinkPravegaTableSource {
+
+        protected TestableFlinkPravegaTableSource(Supplier<FlinkPravegaReader<Row>> sourceFunctionFactory, Supplier<FlinkPravegaInputFormat<Row>> inputFormatFactory, TableSchema schema, TypeInformation<Row> returnType) {
+            super(sourceFunctionFactory, inputFormatFactory, schema, returnType);
+        }
+
+        @Override
+        public String explainSource() {
+            return "TestableFlinkPravegaTableSource";
+        }
+
+        static class TestableBuilder extends FlinkPravegaTableSource.BuilderBase<TestableFlinkPravegaTableSource, TestableBuilder> {
+
+            @Override
+            protected TestableBuilder builder() {
+                return this;
+            }
+
+            @Override
+            protected DeserializationSchema<Row> getDeserializationSchema() {
+                TableSchema tableSchema = getTableSchema();
+                return new JsonRowDeserializationSchema(jsonSchemaToReturnType(tableSchema));
+            }
+        }
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/FlinkTableITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkTableITCase.java
@@ -10,30 +10,33 @@
 
 package io.pravega.connectors.flink;
 
-import io.pravega.connectors.flink.serialization.JsonRowDeserializationSchema;
+import io.pravega.client.stream.Stream;
 import io.pravega.connectors.flink.serialization.JsonRowSerializationSchema;
-import io.pravega.connectors.flink.util.StreamId;
 import io.pravega.connectors.flink.utils.SetupUtils;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -68,10 +71,11 @@ public class FlinkTableITCase {
         }
     }
 
-    // The relational schema associated with SampleRecord.
-    private static final RowTypeInfo SAMPLE_SCHEMA = Types.ROW_NAMED(
-            new String[]{"category", "value"},
-            Types.STRING, Types.INT);
+    // The relational schema associated with SampleRecord:
+    // root
+    //  |-- category: String
+    //  |-- value: Integer
+    private static final TableSchema SAMPLE_SCHEMA = TableSchema.fromTypeInfo(TypeInformation.of(SampleRecord.class));
 
     // Ensure each test completes within 120 seconds.
     @Rule
@@ -91,7 +95,7 @@ public class FlinkTableITCase {
     }
 
     /**
-     * Tests the end-to-end functionality of table source & sink.
+     * Tests the end-to-end functionality of a streaming table source & sink.
      *
      * <p>This test uses the {@link FlinkPravegaTableSink} to emit an in-memory table
      * containing sample data as a Pravega stream of 'append' events (i.e. as a changelog).
@@ -104,11 +108,11 @@ public class FlinkTableITCase {
      * @throws Exception on exception
      */
     @Test
-    public void testEndToEnd() throws Exception {
+    public void testStreamingTable() throws Exception {
 
         // create a Pravega stream for test purposes
-        StreamId stream = new StreamId(setupUtils.getScope(), "FlinkTableITCase.testEndToEnd");
-        this.setupUtils.createTestStream(stream.getName(), 1);
+        Stream stream = Stream.of(setupUtils.getScope(), "FlinkTableITCase.testEndToEnd");
+        this.setupUtils.createTestStream(stream.getStreamName(), 1);
 
         // create a Flink Table environment
         StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment().setParallelism(1);
@@ -126,12 +130,15 @@ public class FlinkTableITCase {
         table.writeToSink(sink);
 
         // register the Pravega stream as a table called 'samples'
-        FlinkPravegaTableSource source = new FlinkPravegaTableSource(
-                this.setupUtils.getControllerUri(), stream, 0, JsonRowDeserializationSchema::new, SAMPLE_SCHEMA);
+        FlinkPravegaTableSource source = FlinkPravegaJsonTableSource.builder()
+                .forStream(stream)
+                .withPravegaConfig(this.setupUtils.getPravegaConfig())
+                .withSchema(SAMPLE_SCHEMA)
+                .build();
         tableEnv.registerTableSource("samples", source);
 
         // select some sample data from the Pravega-backed table, as a view
-        Table view = tableEnv.sql("SELECT * FROM samples WHERE category IN ('A','B')");
+        Table view = tableEnv.sqlQuery("SELECT * FROM samples WHERE category IN ('A','B')");
 
         // write the view to a test sink that verifies the data for test purposes
         tableEnv.toAppendStream(view, SampleRecord.class).addSink(new TestSink(SAMPLES));
@@ -146,6 +153,60 @@ public class FlinkTableITCase {
         }
     }
 
+
+    /**
+     * Tests the end-to-end functionality of a batch table source & sink.
+     *
+     * <p>This test uses the {@link FlinkPravegaTableSink} to emit an in-memory table
+     * containing sample data as a Pravega stream of 'append' events (i.e. as a changelog).
+     * The test then uses the {@link FlinkPravegaTableSource} to absorb the changelog as a new table.
+     *
+     * <p>Flink's ability to convert POJOs (e.g. {@link SampleRecord}) to/from table rows is also demonstrated.
+     *
+     * <p>Because the source is unbounded, the test must throw an exception to deliberately terminate the job.
+     *
+     * @throws Exception on exception
+     */
+    @Test
+    @Ignore("[issue-124] FlinkPravegaTableSink doesn't support BatchTableSink")
+    public void testBatchTable() throws Exception {
+
+        // create a Pravega stream for test purposes
+        Stream stream = Stream.of(setupUtils.getScope(), "FlinkTableITCase.testEndToEnd");
+        this.setupUtils.createTestStream(stream.getStreamName(), 1);
+
+        // create a Flink Table environment
+        ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment();
+        env.setParallelism(1);
+        BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+
+        // define a table of sample data from a collection of POJOs.  Schema:
+        // root
+        //  |-- category: String
+        //  |-- value: Integer
+        Table table = tableEnv.fromDataSet(env.fromCollection(SAMPLES));
+
+        // write the table to a Pravega stream (using the 'category' column as a routing key)
+        FlinkPravegaTableSink sink = new FlinkPravegaTableSink(
+                this.setupUtils.getControllerUri(), stream, JsonRowSerializationSchema::new, "category");
+        table.writeToSink(sink);
+
+        // register the Pravega stream as a table called 'samples'
+        FlinkPravegaTableSource source = FlinkPravegaJsonTableSource.builder()
+                .forStream(stream)
+                .withPravegaConfig(this.setupUtils.getPravegaConfig())
+                .withSchema(SAMPLE_SCHEMA)
+                .build();
+        tableEnv.registerTableSource("samples", source);
+
+        // select some sample data from the Pravega-backed table, as a view
+        Table view = tableEnv.sqlQuery("SELECT * FROM samples WHERE category IN ('A','B')");
+
+        // convert the view to a dataset and collect the results for comparison purposes
+        List<SampleRecord> results = tableEnv.toDataSet(view, SampleRecord.class).collect();
+        Assert.assertEquals(new HashSet<>(SAMPLES), new HashSet<>(results));
+    }
+
     private static class TestSink extends RichSinkFunction<SampleRecord> {
         private final LinkedList<SampleRecord> remainingSamples;
 
@@ -154,7 +215,7 @@ public class FlinkTableITCase {
         }
 
         @Override
-        public void invoke(SampleRecord value) throws Exception {
+        public void invoke(SampleRecord value, Context context) throws Exception {
             remainingSamples.remove(value);
             log.info("processed: {}", value);
 

--- a/src/test/java/io/pravega/connectors/flink/PravegaConfigTest.java
+++ b/src/test/java/io/pravega/connectors/flink/PravegaConfigTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink;
+
+import io.pravega.client.ClientConfig;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.impl.Credentials;
+import io.pravega.client.stream.impl.DefaultCredentials;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link PravegaConfig}.
+ */
+public class PravegaConfigTest {
+
+    private static final Credentials TEST_CREDENTIALS = new DefaultCredentials("password", "username");
+
+    /**
+     * Tests {@code resolve()} which performs stream name resolution.
+     */
+    @Test
+    public void testStreamResolve() {
+        // test parsing logic
+        PravegaConfig config = new PravegaConfig(properties(PravegaConfig.SCOPE_PARAM, "scope1"), Collections.emptyMap(), ParameterTool.fromMap(Collections.emptyMap()));
+        assertEquals("scope1", config.getDefaultScope());
+        Stream expectedStream = Stream.of("scope1/stream1");
+        assertEquals(expectedStream, config.resolve("stream1"));
+        assertEquals(expectedStream, config.resolve("scope1/stream1"));
+        assertNotEquals(expectedStream, config.resolve("scope2/stream1"));
+
+        // test that no default scope is needed when using qualified stream names
+        config = new PravegaConfig(new Properties(), Collections.emptyMap(), ParameterTool.fromMap(Collections.emptyMap()));
+        assertNull(config.getDefaultScope());
+        assertEquals(expectedStream, config.resolve("scope1/stream1"));
+
+        // test an explicitly-configured default scope
+        config = new PravegaConfig(new Properties(), Collections.emptyMap(), ParameterTool.fromMap(Collections.emptyMap()))
+                .withDefaultScope("scope1");
+        assertEquals("scope1", config.getDefaultScope());
+        assertEquals(expectedStream, config.resolve("stream1"));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testStreamResolveWithoutDefaultScope() {
+        PravegaConfig config = new PravegaConfig(new Properties(), Collections.emptyMap(), ParameterTool.fromMap(Collections.emptyMap()));
+        config.resolve("stream1");
+    }
+
+    @Test
+    public void testParameterResolve() {
+        Properties properties = properties(PravegaConfig.CONTROLLER_PARAM, "property1");
+        Map<String, String> variables = variables(PravegaConfig.CONTROLLER_PARAM, "variable1");
+        ParameterTool parameters = parameters(PravegaConfig.CONTROLLER_PARAM, "parameter1");
+
+        assertEquals(Optional.of("parameter1"), PravegaConfig.CONTROLLER_PARAM.resolve(parameters, properties, variables));
+        assertEquals(Optional.of("property1"), PravegaConfig.CONTROLLER_PARAM.resolve(null, properties, variables));
+        assertEquals(Optional.of("variable1"), PravegaConfig.CONTROLLER_PARAM.resolve(null, null, variables));
+        assertEquals(Optional.empty(), PravegaConfig.CONTROLLER_PARAM.resolve(null, null, null));
+    }
+
+    @Test
+    public void testGetClientConfig() {
+        // default controller URI
+        PravegaConfig config = new PravegaConfig(new Properties(), Collections.emptyMap(), ParameterTool.fromMap(Collections.emptyMap()));
+        ClientConfig clientConfig = config.getClientConfig();
+        assertEquals(URI.create("tcp://localhost"), clientConfig.getControllerURI());
+        assertTrue(clientConfig.isValidateHostName());
+
+        // explicitly-configured controller URI
+        config = new PravegaConfig(new Properties(), Collections.emptyMap(), ParameterTool.fromMap(Collections.emptyMap()))
+                .withControllerURI(URI.create("tcp://localhost:9090"))
+                .withCredentials(TEST_CREDENTIALS)
+                .withHostnameValidation(false);
+
+        clientConfig = config.getClientConfig();
+        assertEquals(URI.create("tcp://localhost:9090"), clientConfig.getControllerURI());
+        assertEquals(TEST_CREDENTIALS, clientConfig.getCredentials());
+        assertFalse(clientConfig.isValidateHostName());
+    }
+
+    // helpers
+
+    private static Properties properties(PravegaConfig.PravegaParameter parameter, String value) {
+        Properties properties = new Properties();
+        properties.setProperty(parameter.getPropertyName(), value);
+        return properties;
+    }
+
+    private static Map<String, String> variables(PravegaConfig.PravegaParameter parameter, String value) {
+        return Collections.singletonMap(parameter.getVariableName(), value);
+    }
+
+    private static ParameterTool parameters(PravegaConfig.PravegaParameter parameter, String value) {
+        return ParameterTool.fromMap(Collections.singletonMap(parameter.getParameterName(), value));
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/utils/IntegerDeserializationSchema.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/IntegerDeserializationSchema.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink.utils;
+
+import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class IntegerDeserializationSchema extends AbstractDeserializationSchema<Integer> {
+    @Override
+    public Integer deserialize(byte[] message) throws IOException {
+        return ByteBuffer.wrap(message).getInt();
+    }
+
+    @Override
+    public boolean isEndOfStream(Integer nextElement) {
+        return false;
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
@@ -18,6 +18,7 @@ import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.connectors.flink.PravegaConfig;
 import io.pravega.local.InProcPravegaCluster;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
@@ -116,6 +117,13 @@ public final class SetupUtils {
      */
     public ClientConfig getClientConfig() {
         return this.gateway.getClientConfig();
+    }
+
+    /**
+     * Fetch the {@link PravegaConfig} for integration test purposes.
+     */
+    public PravegaConfig getPravegaConfig() {
+        return PravegaConfig.fromDefaults().withControllerURI(getControllerUri()).withDefaultScope(getScope());
     }
 
     /**

--- a/src/test/java/io/pravega/connectors/flink/utils/StreamSourceOperatorTestHarness.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/StreamSourceOperatorTestHarness.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink.utils;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.checkpoint.ExternallyInducedSource;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
+import org.apache.flink.util.FlinkException;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+
+/**
+ * A test harness for {@link StreamSource StreamSource} operators and {@link SourceFunction SourceFunctions}.
+ *
+ * @param <T> The output type of the source.
+ * @param <F> The type of the source function.
+ */
+public class StreamSourceOperatorTestHarness<T, F extends SourceFunction<T>> extends AbstractStreamOperatorTestHarness<T> implements AutoCloseable {
+
+    private final StreamSource<T, F> sourceOperator;
+
+    private final ConcurrentLinkedQueue<Long> triggeredCheckpoints;
+
+    public StreamSourceOperatorTestHarness(F sourceFunction, int maxParallelism, int parallelism, int subtaskIndex) throws Exception {
+        this(new StreamSource<>(sourceFunction), maxParallelism, parallelism, subtaskIndex);
+    }
+
+    public StreamSourceOperatorTestHarness(StreamSource<T, F> operator, int maxParallelism, int parallelism, int subtaskIndex) throws Exception {
+        super(operator, maxParallelism, parallelism, subtaskIndex);
+        this.sourceOperator = operator;
+        this.triggeredCheckpoints = new ConcurrentLinkedQueue<>();
+    }
+
+    @Override
+    public void setup(TypeSerializer<T> outputSerializer) {
+        super.setup(outputSerializer);
+        if (sourceOperator.getUserFunction() instanceof ExternallyInducedSource) {
+            ExternallyInducedSource externallyInducedSource = (ExternallyInducedSource) sourceOperator.getUserFunction();
+            externallyInducedSource.setCheckpointTrigger(this::triggerCheckpoint);
+        }
+    }
+
+    /**
+     * Runs the source operator synchronously.
+     * @throws Exception if execution fails.
+     */
+    public void run() throws Exception {
+        sourceOperator.run(this.getCheckpointLock(), this.mockTask.getStreamStatusMaintainer());
+    }
+
+    /**
+     * Runs the source operator asychronously with cancellation support.
+     *
+     * @param executor the executor on which to invoke the {@code run} method.
+     * @return a future that completes when the {@code run} method of the {@link StreamSource} completes.
+     */
+    public CompletableFuture<Void> runAsync(Executor executor) {
+        CompletableFuture<Void> promise = new CompletableFuture<>();
+        promise.whenComplete((v, ex) -> {
+            if (ex instanceof CancellationException) {
+                sourceOperator.cancel();
+            }
+        });
+        executor.execute(() -> {
+            try {
+                run();
+                promise.complete(null);
+            } catch (Throwable ex) {
+                promise.completeExceptionally(ex);
+            }
+        });
+        return promise;
+    }
+
+    /**
+     * Sends a cancellation notice to the source operator.
+     */
+    public void cancel() {
+        sourceOperator.cancel();
+    }
+
+    /**
+     * Invoked when an {@link ExternallyInducedSource externally-induced source} triggers a checkpoint.
+     *
+     * The default behavior is to record the checkpoint ID for later.
+     *
+     * @param checkpointId the checkpoint ID
+     * @throws FlinkException if the checkpoint cannot be triggered.
+     *
+     */
+    protected void triggerCheckpoint(long checkpointId) throws FlinkException {
+        triggeredCheckpoints.add(checkpointId);
+    }
+
+    /**
+     * Gets the triggered checkpoints.
+     */
+    public ConcurrentLinkedQueue<Long> getTriggeredCheckpoints() {
+        return triggeredCheckpoints;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Eron Wright <eronwright@gmail.com>

**Change log description**
```
- introduced PravegaConfig to capture high-level client configuration
- general stream cut support
- support for environment-provided default Pravega scope

- builder for FlinkPravegaInputFormat

- builder for FlinkPravegaReader
- rename FlinkPravegaReaderTest to FlinkPravegaReaderITCase
- unit test for FlinkPravegaReader

- implement batch table API support
- builder for FlinkPravegaTableSource
- introduce FlinkPravegaJsonTableSource
- treat FlinkPravegaTableSource as an internal class

- deprecated StreamId in favor of io.pravega.client.stream.Stream
- deprecated FlinkPravegaParams in favor of PravegaConfig, builder classes
- moved IntegerDeserializationSchema to utils
- implemented StreamSourceOperatorTestHarness
```
**Purpose of the change**
Closes #48 (builder API), #68 (reader unit test), and #62 (TableSource batch API)

**What the code does**
This PR introduces a new builder API for the stream, batch, and table connectors, and (trivially) completes the table batch API integration.   The builder API expands the capabilities of the connector to include support for credentials and stream cuts across all connectors.  It also supports environment variables/system properties for configuring the controller URI and the default scope.

Note this is a **breaking change**.

Some usage examples:

Common:
```
PravegaConfig config = PravegaConfig.fromDefaults()
    .withControllerURI("tcp://...")
    .withCredentials(credentials)
    .withDefaultScope("scope-1");
```

Streaming API:
```
FlinkPravegaReader<Integer> pravegaSource = FlinkPravegaReader.<Integer>builder()
                    .forStream("stream-1")
                    .withPravegaConfig(config)
                    .withDeserializationSchema(...)
                    .build();
```

Batch API:
```
FlinkPravegaInputFormat inputFormat = FlinkPravegaInputFormat.<Integer>builder()
                            .forStream("stream-1")
                            .forStream(Stream.of("scope-2/stream-2"), streamCut)
                            .withPravegaConfig(config)
                            .withDeserializationSchema(...)
                            .build(),
```

Table API:
```
TableSchema schema = ...;
FlinkPravegaTableSource source = FlinkPravegaJsonTableSource.builder()
                .forStream(stream)
                .withPravegaConfig(config)
                .withSchema(schema)
                .build();
```

**How to verify it**
New and revised unit tests, notably:
- `FlinkPravegaReaderTest`
- `PravegaConfigTest`
- `FlinkPravegaTableSourceTest`
