### PR TITLE
[issue-146] Support timestamp rows with FlinkPravegaTableSource

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
@@ -188,7 +188,7 @@ public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>,
 
         /**
          * Configures a field of the table to be a processing time attribute.
-         * The configured field must be present in the tabel schema and of type {@link Types#SQL_TIMESTAMP()}.
+         * The configured field must be present in the table schema and of type {@link Types#SQL_TIMESTAMP()}.
          *
          * @param proctimeAttribute The name of the processing time attribute in the table schema.
          * @return The builder.

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
@@ -19,12 +19,21 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.Types;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.sources.BatchTableSource;
+import org.apache.flink.table.sources.DefinedProctimeAttribute;
+import org.apache.flink.table.sources.DefinedRowtimeAttributes;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.sources.tsextractors.TimestampExtractor;
+import org.apache.flink.table.sources.wmstrategies.WatermarkStrategy;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
+import scala.Option;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -35,7 +44,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * Supports both stream and batch environments.
  */
-public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>, BatchTableSource<Row> {
+public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>, BatchTableSource<Row>,
+        DefinedProctimeAttribute, DefinedRowtimeAttributes {
 
     private final Supplier<FlinkPravegaReader<Row>> sourceFunctionFactory;
 
@@ -45,6 +55,12 @@ public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>,
 
     /** Type information describing the result type. */
     private final TypeInformation<Row> returnType;
+
+    /** Field name of the processing time attribute, null if no processing time field is defined. */
+    private String proctimeAttribute;
+
+    /** Descriptor for a rowtime attribute. */
+    private List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors;
 
     /**
      * Creates a Pravega {@link TableSource}.
@@ -82,7 +98,7 @@ public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>,
     @Override
     public DataSet<Row> getDataSet(ExecutionEnvironment env) {
         FlinkPravegaInputFormat<Row> inputFormat = inputFormatFactory.get();
-        return env.createInput(inputFormat);
+        return env.createInput(inputFormat, returnType);
     }
 
     @Override
@@ -93,6 +109,53 @@ public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>,
     @Override
     public TableSchema getTableSchema() {
         return schema;
+    }
+
+    @Override
+    public String getProctimeAttribute() {
+        return proctimeAttribute;
+    }
+
+    @Override
+    public List<RowtimeAttributeDescriptor> getRowtimeAttributeDescriptors() {
+        return rowtimeAttributeDescriptors;
+    }
+
+    /**
+     * Declares a field of the schema to be the processing time attribute.
+     *
+     * @param proctimeAttribute The name of the field that becomes the processing time field.
+     */
+    protected void setProctimeAttribute(String proctimeAttribute) {
+        if (proctimeAttribute != null) {
+            // validate that field exists and is of correct type
+            Option<TypeInformation<?>> tpe = schema.getType(proctimeAttribute);
+            if (tpe.isEmpty()) {
+                throw new ValidationException("Processing time attribute " + proctimeAttribute + " is not present in TableSchema.");
+            } else if (tpe.get() != Types.SQL_TIMESTAMP()) {
+                throw new ValidationException("Processing time attribute " + proctimeAttribute + " is not of type SQL_TIMESTAMP.");
+            }
+        }
+        this.proctimeAttribute = proctimeAttribute;
+    }
+
+    /**
+     * Declares a list of fields to be rowtime attributes.
+     *
+     * @param rowtimeAttributeDescriptors The descriptors of the rowtime attributes.
+     */
+    protected void setRowtimeAttributeDescriptors(List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors) {
+        // validate that all declared fields exist and are of correct type
+        for (RowtimeAttributeDescriptor desc : rowtimeAttributeDescriptors) {
+            String rowtimeAttribute = desc.getAttributeName();
+            Option<TypeInformation<?>> tpe = schema.getType(rowtimeAttribute);
+            if (tpe.isEmpty()) {
+                throw new ValidationException("Rowtime attribute " + rowtimeAttribute + " is not present in TableSchema.");
+            } else if (tpe.get() != Types.SQL_TIMESTAMP()) {
+                throw new ValidationException("Rowtime attribute " + rowtimeAttribute + " is not of type SQL_TIMESTAMP.");
+            }
+        }
+        this.rowtimeAttributeDescriptors = rowtimeAttributeDescriptors;
     }
 
     /**
@@ -106,6 +169,10 @@ public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>,
 
         private TableSchema schema;
 
+        private String proctimeAttribute;
+
+        private RowtimeAttributeDescriptor rowtimeAttributeDescriptor;
+
         /**
          * Sets the schema of the produced table.
          *
@@ -116,6 +183,48 @@ public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>,
             Preconditions.checkNotNull(schema, "Schema must not be null.");
             Preconditions.checkArgument(this.schema == null, "Schema has already been set.");
             this.schema = schema;
+            return builder();
+        }
+
+        /**
+         * Configures a field of the table to be a processing time attribute.
+         * The configured field must be present in the tabel schema and of type {@link Types#SQL_TIMESTAMP()}.
+         *
+         * @param proctimeAttribute The name of the processing time attribute in the table schema.
+         * @return The builder.
+         */
+        public B withProctimeAttribute(String proctimeAttribute) {
+            Preconditions.checkNotNull(proctimeAttribute, "Proctime attribute must not be null.");
+            Preconditions.checkArgument(!proctimeAttribute.isEmpty(), "Proctime attribute must not be empty.");
+            Preconditions.checkArgument(this.proctimeAttribute == null, "Proctime attribute has already been set.");
+            this.proctimeAttribute = proctimeAttribute;
+            return builder();
+        }
+
+        /**
+         * Configures a field of the table to be a rowtime attribute.
+         * The configured field must be present in the table schema and of type {@link Types#SQL_TIMESTAMP()}.
+         *
+         * @param rowtimeAttribute The name of the rowtime attribute in the table schema.
+         * @param timestampExtractor The {@link TimestampExtractor} to extract the rowtime attribute from the physical type.
+         * @param watermarkStrategy The {@link WatermarkStrategy} to generate watermarks for the rowtime attribute.
+         * @return The builder.
+         */
+        public B withRowtimeAttribute(
+                String rowtimeAttribute,
+                TimestampExtractor timestampExtractor,
+                WatermarkStrategy watermarkStrategy) {
+            Preconditions.checkNotNull(rowtimeAttribute, "Rowtime attribute must not be null.");
+            Preconditions.checkArgument(!rowtimeAttribute.isEmpty(), "Rowtime attribute must not be empty.");
+            Preconditions.checkNotNull(timestampExtractor, "Timestamp extractor must not be null.");
+            Preconditions.checkNotNull(watermarkStrategy, "Watermark assigner must not be null.");
+            Preconditions.checkArgument(this.rowtimeAttributeDescriptor == null,
+                    "Currently, only one rowtime attribute is supported.");
+
+            this.rowtimeAttributeDescriptor = new RowtimeAttributeDescriptor(
+                    rowtimeAttribute,
+                    timestampExtractor,
+                    watermarkStrategy);
             return builder();
         }
 
@@ -135,6 +244,14 @@ public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>,
          * @param source the table source.
          */
         protected void configureTableSource(T source) {
+            // configure processing time attributes
+            source.setProctimeAttribute(proctimeAttribute);
+            // configure rowtime attributes
+            if (rowtimeAttributeDescriptor == null) {
+                source.setRowtimeAttributeDescriptors(Collections.emptyList());
+            } else {
+                source.setRowtimeAttributeDescriptors(Collections.singletonList(rowtimeAttributeDescriptor));
+            }
         }
 
         /**

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableITCase.java
@@ -1,0 +1,345 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.connectors.flink;
+
+import io.pravega.client.stream.Stream;
+import io.pravega.connectors.flink.serialization.JsonRowSerializationSchema;
+import io.pravega.connectors.flink.utils.SetupUtils;
+import io.pravega.connectors.flink.utils.SuccessException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.Types;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.table.sources.tsextractors.ExistingField;
+import org.apache.flink.table.sources.wmstrategies.BoundedOutOfOrderTimestamps;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Integration tests for {@link FlinkPravegaTableSource}
+ */
+@Slf4j
+public class FlinkPravegaTableITCase {
+
+    // Setup utility.
+    protected static final SetupUtils SETUP_UTILS = new SetupUtils();
+
+    private static final List<Row> RESULTS = new ArrayList<>();
+
+    // Number of events to generate for each of the tests.
+    private static final int EVENT_COUNT_PER_SOURCE = 11;
+
+    //Ensure each test completes within defined interval
+    @Rule
+    public final Timeout globalTimeout = new Timeout(180, TimeUnit.SECONDS);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        SETUP_UTILS.setEnableAuth(false);
+        SETUP_UTILS.setEnableTls(false);
+        SETUP_UTILS.startAllServices();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        SETUP_UTILS.stopAllServices();
+    }
+
+    @Test
+    public void testJsonTableSource() throws Exception {
+
+        StreamExecutionEnvironment execEnvWrite = StreamExecutionEnvironment.getExecutionEnvironment();
+        execEnvWrite.setParallelism(1);
+
+        Stream stream = Stream.of(SETUP_UTILS.getScope(), "testJsonTableSource");
+        SETUP_UTILS.createTestStream(stream.getStreamName(), 1);
+
+        String[] fieldNames = {"user", "uri", "accessTime"};
+
+        PravegaConfig pravegaConfig = SETUP_UTILS.getPravegaConfig();
+
+        // Write some data to the stream
+        DataStreamSource<Row> dataStream = execEnvWrite
+                .addSource(new TableEventSource(EVENT_COUNT_PER_SOURCE));
+
+        FlinkPravegaWriter<Row> pravegaSink = FlinkPravegaWriter.<Row>builder()
+                .withPravegaConfig(pravegaConfig)
+                .forStream(stream)
+                .withSerializationSchema(new JsonRowSerializationSchema(fieldNames))
+                .withEventRouter((Row event) -> "fixedkey")
+                .build();
+
+        dataStream.addSink(pravegaSink);
+
+        Assert.assertNotNull(execEnvWrite.getExecutionPlan());
+
+        execEnvWrite.execute("PopulateRowData");
+
+        // read data from the stream using Table reader
+        TableSchema tableSchema = TableSchema.builder()
+                .field("user", Types.STRING())
+                .field("uri", Types.STRING())
+                .field("accessTime", Types.SQL_TIMESTAMP())
+                .build();
+
+        FlinkPravegaJsonTableSource source = FlinkPravegaJsonTableSource.builder()
+                                                .forStream(stream)
+                                                .withPravegaConfig(pravegaConfig)
+                                                .failOnMissingField(true)
+                                                //.withProctimeAttribute("accessTime")
+                                                .withRowtimeAttribute("accessTime",
+                                                        new ExistingField("accessTime"),
+                                                        new BoundedOutOfOrderTimestamps(30000L))
+                                                .withSchema(tableSchema)
+                                                .withReaderGroupScope(stream.getScope())
+                                                .build();
+
+        testTableSourceStream(source);
+
+        tesTableSourceBatch(source);
+
+    }
+
+    private void testTableSourceStream(FlinkPravegaJsonTableSource source) throws Exception {
+
+        final StreamExecutionEnvironment execEnvRead = StreamExecutionEnvironment.getExecutionEnvironment();
+        execEnvRead.setParallelism(1);
+        execEnvRead.enableCheckpointing(100);
+        execEnvRead.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+        StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(execEnvRead);
+        tableEnv.registerTableSource("MyTableRow", source);
+
+        String sqlQuery = "SELECT user, count(uri) from MyTableRow GROUP BY user";
+
+        Table result = tableEnv.sqlQuery(sqlQuery);
+
+        DataStream<Tuple2<Boolean, Row>> resultSet = tableEnv.toRetractStream(result, Row.class);
+        StringSink2 stringSink = new StringSink2(EVENT_COUNT_PER_SOURCE);
+        resultSet.addSink(stringSink);
+
+        try {
+            execEnvRead.execute("ReadRowData");
+        } catch (Exception e) {
+            if (!(ExceptionUtils.getRootCause(e) instanceof SuccessException)) {
+                throw e;
+            }
+        }
+
+        log.info("results: {}", RESULTS);
+
+        boolean compare = compare(RESULTS, getExpectedResultsRetracted());
+        assertTrue("Output does not match expected result", compare);
+    }
+
+    public void tesTableSourceBatch(FlinkPravegaJsonTableSource source) throws Exception {
+
+        ExecutionEnvironment execEnvRead = ExecutionEnvironment.getExecutionEnvironment();
+        BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(execEnvRead);
+        execEnvRead.setParallelism(1);
+
+        tableEnv.registerTableSource("MyTableRow", source);
+
+        String sqlQuery = "SELECT user, " +
+                "TUMBLE_END(accessTime, INTERVAL '5' MINUTE) AS accessTime, " +
+                "COUNT(uri) AS cnt " +
+                "from MyTableRow GROUP BY " +
+                "user, TUMBLE(accessTime, INTERVAL '5' MINUTE)";
+        Table result = tableEnv.sqlQuery(sqlQuery);
+
+        DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+
+        List<Row> results = resultSet.collect();
+        log.info("results: {}", results);
+
+        boolean compare = compare(results, getExpectedResultsAppend());
+        assertTrue("Output does not match expected result", compare);
+
+    }
+
+    static boolean compare(List<Row> results, List<Row> expectedResults) {
+
+        if (results.size() != expectedResults.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < results.size(); i++) {
+            Row result = results.get(i);
+            Row expected = expectedResults.get(i);
+            if (!result.equals(expected)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    static List<Row> getExpectedResultsAppend() {
+
+        String[][] data = {
+                { "Bob",   "2018-08-02 08:25:00.0", "1" },
+                { "Chris", "2018-08-02 08:25:00.0", "1" },
+                { "David", "2018-08-02 08:30:00.0", "1" },
+                { "Gary",  "2018-08-02 09:35:00.0", "2" },
+                { "Mary",  "2018-08-02 09:35:00.0", "2" },
+                { "Nina",  "2018-08-02 09:40:00.0", "1" },
+                { "Peter", "2018-08-02 09:45:00.0", "1" },
+                { "Tony",  "2018-08-02 09:45:00.0", "1" },
+                { "Tony",  "2018-08-02 10:45:00.0", "1" }
+        };
+
+        List<Row> expectedResults = new ArrayList<>();
+
+        for (int i = 0; i < data.length; i++) {
+            Row row = new Row(3);
+            row.setField(0, data[i][0]);
+            row.setField(1, Timestamp.valueOf(data[i][1]));
+            row.setField(2, Long.valueOf(data[i][2]));
+            expectedResults.add(row);
+        }
+
+        return expectedResults;
+    }
+
+    static List<Row> getExpectedResultsRetracted() {
+        String[][] data = {
+                { "Bob",   "1" },
+                { "Chris", "1" },
+                { "David", "1" },
+                { "Gary",  "2" },
+                { "Nina",  "1" },
+                { "Mary",  "2" },
+                { "Peter", "1" },
+                { "Tony",  "2" }
+
+        };
+
+        List<Row> expectedResults = new ArrayList<>();
+
+        for (int i = 0; i < data.length; i++) {
+            Row row = new Row(2);
+            row.setField(0, data[i][0]);
+            row.setField(1, Long.valueOf(data[i][1]));
+            expectedResults.add(row);
+        }
+
+        return expectedResults;
+    }
+
+    static class TableEventSource extends RichParallelSourceFunction<Row> {
+
+        private final int totalEvents;
+
+        private int currentOffset = 0;
+
+        private final String[][] data = {
+                {"Bob",   "/checkout",       "2018-08-02 08:20:00.0"},
+                {"Chris", "/product?id=1",   "2018-08-02 08:23:00.0"},
+                {"David", "/search",         "2018-08-02 08:25:00.0"},
+                {"Gary",  "/cart",           "2018-08-02 09:32:00.0"},
+                {"Mary",  "/checkout",       "2018-08-02 09:33:00.0"},
+                {"Gary",  "/home",           "2018-08-02 09:33:00.0"},
+                {"Nina",  "/cart",           "2018-08-02 09:39:00.0"},
+                {"Mary",  "/search",         "2018-08-02 09:34:00.0"},
+                {"Peter", "/checkout",       "2018-08-02 09:41:00.0"},
+                {"Tony",  "/search",         "2018-08-02 09:41:00.0"},
+                {"Tony",  "/cart",           "2018-08-02 10:41:00.0"}
+        };
+
+        public TableEventSource(final int totalEvents) {
+            Preconditions.checkArgument(totalEvents > 0);
+            this.totalEvents = totalEvents;
+        }
+
+        @Override
+        public void run(SourceContext<Row> ctx) throws Exception {
+            while (currentOffset < totalEvents) {
+                Row row = new Row(3);
+                row.setField(0, data[currentOffset][0]);
+                row.setField(1, data[currentOffset][1]);
+                row.setField(2, Timestamp.valueOf(data[currentOffset][2]));
+
+                log.info("writing record: {}", row);
+                synchronized (ctx.getCheckpointLock()) {
+                    ctx.collect(row);
+                    currentOffset++;
+                }
+                Thread.sleep(100);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            // source terminates after fixed interval
+        }
+    }
+
+    static class StringSink2 extends RichSinkFunction<Tuple2<Boolean, Row>> {
+
+        private int eventCount;
+        private int count = 0;
+
+        public StringSink2(int eventCount) {
+            this.eventCount = eventCount;
+        }
+
+        @Override
+        public void invoke(Tuple2<Boolean, Row> value, Context context) throws Exception {
+            log.info("reading row element: {}", value);
+            Row data = value.f1;
+            if (value.f0.booleanValue()) {
+                log.info("adding row element: {}", value);
+                RESULTS.add(data);
+                count++;
+            } else {
+                int index = RESULTS.indexOf(data);
+                if (index >= 0) {
+                    RESULTS.remove(index);
+                } else {
+                    throw new RuntimeException("Tried to retract a value that wasn't added first. " +
+                            "This is probably an incorrectly implemented test. " +
+                            "Try to set the parallelism of the sink to 1.");
+                }
+            }
+
+            if (count == eventCount) {
+                log.info("done processing...");
+                throw new SuccessException();
+            }
+        }
+
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableITCase.java
@@ -129,7 +129,7 @@ public class FlinkPravegaTableITCase {
 
         testTableSourceStream(source);
 
-        tesTableSourceBatch(source);
+        testTableSourceBatch(source);
 
     }
 
@@ -165,7 +165,7 @@ public class FlinkPravegaTableITCase {
         assertTrue("Output does not match expected result", compare);
     }
 
-    public void tesTableSourceBatch(FlinkPravegaJsonTableSource source) throws Exception {
+    public void testTableSourceBatch(FlinkPravegaJsonTableSource source) throws Exception {
 
         ExecutionEnvironment execEnvRead = ExecutionEnvironment.getExecutionEnvironment();
         BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(execEnvRead);

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableSourceTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableSourceTest.java
@@ -64,15 +64,17 @@ public class FlinkPravegaTableSourceTest {
         FlinkPravegaReader<Row> reader = mock(FlinkPravegaReader.class);
         FlinkPravegaInputFormat<Row> inputFormat = mock(FlinkPravegaInputFormat.class);
 
+        TypeInformation<Row> returnType = jsonSchemaToReturnType(SAMPLE_SCHEMA);
+
         TestableFlinkPravegaTableSource tableSource = new TestableFlinkPravegaTableSource(
                 () -> reader,
                 () -> inputFormat,
                 SAMPLE_SCHEMA,
-                jsonSchemaToReturnType(SAMPLE_SCHEMA)
+                returnType
         );
         ExecutionEnvironment batchEnv = mock(ExecutionEnvironment.class);
         tableSource.getDataSet(batchEnv);
-        verify(batchEnv).createInput(inputFormat);
+        verify(batchEnv).createInput(inputFormat, returnType);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
added processing and event time support to table source connector

**Purpose of the change**
To address the issue https://github.com/pravega/flink-connectors/issues/146

**What the code does**
Implements `DefinedProctimeAttribute` and `DefinedRowtimeAttributes` and enables API to supply the processing and event time capabilities to the table source connector

**How to verify it**
added integration test `FlinkPravegaTableITCase` to verify the implementation.
