### PR TITLE
[issue-31] Implement connector metrics

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ findbugsVersion=3.0.1
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.4.0-SNAPSHOT
-pravegaVersion=0.4.0-50.63aea88-SNAPSHOT
+pravegaVersion=0.4.0-50.dc5d241-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'

--- a/src/main/java/io/pravega/connectors/flink/AbstractReaderBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractReaderBuilder.java
@@ -33,6 +33,8 @@ public abstract class AbstractReaderBuilder<B extends AbstractReaderBuilder> imp
 
     private PravegaConfig pravegaConfig;
 
+    private boolean enableMetrics = true;
+
     protected AbstractReaderBuilder() {
         this.streams = new ArrayList<>(1);
         this.pravegaConfig = PravegaConfig.fromDefaults();
@@ -135,6 +137,24 @@ public abstract class AbstractReaderBuilder<B extends AbstractReaderBuilder> imp
         return streams.stream()
                 .map(s -> StreamWithBoundaries.of(pravegaConfig.resolve(s.streamSpec), s.from, s.to))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * enable/disable pravega reader metrics (default: enabled).
+     *
+     * @param enable boolean
+     * @return A builder to configure and create a reader.
+     */
+    public B enableMetrics(boolean enable) {
+        this.enableMetrics = enable;
+        return builder();
+    }
+
+    /**
+     * getter to fetch the metrics flag.
+     */
+    protected boolean isMetricsEnabled() {
+        return enableMetrics;
     }
 
     protected abstract B builder();

--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
@@ -151,7 +151,8 @@ abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStreamingRead
                 rgName,
                 getDeserializationSchema(),
                 this.eventReadTimeout,
-                this.checkpointInitiateTimeout);
+                this.checkpointInitiateTimeout,
+                isMetricsEnabled());
     }
 
     /**

--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
@@ -75,6 +75,7 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
                 serializationSchema,
                 eventRouter,
                 writerMode,
-                txnLeaseRenewalPeriod.toMilliseconds());
+                txnLeaseRenewalPeriod.toMilliseconds(),
+                isMetricsEnabled());
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/AbstractWriterBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractWriterBuilder.java
@@ -26,6 +26,8 @@ public abstract class AbstractWriterBuilder<B extends AbstractWriterBuilder> imp
 
     private StreamSpec stream;
 
+    private boolean enableMetrics = true;
+
     public AbstractWriterBuilder() {
         this.pravegaConfig = PravegaConfig.fromDefaults();
     }
@@ -79,6 +81,24 @@ public abstract class AbstractWriterBuilder<B extends AbstractWriterBuilder> imp
         Preconditions.checkState(stream != null, "A stream must be supplied.");
         PravegaConfig pravegaConfig = getPravegaConfig();
         return pravegaConfig.resolve(stream.streamSpec);
+    }
+
+    /**
+     * enable/disable pravega writer metrics (default: enabled).
+     *
+     * @param enable boolean
+     * @return A builder to configure and create a writer.
+     */
+    public B enableMetrics(boolean enable) {
+        this.enableMetrics = enable;
+        return builder();
+    }
+
+    /**
+     * getter to fetch the metrics flag.
+     */
+    protected boolean isMetricsEnabled() {
+        return enableMetrics;
     }
 
     protected abstract B builder();

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
@@ -187,11 +187,11 @@ public class FlinkPravegaWriter<T>
     /**
      * Gauge for getting the scoped name information.
      */
