### PR TITLE
[issue-168] Add distribution publishing configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,3 +158,30 @@ def getProjectVersion() {
     }
     return ver
 }
+
+distributions {
+    release {
+        contents {
+            from shadowJar
+            from(project.configurations.shadow)
+            from javadocJar
+            from sourceJar
+        }
+    }
+    workspace {
+        contents {
+            from ('.') {
+                exclude "build"
+                exclude ".gradle"
+                exclude ".idea"
+                exclude "out"
+                exclude "pravega/*"
+            }
+        }
+    }
+}
+
+task distribution(type: Copy, dependsOn: [installReleaseDist, installWorkspaceDist, assembleWorkspaceDist]) {
+    from ("$buildDir/install/flink-connectors-release")
+    into ("$buildDir/distributions")
+}

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -10,6 +10,7 @@
  */
 
 apply plugin: 'java'
+apply plugin: 'distribution'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 compileJava {


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
  - added distribution task to the build script

**Purpose of the change**
To address the issue https://github.com/pravega/flink-connectors/issues/168

**What the code does**
  - added new build task to assemble release artifacts to a specific directory location

**How to verify it**
run `./gradlew clean distribution` and verify the release artifacts under `$buildDir/distributions`