### PR TITLE
[issue-170] Update connector to support Flink 1.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,6 @@ dependencies {
     testCompile group: 'org.mockito', name: 'mockito-all', version: mockitoVersion
     testCompile group: 'org.apache.flink', name: 'flink-tests_2.11', version: flinkVersion
     testCompile group: 'org.apache.flink', name: 'flink-test-utils_2.11', version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-streaming-contrib_2.11', version: flinkVersion
     testCompile group: 'org.apache.flink', name: 'flink-streaming-java_2.11', classifier: 'tests', version: flinkVersion
     testCompile group: 'org.apache.flink', name: 'flink-runtime_2.11', classifier: 'tests', version: flinkVersion
     testCompile group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 
 # 3rd party Versions.
 checkstyleToolVersion=7.1
-flinkVersion=1.4.0
+flinkVersion=1.6.0
 jacksonVersion=2.8.9
 lombokVersion=1.16.18
 twitterMvnRepoVersion=4.3.4-TWTTR

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatITCase.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -35,7 +35,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
-public class FlinkPravegaInputFormatITCase extends StreamingMultipleProgramsTestBase {
+public class FlinkPravegaInputFormatITCase extends AbstractTestBase {
 
     /** Setup utility */
     private static final SetupUtils SETUP_UTILS = new SetupUtils();

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderITCase.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  * Integration tests for {@link FlinkPravegaReader}.
  */
 @Slf4j
-public class FlinkPravegaReaderITCase extends StreamingMultipleProgramsTestBase {
+public class FlinkPravegaReaderITCase extends AbstractTestBase {
 
     // Setup utility.
     protected static final SetupUtils SETUP_UTILS = new SetupUtils();

--- a/src/test/java/io/pravega/connectors/flink/utils/ThrottledIntegerWriter.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/ThrottledIntegerWriter.java
@@ -70,7 +70,7 @@ public class ThrottledIntegerWriter extends CheckedThread implements AutoCloseab
                 }
             }
 
-            eventWriter.writeEvent(String.valueOf(i), i);
+            eventWriter.writeEvent(String.valueOf(i), i).get();
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
- bumped flink version from 1.4.0 to 1.6.0
- dropped `flink-streaming-contrib` reference (FLINK-8175)

**Purpose of the change**
To address https://github.com/pravega/flink-connectors/issues/170

**What the code does**
build script changes

**How to verify it**
make sure the build and integration test works by running `./gradlew clean build`