### PR TITLE
[issue-127] Suppress unnecessary log outputs from Travis build

### DIFF
--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -17,8 +17,18 @@
         </encoder>
     </appender>
 
-    <root level="error">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="FILE" />
     </root>
+
+    <!-- suppress unnecessary logging statements to keep the log file size minimum -->
+    <logger name="io.pravega.client.segment.impl" level="ERROR"/>
+    <logger name="io.pravega.client.netty.impl" level="ERROR"/>
+    <logger name="org.apache.zookeeper" level="ERROR"/>
+    <logger name="org.apache.curator" level="ERROR"/>
+    <logger name="io.pravega.shared.protocol.netty.ExceptionLoggingHandler" level="OFF"/>
+    <logger name="io.pravega.controller.util.Config" level="OFF"/>
+    <logger name="io.pravega.segmentstore.server.host.handler.ServerConnectionInboundHandler" level="OFF"/>
+
 </configuration>


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
Suppress noisy logging statements from the build/test output

**Purpose of the change**
To address the issue https://github.com/pravega/flink-connectors/issues/127

**What the code does**
added few log4j configurations to suppress unnecessary logging statements.

**How to verify it**
run `./gradlew clean build` and make sure the log file size is under 5 MB limit 