### PR TITLE
[issue-188] Update Connector version to 0.3.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,8 +22,8 @@ gradleGitPluginVersion=1.7.2
 findbugsVersion=3.0.1
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.3.2-SNAPSHOT
-pravegaVersion=0.3.1
+connectorVersion=0.3.2
+pravegaVersion=0.3.2
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**

  * updated connector and pravega version to 0.3.2
  * updated pravega sub-module commit to pravega v0.3.2 latest commit

**Purpose of the change**
To address https://github.com/pravega/flink-connectors/issues/188

**What the code does**
build configuration changes to use appropriate Pravega version

**How to verify it**
`./gradlew clean build` should pass