### PR TITLE
[issue 192] Compilation error due to redundant variable declaration

### DIFF
--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableSourceTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableSourceTest.java
@@ -65,8 +65,6 @@ public class FlinkPravegaTableSourceTest {
         FlinkPravegaInputFormat<Row> inputFormat = mock(FlinkPravegaInputFormat.class);
         TypeInformation<Row> returnType = jsonSchemaToReturnType(SAMPLE_SCHEMA);
 
-        TypeInformation<Row> returnType = jsonSchemaToReturnType(SAMPLE_SCHEMA);
-
         TestableFlinkPravegaTableSource tableSource = new TestableFlinkPravegaTableSource(
                 () -> reader,
                 () -> inputFormat,


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**
* Fixes compilation error due to redundant declaration in the `testBatchTableSource` test case.

**Purpose of the change**
Fixes #192 

**What the code does**
Removes a redundant variable declaration in `testBatchTableSource`.

**How to verify it**
Build.