### PR TITLE
[issue-126] Update default transaction timeouts in FlinkPravegaWriter to sync with Pravega defaults

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
@@ -24,8 +24,8 @@ import org.apache.flink.util.Preconditions;
 public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStreamingWriterBuilder> extends AbstractWriterBuilder<B> {
 
     // the numbers below are picked somewhat arbitrarily at this point
-    private static final long DEFAULT_TXN_TIMEOUT_MILLIS = 2 * 60 * 60 * 1000; // 2 hours
-    private static final long DEFAULT_TX_SCALE_GRACE_MILLIS = 10 * 60 * 1000; // 10 minutes
+    private static final long DEFAULT_TXN_TIMEOUT_MILLIS = 30000; // 30 seconds
+    private static final long DEFAULT_TX_SCALE_GRACE_MILLIS = 30000; // 30 seconds
 
     protected PravegaWriterMode writerMode;
     protected Time txnTimeout;

--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
@@ -23,7 +23,7 @@ import org.apache.flink.util.Preconditions;
  */
 public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStreamingWriterBuilder> extends AbstractWriterBuilder<B> {
 
-    // the numbers below are picked somewhat arbitrarily at this point
+    // the numbers below are picked based on the default max settings in Pravega
     private static final long DEFAULT_TXN_TIMEOUT_MILLIS = 30000; // 30 seconds
     private static final long DEFAULT_TX_SCALE_GRACE_MILLIS = 30000; // 30 seconds
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterITCase.java
@@ -201,7 +201,7 @@ public class FlinkPravegaWriterITCase {
                 .withSerializationSchema(new IntSerializer())
                 .withEventRouter(event -> "fixedkey")
                 .withWriterMode(PravegaWriterMode.EXACTLY_ONCE)
-                .withTxnTimeout(Time.seconds(30))
+                .withTxnLeaseRenewalPeriod(Time.seconds(30))
                 .build();
 
         env


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
This PR addresses the issue https://github.com/pravega/flink-connectors/issues/126
- The transaction timeouts are updated to use the maximum defaults of Pravega

**Purpose of the change**
- To avoid flink app from failing due to larger transaction timeouts

**What the code does**
- configures default timeouts when the value is not supplied

**How to verify it**
`./gradlew clean build` should pass