### PR TITLE
[issue-149] Added missing Apache License copyright headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+<!--
+Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
 # Pravega Flink Connectors [![Build Status](https://travis-ci.org/pravega/flink-connectors.svg?branch=master)](https://travis-ci.org/pravega/flink-connectors)
 
 Connectors to read and write [Pravega](http://pravega.io/) streams with [Apache Flink](http://flink.apache.org/) stream processing applications.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,11 @@
 #
-#  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 
 # 3rd party Versions.

--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -1,3 +1,14 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 import java.text.SimpleDateFormat
 
 apply plugin: 'com.jfrog.bintray'

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -1,3 +1,14 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 apply plugin: 'checkstyle'
 
 checkstyle {

--- a/gradle/findbugs.gradle
+++ b/gradle/findbugs.gradle
@@ -1,3 +1,14 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 apply plugin: 'findbugs'
 
 tasks.withType(FindBugs) {

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -1,3 +1,14 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 apply plugin: 'idea'
 
 idea.project?.ipr {

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,3 +1,14 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 apply plugin: 'jacoco'
 
 jacocoTestReport {

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -1,3 +1,14 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 apply plugin: 'java'
 apply plugin: 'com.github.johnrengelman.shadow'
 

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,3 +1,14 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 apply plugin: 'maven'
 apply plugin: 'signing'
 

--- a/gradlew
+++ b/gradlew
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 #
-#  Copyright (c) 2017 Dell Inc., or its subsidiaries.
-#
 ##############################################################################
 ##
 ##  Gradle start up script for UN*X
 ##
 ##############################################################################
+
+#
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
 
 # Attempt to set APP_HOME
 # Resolve links: $0 may be a link

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,12 +1,21 @@
 @if "%DEBUG%" == "" @echo off
 @rem
-@rem  Copyright (c) 2017 Dell Inc., or its subsidiaries.
 @rem
 @rem ##########################################################################
 @rem
 @rem  Gradle startup script for Windows
 @rem
 @rem ##########################################################################
+
+@rem
+@rem  Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+@rem
+@rem  Licensed under the Apache License, Version 2.0 (the "License");
+@rem  you may not use this file except in compliance with the License.
+@rem  You may obtain a copy of the License at
+@rem
+@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem
 
 @rem Set local scope for the variables with windows NT shell
 if "%OS%"=="Windows_NT" setlocal

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
 rootProject.name='flink-connectors'
 
 includeBuild('pravega') {


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
- added missing apache license copyright headers to the some of the files

**Purpose of the change**
To addresses https://github.com/pravega/flink-connectors/issues/149

**What the code does**
No changes to the code

**How to verify it**
run `./gradlew clean build` and make sure it works