### PR TITLE
[issue-131] Remove pravega source dependency and use SNAPSHOT release versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ repositories {
         maven {
             url "https://oss.sonatype.org/content/repositories/snapshots"
         }
+        maven {
+            url "https://oss.jfrog.org/jfrog-dependencies"
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,11 @@ findbugsVersion=3.0.1
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.3.0-SNAPSHOT
-pravegaVersion=0.3.0-SNAPSHOT
+pravegaVersion=0.3.0-50.b5ecb57-SNAPSHOT
 apacheCommonsVersion=3.7
+
+# flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
+usePravegaVersionSubModule=false
 
 # These properties are only needed for publishing to maven central
 # Pravega Signing Key

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 rootProject.name='flink-connectors'
 
 includeBuild('pravega') {
-    if (pravegaVersion.endsWith("-SNAPSHOT")) {
+    if (usePravegaVersionSubModule.toBoolean()) {
         dependencySubstitution {
             substitute module('io.pravega:pravega-client') with project(':client')
             substitute module('io.pravega:pravega-common') with project(':common')

--- a/src/test/java/io/pravega/connectors/flink/PravegaConfigTest.java
+++ b/src/test/java/io/pravega/connectors/flink/PravegaConfigTest.java
@@ -95,7 +95,7 @@ public class PravegaConfigTest {
         // default controller URI
         PravegaConfig config = new PravegaConfig(new Properties(), Collections.emptyMap(), ParameterTool.fromMap(Collections.emptyMap()));
         ClientConfig clientConfig = config.getClientConfig();
-        assertEquals(URI.create("tcp://localhost"), clientConfig.getControllerURI());
+        assertEquals(URI.create("tcp://localhost:9090"), clientConfig.getControllerURI());
         assertTrue(clientConfig.isValidateHostName());
 
         // explicitly-configured controller URI


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**

This PR addresses the issue https://github.com/pravega/flink-connectors/issues/131
- enabled build configuration to draw Pravega artifacts from jcenter
- enabled option to allow Pravega source dependency (sub-module) in place of snapshots

**Purpose of the change**
- To allow connector to draw Pravega artifacts/snapshot dependencies from central repository 

**What the code does**
- allows connector build to resolve Pravega artifacts either from snapshot repo or source dependency

**How to verify it**
- run `./gradlew clean build` to draw Pravega snapshots from jcenter
- run `./gradlew clean build -PusePravegaVersionSubModule=true` to use Pravega that is part of sub-module
