### PR TITLE
[issue-152] Fix segment number API change introduced in Pravega

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ findbugsVersion=3.0.1
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.3.0-SNAPSHOT
-pravegaVersion=0.3.0-50.b5ecb57-SNAPSHOT
+pravegaVersion=0.3.0-50.60a2344-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'

--- a/src/main/java/io/pravega/connectors/flink/PravegaInputSplit.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaInputSplit.java
@@ -79,7 +79,7 @@ public class PravegaInputSplit implements InputSplit {
         return splitId == that.splitId &&
                 segmentRange.getStartOffset() == that.getSegmentRange().getStartOffset() &&
                 segmentRange.getEndOffset() == that.getSegmentRange().getEndOffset() &&
-                segmentRange.getSegmentNumber() == that.getSegmentRange().getSegmentNumber();
+                segmentRange.getSegmentId() == that.getSegmentRange().getSegmentId();
     }
 
     @Override
@@ -89,7 +89,7 @@ public class PravegaInputSplit implements InputSplit {
         int result = 1;
 
         result = result * prime + splitId;
-        result = result * prime + getSegmentRange().getSegmentNumber();
+        result = result * prime + Long.hashCode(getSegmentRange().getSegmentId());
         result = result * prime + Long.hashCode(getSegmentRange().getStartOffset());
         result = result * prime + Long.hashCode(getSegmentRange().getEndOffset());
 


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
- Fixed segment number breaking API changes introduced in Pravega https://github.com/pravega/pravega/commit/60a2344945f5d9cb68fc497f5e80b79cd013286e
- Updated pravega version to latest snapshot

**Purpose of the change**
To fix https://github.com/pravega/flink-connectors/issues/152

**What the code does**
Updated the API call from `getSegmentNumber()` to `getSegmentId()`

**How to verify it**
Run `./gradlew clean build` and make sure test cases pass