### PR TITLE
[issue-167] Add developer information to pom file for maven publishing

### DIFF
--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -86,6 +86,16 @@ tasks.withType(Upload) {
                     url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                 }
             }
+            developers {
+                developer {
+                    id 'fpj'
+                    name 'Flavio Junqueira'
+                }
+                developer {
+                    id 'eronwright'
+                    name 'Eron Wright'
+                }
+            }
         }
 
         pom.scopeMappings.mappings.remove(configurations.testCompile)


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
updated maven publishing build configuration to add developer info to generated pom file

**Purpose of the change**
To address https://github.com/pravega/flink-connectors/issues/167

**What the code does**
build configuration changes

**How to verify it**
run ./gradlew build and see if the generated pom file contains the developer information