### PR TITLE
[issue-139] Fix precedence of scope parameter in `PravegaConfig`

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/PravegaConfig.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaConfig.java
@@ -120,10 +120,12 @@ public class PravegaConfig implements Serializable {
     /**
      * Configures the default Pravega scope, to resolve unqualified stream names and to support reader groups.
      *
-     * @param scope The scope to use.
+     * @param scope The scope to use (with lowest priority).
      */
     public PravegaConfig withDefaultScope(String scope) {
-        this.defaultScope = scope;
+        if (this.defaultScope == null) {
+            this.defaultScope = scope;
+        }
         return this;
     }
 

--- a/src/test/java/io/pravega/connectors/flink/PravegaConfigTest.java
+++ b/src/test/java/io/pravega/connectors/flink/PravegaConfigTest.java
@@ -53,10 +53,9 @@ public class PravegaConfigTest {
         assertNull(config.getDefaultScope());
         assertEquals(expectedStream, config.resolve("scope1/stream1"));
 
-        // test an explicitly-configured default scope
+        // test an application-level default scope
         config = new PravegaConfig(new Properties(), Collections.emptyMap(), ParameterTool.fromMap(Collections.emptyMap()))
-                .withDefaultScope("scope1");
-        assertEquals("scope1", config.getDefaultScope());
+                .withDefaultScope(expectedStream.getScope());
         assertEquals(expectedStream, config.resolve("stream1"));
     }
 
@@ -64,6 +63,19 @@ public class PravegaConfigTest {
     public void testStreamResolveWithoutDefaultScope() {
         PravegaConfig config = new PravegaConfig(new Properties(), Collections.emptyMap(), ParameterTool.fromMap(Collections.emptyMap()));
         config.resolve("stream1");
+    }
+
+    @Test
+    public void testScopePriority() {
+        PravegaConfig config;
+
+        config = new PravegaConfig(new Properties(), Collections.emptyMap(), ParameterTool.fromMap(Collections.emptyMap()))
+                .withDefaultScope("scope1");
+        assertEquals("scope1", config.getDefaultScope());
+
+        config = new PravegaConfig(properties(PravegaConfig.SCOPE_PARAM, "scope2"), Collections.emptyMap(), ParameterTool.fromMap(Collections.emptyMap()))
+                .withDefaultScope("scope1");
+        assertEquals("scope2", config.getDefaultScope());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Eron Wright <eronwright@gmail.com>

**Change log description**
- `PravegaConfig::withDefaultScope` applies with lower priority than other sources

**Purpose of the change**
Closes #139

**What the code does**

**How to verify it**
`PravegaConfigTest`