### PR TITLE
[issue-66] Use single threaded executor in FlinkPravegaWriter

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
@@ -223,7 +223,7 @@ public class FlinkPravegaWriter<T>
 
     @VisibleForTesting
     protected ExecutorService createExecutorService() {
-        return Executors.newFixedThreadPool(5);
+        return Executors.newSingleThreadExecutor();
     }
 
     private void initializeInternalWriter() {


### PR DESCRIPTION
Signed-off-by: Eron Wright <eronwright@gmail.com>

**Change log description**
- Use single threaded executor in FlinkPravegaWriter

**Purpose of the change**
Avoid wasting threads when a single thread will suffice.  Closes #66.

**What the code does**
Reduces the non-transactional writer's thread pool size from 5 to 1.

**How to verify it**
- FlinkPravegaWriter
