### PR TITLE
[issue-141] updated travis configuration for snapshot publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,14 @@ cache:
 stages:
   - name: build
   - name: snapshot
-    if: branch = master
+    if: branch = master AND NOT (type = pull_request)
 
 jobs:
   include:
     - stage: build
       script: ./gradlew clean assemble
     - stage: snapshot
-      script: ./gradlew clean assemble publishToRepo -PpublishUrl=jcenterSnapshot -PpublishUsername=$BINTRAY_USER -PpublishPassword=$BINTRAY_KEY
+      script: ./gradlew publishToRepo -PpublishUrl=jcenterSnapshot -PpublishUsername=$BINTRAY_USER -PpublishPassword=$BINTRAY_KEY
 
 notifications:
   slack:


### PR DESCRIPTION
 *Change log description**

Added conditional check to ensure not to trigger publishing for every pull request. This fix addresses the issue https://github.com/pravega/flink-connectors/issues/141

**Purpose of the change**
To enable snapshot publishing only on stable master builds

**What the code does**
It enables snapshot build stage only when the branch is master and it's not of pull request type

**How to verify it**
Travis publishing should not happen for any PRs but only after the PR has been merged to master