-    private static class ScopedStreamGauge implements Gauge<String> {
+    private static class StreamNameGauge implements Gauge<String> {
 
         final String scopedStream;
 
-        public ScopedStreamGauge(String scopedStream) {
+        public StreamNameGauge(String scopedStream) {
             this.scopedStream = scopedStream;
         }
 
@@ -207,7 +207,7 @@ public class FlinkPravegaWriter<T>
      */
     private void registerMetrics() {
         MetricGroup pravegaWriterMetricGroup = getRuntimeContext().getMetricGroup().addGroup(PRAVEGA_WRITER_METRICS_GROUP);
-        pravegaWriterMetricGroup.gauge(SCOPED_STREAM_METRICS_GAUGE, new ScopedStreamGauge(stream.getScopedName()));
+        pravegaWriterMetricGroup.gauge(SCOPED_STREAM_METRICS_GAUGE, new StreamNameGauge(stream.getScopedName()));
     }
 
     // ------------------------------------------------------------------------

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
@@ -21,6 +21,8 @@ import io.pravega.common.Exceptions;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
@@ -57,6 +59,15 @@ public class FlinkPravegaWriter<T>
         implements ListCheckpointed<FlinkPravegaWriter.PendingTransaction>, CheckpointListener {
 
     private static final long serialVersionUID = 1L;
+
+    // ----- metrics field constants -----
+
+    private static final String PRAVEGA_WRITER_METRICS_GROUP = "PravegaWriter";
+
+    private static final String SCOPED_STREAM_METRICS_GAUGE = "stream";
+
+    // flag to enable/disable metrics
+    final boolean enableMetrics;
 
     // Writer interface to assist exactly-once and at-least-once functionality
     @VisibleForTesting
@@ -95,6 +106,7 @@ public class FlinkPravegaWriter<T>
      * @param eventRouter           The implementation to extract the partition key from the event.
      * @param writerMode            The Pravega writer mode.
      * @param txnLeaseRenewalPeriod Transaction lease renewal period in milliseconds.
+     * @param enableMetrics         Flag to indicate whether metrics needs to be enabled or not.
      */
     protected FlinkPravegaWriter(
             final ClientConfig clientConfig,
@@ -102,7 +114,8 @@ public class FlinkPravegaWriter<T>
             final SerializationSchema<T> serializationSchema,
             final PravegaEventRouter<T> eventRouter,
             final PravegaWriterMode writerMode,
-            final long txnLeaseRenewalPeriod) {
+            final long txnLeaseRenewalPeriod,
+            final boolean enableMetrics) {
 
         this.clientConfig = Preconditions.checkNotNull(clientConfig, "clientConfig");
         this.stream = Preconditions.checkNotNull(stream, "stream");
@@ -111,6 +124,7 @@ public class FlinkPravegaWriter<T>
         this.writerMode = Preconditions.checkNotNull(writerMode, "writerMode");
         Preconditions.checkArgument(txnLeaseRenewalPeriod > 0, "txnLeaseRenewalPeriod must be > 0");
         this.txnLeaseRenewalPeriod = txnLeaseRenewalPeriod;
+        this.enableMetrics = enableMetrics;
     }
 
     /**
@@ -135,6 +149,9 @@ public class FlinkPravegaWriter<T>
         writer.open();
         log.info("Initialized Pravega writer for stream: {} with controller URI: {}", stream,
                 clientConfig.getControllerURI());
+        if (enableMetrics) {
+            registerMetrics();
+        }
     }
 
     @Override
@@ -165,6 +182,32 @@ public class FlinkPravegaWriter<T>
         if (exception != null) {
             throw exception;
         }
+    }
+
+    /**
+     * Gauge for getting the scoped name information.
+     */
+    private static class ScopedStreamGauge implements Gauge<String> {
+
+        final String scopedStream;
+
+        public ScopedStreamGauge(String scopedStream) {
+            this.scopedStream = scopedStream;
+        }
+
+        @Override
+        public String getValue() {
+            return scopedStream;
+        }
+    }
+
+    /**
+     * register metrics
+     *
+     */
+    private void registerMetrics() {
+        MetricGroup pravegaWriterMetricGroup = getRuntimeContext().getMetricGroup().addGroup(PRAVEGA_WRITER_METRICS_GROUP);
+        pravegaWriterMetricGroup.gauge(SCOPED_STREAM_METRICS_GAUGE, new ScopedStreamGauge(stream.getScopedName()));
     }
 
     // ------------------------------------------------------------------------

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
@@ -185,19 +185,19 @@ public class FlinkPravegaWriter<T>
     }
 
     /**
-     * Gauge for getting the scoped name information.
+     * Gauge for getting the fully qualified stream name information.
      */
     private static class StreamNameGauge implements Gauge<String> {
 
-        final String scopedStream;
+        final String stream;
 
-        public StreamNameGauge(String scopedStream) {
-            this.scopedStream = scopedStream;
+        public StreamNameGauge(String stream) {
+            this.stream = stream;
         }
 
         @Override
         public String getValue() {
-            return scopedStream;
+            return stream;
         }
     }
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderITCase.java
@@ -127,6 +127,7 @@ public class FlinkPravegaReaderITCase extends StreamingMultipleProgramsTestBase 
             // the Pravega reader
             final FlinkPravegaReader<Integer> pravegaSource = FlinkPravegaReader.<Integer>builder()
                     .forStream(streamName)
+                    .enableMetrics(false)
                     .withPravegaConfig(SETUP_UTILS.getPravegaConfig())
                     .withDeserializationSchema(new IntegerDeserializationSchema())
                     .build();

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointITCase.java
@@ -194,6 +194,7 @@ public class FlinkPravegaReaderSavepointITCase extends TestLogger {
         // the Pravega reader
         final FlinkPravegaReader<Integer> pravegaSource = FlinkPravegaReader.<Integer>builder()
                 .forStream(streamName)
+                .enableMetrics(false)
                 .withPravegaConfig(SETUP_UTILS.getPravegaConfig())
                 .withDeserializationSchema(new IntegerDeserializationSchema())
                 .uid("my_reader_name")

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -46,7 +46,6 @@ import static io.pravega.connectors.flink.FlinkPravegaReader.ONLINE_READERS_METR
 import static io.pravega.connectors.flink.FlinkPravegaReader.PRAVEGA_READER_METRICS_GROUP;
 import static io.pravega.connectors.flink.FlinkPravegaReader.READER_GROUP_METRICS_GROUP;
 import static io.pravega.connectors.flink.FlinkPravegaReader.READER_GROUP_NAME_METRICS_GAUGE;
-import static io.pravega.connectors.flink.FlinkPravegaReader.SEPARATOR;
 import static io.pravega.connectors.flink.FlinkPravegaReader.UNREAD_BYTES_METRICS_GAUGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -133,7 +132,7 @@ public class FlinkPravegaReaderTest {
             // verify if metrics are generated
             MetricGroup pravegaReaderMetricGroup = testHarness.getMetricGroup().addGroup(PRAVEGA_READER_METRICS_GROUP);
             MetricGroup readerGroupMetricGroup = pravegaReaderMetricGroup.addGroup(READER_GROUP_METRICS_GROUP);
-            String scopeString = ScopeFormat.concat(',', readerGroupMetricGroup.getScopeComponents());
+            String scopeString = ScopeFormat.concat('.', readerGroupMetricGroup.getScopeComponents());
 
             validateMetricGroup(scopeString, UNREAD_BYTES_METRICS_GAUGE, readerGroupMetricGroup);
             validateMetricGroup(scopeString, READER_GROUP_NAME_METRICS_GAUGE, readerGroupMetricGroup);
@@ -148,9 +147,8 @@ public class FlinkPravegaReaderTest {
      * helper method to validate the metrics
      */
     private void validateMetricGroup(String prefix, String metric, MetricGroup readerGroupMetricGroup) {
-        String expectedValue = prefix + SEPARATOR + metric;
+        String expectedValue = prefix.concat(".").concat(metric);
         Assert.assertTrue(metric, expectedValue.equals(readerGroupMetricGroup.getMetricIdentifier(metric)));
-
     }
 
     /**

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -153,8 +153,9 @@ public class FlinkPravegaReaderTest {
     private static TestableFlinkPravegaReader<Integer> createReader() {
         ClientConfig clientConfig = ClientConfig.builder().build();
         ReaderGroupConfig rgConfig = ReaderGroupConfig.builder().stream(SAMPLE_STREAM).build();
+        boolean enableMetrics = true;
         return new TestableFlinkPravegaReader<>(
-                "hookUid", clientConfig, rgConfig, SAMPLE_SCOPE, GROUP_NAME, DESERIALIZATION_SCHEMA, READER_TIMEOUT, CHKPT_TIMEOUT);
+                "hookUid", clientConfig, rgConfig, SAMPLE_SCOPE, GROUP_NAME, DESERIALIZATION_SCHEMA, READER_TIMEOUT, CHKPT_TIMEOUT, enableMetrics);
     }
 
     /**
@@ -303,8 +304,12 @@ public class FlinkPravegaReaderTest {
         @SuppressWarnings("unchecked")
         final EventStreamReader<T> eventStreamReader = mock(EventStreamReader.class);
 
-        protected TestableFlinkPravegaReader(String hookUid, ClientConfig clientConfig, ReaderGroupConfig readerGroupConfig, String readerGroupScope, String readerGroupName, DeserializationSchema<T> deserializationSchema, Time eventReadTimeout, Time checkpointInitiateTimeout) {
-            super(hookUid, clientConfig, readerGroupConfig, readerGroupScope, readerGroupName, deserializationSchema, eventReadTimeout, checkpointInitiateTimeout);
+        protected TestableFlinkPravegaReader(String hookUid, ClientConfig clientConfig,
+                                             ReaderGroupConfig readerGroupConfig, String readerGroupScope,
+                                             String readerGroupName, DeserializationSchema<T> deserializationSchema,
+                                             Time eventReadTimeout, Time checkpointInitiateTimeout,
+                                             boolean enableMetrics) {
+            super(hookUid, clientConfig, readerGroupConfig, readerGroupScope, readerGroupName, deserializationSchema, eventReadTimeout, checkpointInitiateTimeout, enableMetrics);
         }
 
         @Override

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -561,7 +561,7 @@ public class FlinkPravegaWriterTest {
 
     private FlinkPravegaWriter<Integer> spySinkFunction(ClientFactory clientFactory, PravegaEventRouter<Integer> eventRouter, PravegaWriterMode writerMode) {
         FlinkPravegaWriter<Integer> writer = spy(new FlinkPravegaWriter<>(
-                MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME), new IntegerSerializationSchema(), eventRouter, writerMode, 30));
+                MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME), new IntegerSerializationSchema(), eventRouter, writerMode, 30, true));
         Mockito.doReturn(clientFactory).when(writer).createClientFactory(MOCK_SCOPE_NAME, MOCK_CLIENT_CONFIG);
         return writer;
     }

--- a/src/test/java/io/pravega/connectors/flink/utils/StreamSourceOperatorTestHarness.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/StreamSourceOperatorTestHarness.java
@@ -10,6 +10,7 @@
 package io.pravega.connectors.flink.utils;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.api.checkpoint.ExternallyInducedSource;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.operators.StreamSource;
@@ -109,5 +110,12 @@ public class StreamSourceOperatorTestHarness<T, F extends SourceFunction<T>> ext
      */
     public ConcurrentLinkedQueue<Long> getTriggeredCheckpoints() {
         return triggeredCheckpoints;
+    }
+
+    /**
+     * Gets handle to the MetricGroup.
+     */
+    public MetricGroup getMetricGroup() {
+        return sourceOperator.getMetricGroup();
     }
 }


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

  * Added support to draw reader group metrics for FlinkPravegaReader
  * Following metrics are enabled
    - reader group name
    - scope
    - stream names
    - online readers
    - segment positions
    - unread bytes

**Change log description**
Fixes #31

**Purpose of the change**
To publish reader group metrics

**What the code does**
Publishes the runtime stats of the reader group as Flink metrics

**How to verify it**
- On a running Flink cluster alongside with Pravega, run a job that uses `FlinkPravegaReader`  (e.g., anomaly-samples application) and verify if the metrics are visible from UI as well as REST API
```
curl -i -s -f localhost:1028/jobs/2c248d6fe8ed518e959989889a3c5ced/vertices/bc764cd8ddf7a0cff126f51c16239658/metrics?get=0.Source__AnomalyEventReader.PravegaReader.readerGroup.readerGroupName
[{"id":"0.Source__AnomalyEventReader.PravegaReader.readerGroup.readerGroupName","value":"flinkmrdf01aislmcira301jg"}]

curl -i -s -f localhost:1028/jobs/2c248d6fe8ed518e959989889a3c5ced/vertices/bc764cd8ddf7a0cff126f51c16239658/metrics?get=0.Source__AnomalyEventReader.PravegaReader.readerGroup.scope
[{"id":"0.Source__AnomalyEventReader.PravegaReader.readerGroup.scope","value":"anomaly"}]

curl -i -s -f localhost:1028/jobs/2c248d6fe8ed518e959989889a3c5ced/vertices/bc764cd8ddf7a0cff126f51c16239658/metrics?get=0.Source__AnomalyEventReader.PravegaReader.readerGroup.streams
[{"id":"0.Source__AnomalyEventReader.PravegaReader.readerGroup.streams","value":"test"}]

curl -i -s -f localhost:1028/jobs/2c248d6fe8ed518e959989889a3c5ced/vertices/bc764cd8ddf7a0cff126f51c16239658/metrics?get=0.Source__AnomalyEventReader.PravegaReader.readerGroup.onlineReaders
[{"id":"0.Source__AnomalyEventReader.PravegaReader.readerGroup.onlineReaders","value":"Source: AnomalyEventReader (1/1)"}]

curl -i -s -f localhost:1028/jobs/2c248d6fe8ed518e959989889a3c5ced/vertices/bc764cd8ddf7a0cff126f51c16239658/metrics?get=0.Source__AnomalyEventReader.PravegaReader.readerGroup.stream.test.segmentPositions
[{"id":"0.Source__AnomalyEventReader.PravegaReader.readerGroup.stream-test.segmentPositions","value":"stream=test, segments={anomaly/test/2.#epoch.0=0 ,anomaly/test/0.#epoch.0=0 ,anomaly/test/1.#epoch.0=0 ,}"}]

curl -i -s -f localhost:1028/jobs/2c248d6fe8ed518e959989889a3c5ced/vertices/bc764cd8ddf7a0cff126f51c16239658/metrics?get=0.Source__AnomalyEventReader.PravegaReader.readerGroup.unreadBytes
[{"id":"0.Source__AnomalyEventReader.PravegaReader.readerGroup.unreadBytes","value":"3197"}]

```
