### PR TITLE
[issue-154] Remove scale grace period for the writer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ findbugsVersion=3.0.1
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.3.0-SNAPSHOT
-pravegaVersion=0.3.0-50.60a2344-SNAPSHOT
+pravegaVersion=0.3.0-50.5f4d75b-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'

--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
@@ -25,16 +25,13 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
 
     // the numbers below are picked somewhat arbitrarily at this point
     private static final long DEFAULT_TXN_TIMEOUT_MILLIS = 2 * 60 * 60 * 1000; // 2 hours
-    private static final long DEFAULT_TX_SCALE_GRACE_MILLIS = 10 * 60 * 1000; // 10 minutes
 
     protected PravegaWriterMode writerMode;
     protected Time txnTimeout;
-    protected Time txnGracePeriod;
 
     protected AbstractStreamingWriterBuilder() {
         writerMode = PravegaWriterMode.ATLEAST_ONCE;
         txnTimeout = Time.milliseconds(DEFAULT_TXN_TIMEOUT_MILLIS);
-        txnGracePeriod = Time.milliseconds(DEFAULT_TX_SCALE_GRACE_MILLIS);
     }
 
     /**
@@ -63,20 +60,6 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
     }
 
     /**
-     * Sets the transaction grace period.
-     *
-     * The grace period is the maximum amount of time for which a transaction may
-     * remain active, after a scale operation has been initiated on the underlying stream.
-     *
-     * @param timeout the timeout
-     */
-    public B withTxnGracePeriod(Time timeout) {
-        Preconditions.checkArgument(timeout.getSize() > 0, "The timeout must be a positive value.");
-        this.txnGracePeriod = timeout;
-        return builder();
-    }
-
-    /**
      * Creates the sink function for the current builder state.
      *
      * @param serializationSchema the deserialization schema to use.
@@ -91,7 +74,6 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
                 serializationSchema,
                 eventRouter,
                 writerMode,
-                txnTimeout.toMilliseconds(),
-                txnGracePeriod.toMilliseconds());
+                txnTimeout.toMilliseconds());
     }
 }

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterITCase.java
@@ -202,7 +202,6 @@ public class FlinkPravegaWriterITCase {
                 .withEventRouter(event -> "fixedkey")
                 .withWriterMode(PravegaWriterMode.EXACTLY_ONCE)
                 .withTxnTimeout(Time.seconds(30))
-                .withTxnGracePeriod(Time.seconds(30))
                 .build();
 
         env

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -561,7 +561,7 @@ public class FlinkPravegaWriterTest {
 
     private FlinkPravegaWriter<Integer> spySinkFunction(ClientFactory clientFactory, PravegaEventRouter<Integer> eventRouter, PravegaWriterMode writerMode) {
         FlinkPravegaWriter<Integer> writer = spy(new FlinkPravegaWriter<>(
-                MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME), new IntegerSerializationSchema(), eventRouter, writerMode, 30, 30));
+                MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME), new IntegerSerializationSchema(), eventRouter, writerMode, 30));
         Mockito.doReturn(clientFactory).when(writer).createClientFactory(MOCK_SCOPE_NAME, MOCK_CLIENT_CONFIG);
         return writer;
     }


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
* removed scale grace period configuration for the transaction writer
* updated pravega snapshot version (source and binary) dependency

**Purpose of the change**
To address https://github.com/pravega/flink-connectors/issues/154

**What the code does**
removed passing transaction scale grace period configuration

**How to verify it**
`./gradlew clean build` and make sure the tests pass