### PR TITLE
[issue-201] Update connector to support Pravega client API refactor

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ gradleMkdocsPluginVersion=1.1.0
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.4.0-SNAPSHOT
-pravegaVersion=0.4.0-50.da91e55-SNAPSHOT
+pravegaVersion=0.5.0-49.b80b627-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaOutputFormat.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaOutputFormat.java
@@ -11,7 +11,7 @@
 package io.pravega.connectors.flink;
 
 import io.pravega.client.ClientConfig;
-import io.pravega.client.ClientFactory;
+import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Serializer;
@@ -53,7 +53,7 @@ public class FlinkPravegaOutputFormat<T> extends RichOutputFormat<T> {
     private final SerializationSchema<T> serializationSchema;
 
     // The factory used to create Pravega clients; closing this will also close all Pravega connections.
-    private transient ClientFactory clientFactory;
+    private transient EventStreamClientFactory clientFactory;
 
     // The Pravega client config.
     private final ClientConfig clientConfig;
@@ -190,8 +190,8 @@ public class FlinkPravegaOutputFormat<T> extends RichOutputFormat<T> {
     }
 
     @VisibleForTesting
-    protected ClientFactory createClientFactory(String scopeName, ClientConfig clientConfig) {
-        return ClientFactory.withScope(scopeName, clientConfig);
+    protected EventStreamClientFactory createClientFactory(String scopeName, ClientConfig clientConfig) {
+        return EventStreamClientFactory.withScope(scopeName, clientConfig);
     }
 
     @VisibleForTesting

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -10,7 +10,7 @@
 package io.pravega.connectors.flink.util;
 
 import io.pravega.client.ClientConfig;
-import io.pravega.client.ClientFactory;
+import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.Serializer;
@@ -106,7 +106,7 @@ public class FlinkPravegaUtils {
                 ? ((WrappingSerializer<T>) deserializationSchema).getWrappedSerializer()
                 : new FlinkDeserializer<>(deserializationSchema);
 
-        return ClientFactory.withScope(readerGroupScopeName, clientConfig)
+        return EventStreamClientFactory.withScope(readerGroupScopeName, clientConfig)
                 .createReader(readerId, readerGroupName, deserializer, readerConfig);
     }
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatTest.java
@@ -10,7 +10,7 @@
 package io.pravega.connectors.flink;
 
 import io.pravega.client.ClientConfig;
-import io.pravega.client.ClientFactory;
+import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.Stream;
 import org.apache.flink.api.common.serialization.SerializationSchema;
@@ -117,7 +117,7 @@ public class FlinkPravegaOutputFormatTest {
         when(pravegaConfig.resolve(anyString())).thenReturn(stream);
 
         EventStreamWriter<String> pravegaWriter = mockEventStreamWriter();
-        ClientFactory clientFactory = mockClientFactory(pravegaWriter);
+        EventStreamClientFactory clientFactory = mockClientFactory(pravegaWriter);
         FlinkPravegaOutputFormat<String> spyFlinkPravegaOutputFormat = spyFlinkPravegaOutputFormat(clientFactory);
 
         // test open
@@ -175,13 +175,13 @@ public class FlinkPravegaOutputFormatTest {
         return mock(EventStreamWriter.class);
     }
 
-    private <T> ClientFactory mockClientFactory(EventStreamWriter<T> eventWriter) {
-        ClientFactory clientFactory = mock(ClientFactory.class);
+    private <T> EventStreamClientFactory mockClientFactory(EventStreamWriter<T> eventWriter) {
+        EventStreamClientFactory clientFactory = mock(EventStreamClientFactory.class);
         when(clientFactory.<T>createEventWriter(anyString(), anyObject(), anyObject())).thenReturn(eventWriter);
         return clientFactory;
     }
 
-    private FlinkPravegaOutputFormat<String> spyFlinkPravegaOutputFormat(ClientFactory clientFactory) {
+    private FlinkPravegaOutputFormat<String> spyFlinkPravegaOutputFormat(EventStreamClientFactory clientFactory) {
 
         FlinkPravegaOutputFormat<String> flinkPravegaOutputFormat = FlinkPravegaOutputFormat.<String>builder()
                 .withEventRouter(eventRouter)

--- a/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
@@ -10,7 +10,7 @@
 package io.pravega.connectors.flink.utils;
 
 import io.pravega.client.ClientConfig;
-import io.pravega.client.ClientFactory;
+import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.Stream;
@@ -164,10 +164,10 @@ public final class SetupUtils {
     }
 
     /**
-     * Create a {@link ClientFactory} for this cluster and scope.
+     * Create a {@link EventStreamClientFactory} for this cluster and scope.
      */
-    public ClientFactory newClientFactory() {
-        return ClientFactory.withScope(this.scope, getControllerUri());
+    public EventStreamClientFactory newClientFactory() {
+        return EventStreamClientFactory.withScope(this.scope, getClientConfig());
     }
 
     /**
@@ -207,7 +207,7 @@ public final class SetupUtils {
         Preconditions.checkState(this.started.get(), "Services not yet started");
         Preconditions.checkNotNull(streamName);
 
-        ClientFactory clientFactory = ClientFactory.withScope(this.scope, getClientConfig());
+        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(this.scope, getClientConfig());
         return clientFactory.createEventWriter(
                 streamName,
                 new IntegerSerializer(),
@@ -231,7 +231,7 @@ public final class SetupUtils {
                 readerGroup,
                 ReaderGroupConfig.builder().stream(Stream.of(this.scope, streamName)).build());
 
-        ClientFactory clientFactory = ClientFactory.withScope(this.scope, getClientConfig());
+        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(this.scope, getClientConfig());
         final String readerGroupId = UUID.randomUUID().toString();
         return clientFactory.createReader(
                 readerGroupId,


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
Updated connector code to fix the deprecated API build error because of the recent changes introduced in Pravega client API.

**Purpose of the change**
To address the issue https://github.com/pravega/flink-connectors/issues/201

**What the code does**
- Updated Pravega artifact and submodule version to latest snapshot
- Addressed the Pravega client API refactoring changes. 
- Fixed unit/integration tests.

**How to verify it**
`./gradlew clean build` should pass