### PR TITLE
[issue-213] Fix table API changes addressed for Flink 1.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,24 +110,24 @@ dependencies {
     compileOnly group: 'org.slf4j', name: 'slf4j-api', version: slf4jApiVersion // provided by flink-runtime
     compile group: 'org.apache.commons', name: 'commons-lang3', version: apacheCommonsVersion
     compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion // not needed at runtime
-    compileOnly group: 'org.apache.flink', name: 'flink-streaming-scala_2.11', version: flinkVersion // provided by application
-    compileOnly group: 'org.apache.flink', name: 'flink-table_2.11', version: flinkVersion // provided by application
+    compileOnly group: 'org.apache.flink', name: 'flink-streaming-scala_'+flinkScalaVersion, version: flinkVersion // provided by application
+    compileOnly group: 'org.apache.flink', name: 'flink-table_'+flinkScalaVersion, version: flinkVersion // provided by application
     compileOnly group: 'org.apache.flink', name: 'flink-json', version: flinkVersion
     compileOnly group: 'org.apache.flink', name: 'flink-avro', version: flinkVersion
     compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion // provided by flink-runtime
 
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.mockito', name: 'mockito-all', version: mockitoVersion
-    testCompile group: 'org.apache.flink', name: 'flink-tests_2.11', version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-test-utils_2.11', version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-streaming-java_2.11', classifier: 'tests', version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-runtime_2.11', classifier: 'tests', version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-tests_'+flinkScalaVersion, version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-test-utils_'+flinkScalaVersion, version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-streaming-java_'+flinkScalaVersion, classifier: 'tests', version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-runtime_'+flinkScalaVersion, classifier: 'tests', version: flinkVersion
     testCompile group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion
 
     //  configuring the shaded pom dependencies
     shadowOnly group: 'org.slf4j', name: 'slf4j-api', version: slf4jApiVersion
-    shadowOnly group: 'org.apache.flink', name: 'flink-streaming-java_2.11', version: flinkVersion
-    shadowOnly group: 'org.apache.flink', name: 'flink-table_2.11', version: flinkVersion
+    shadowOnly group: 'org.apache.flink', name: 'flink-streaming-java_'+flinkScalaVersion, version: flinkVersion
+    shadowOnly group: 'org.apache.flink', name: 'flink-table_'+flinkScalaVersion, version: flinkVersion
     shadowOnly group: 'org.apache.flink', name: 'flink-json', version: flinkVersion
     shadowOnly group: 'org.apache.flink', name: 'flink-avro', version: flinkVersion
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,8 @@
 
 # 3rd party Versions.
 checkstyleToolVersion=7.1
-flinkVersion=1.6.0
+flinkVersion=1.7.2
+flinkScalaVersion=2.12
 jacksonVersion=2.8.9
 lombokVersion=1.16.18
 twitterMvnRepoVersion=4.3.4-TWTTR

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableFactoryBase.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableFactoryBase.java
@@ -90,16 +90,16 @@ public abstract class FlinkPravegaTableFactoryBase {
 
     protected Map<String, String> getRequiredContext() {
         Map<String, String> context = new HashMap<>();
-        context.put(CONNECTOR_TYPE(), CONNECTOR_TYPE_VALUE_PRAVEGA);
+        context.put(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE_PRAVEGA);
 
         // to preserve backward compatibility in case the connector property format changes
         // It is not clear on how the framework is making use of the "connector.property-version" but all the implementation classes supplies value as "1"
         // https://github.com/apache/flink/blob/release-1.6.0/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/descriptors/ConnectorDescriptorValidator.scala#L45
         // https://github.com/apache/flink/blob/release-1.6.0/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/TableFactoryService.scala#L202
         // https://github.com/apache/flink/blob/release-1.6.0/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java#L98
-        context.put(CONNECTOR_PROPERTY_VERSION(), "1");
+        context.put(CONNECTOR_PROPERTY_VERSION, "1");
 
-        context.put(CONNECTOR_VERSION(), getVersion());
+        context.put(CONNECTOR_VERSION, getVersion());
         return context;
     }
 
@@ -156,7 +156,7 @@ public abstract class FlinkPravegaTableFactoryBase {
         properties.add(SCHEMA() + ".#." + ROWTIME_WATERMARKS_DELAY());
 
         // format wildcard
-        properties.add(FORMAT() + ".*");
+        properties.add(FORMAT + ".*");
 
         return properties;
     }
@@ -245,7 +245,7 @@ public abstract class FlinkPravegaTableFactoryBase {
         FlinkPravegaTableSource flinkPravegaTableSource = new FlinkPravegaTableSourceImpl(
                                                                     tableSourceReaderBuilder::buildSourceFunction,
                                                                     tableSourceReaderBuilder::buildInputFormat, schema,
-                                                                    new RowTypeInfo(schema.getTypes(), schema.getColumnNames()));
+                                                                    new RowTypeInfo(schema.getFieldTypes(), schema.getFieldNames()));
         flinkPravegaTableSource.setRowtimeAttributeDescriptors(SchemaValidator.deriveRowtimeAttributes(descriptorProperties));
         Optional<String> procTimeAttribute = SchemaValidator.deriveProctimeAttribute(descriptorProperties);
         if (procTimeAttribute.isPresent()) {
@@ -281,7 +281,7 @@ public abstract class FlinkPravegaTableFactoryBase {
 
         return new FlinkPravegaTableSinkImpl(tableSinkWriterBuilder::createSinkFunction,
                 tableSinkWriterBuilder::createOutputFormat)
-                .configure(schema.getColumnNames(), schema.getTypes());
+                .configure(schema.getFieldNames(), schema.getFieldTypes());
     }
 
     public static final class FlinkPravegaTableSourceImpl extends FlinkPravegaTableSource {

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
@@ -31,10 +31,10 @@ import org.apache.flink.table.sources.tsextractors.TimestampExtractor;
 import org.apache.flink.table.sources.wmstrategies.WatermarkStrategy;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
-import scala.Option;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -129,8 +129,8 @@ public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>,
     protected void setProctimeAttribute(String proctimeAttribute) {
         if (proctimeAttribute != null) {
             // validate that field exists and is of correct type
-            Option<TypeInformation<?>> tpe = schema.getType(proctimeAttribute);
-            if (tpe.isEmpty()) {
+            Optional<TypeInformation<?>> tpe = schema.getFieldType(proctimeAttribute);
+            if (!tpe.isPresent()) {
                 throw new ValidationException("Processing time attribute " + proctimeAttribute + " is not present in TableSchema.");
             } else if (tpe.get() != Types.SQL_TIMESTAMP()) {
                 throw new ValidationException("Processing time attribute " + proctimeAttribute + " is not of type SQL_TIMESTAMP.");
@@ -148,8 +148,8 @@ public abstract class FlinkPravegaTableSource implements StreamTableSource<Row>,
         // validate that all declared fields exist and are of correct type
         for (RowtimeAttributeDescriptor desc : rowtimeAttributeDescriptors) {
             String rowtimeAttribute = desc.getAttributeName();
-            Option<TypeInformation<?>> tpe = schema.getType(rowtimeAttribute);
-            if (tpe.isEmpty()) {
+            Optional<TypeInformation<?>> tpe = schema.getFieldType(rowtimeAttribute);
+            if (!tpe.isPresent()) {
                 throw new ValidationException("Rowtime attribute " + rowtimeAttribute + " is not present in TableSchema.");
             } else if (tpe.get() != Types.SQL_TIMESTAMP()) {
                 throw new ValidationException("Rowtime attribute " + rowtimeAttribute + " is not of type SQL_TIMESTAMP.");

--- a/src/main/java/io/pravega/connectors/flink/Pravega.java
+++ b/src/main/java/io/pravega/connectors/flink/Pravega.java
@@ -91,8 +91,9 @@ public class Pravega extends ConnectorDescriptor {
      * Internal method for connector properties conversion.
      */
     @Override
-    public void addConnectorProperties(DescriptorProperties properties) {
-        properties.putString(CONNECTOR_VERSION(), String.valueOf(CONNECTOR_VERSION_VALUE));
+    protected Map<String, String> toConnectorProperties() {
+        final DescriptorProperties properties = new DescriptorProperties();
+        properties.putString(CONNECTOR_VERSION, String.valueOf(CONNECTOR_VERSION_VALUE));
 
         if (tableSourceReaderBuilder == null && tableSinkWriterBuilder == null) {
             throw new ValidationException("Missing both reader and writer configurations.");
@@ -112,6 +113,7 @@ public class Pravega extends ConnectorDescriptor {
         if (tableSinkWriterBuilder != null) {
             populateWriterProperties(properties);
         }
+        return properties.asMap();
     }
 
     /**

--- a/src/main/java/io/pravega/connectors/flink/PravegaValidator.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaValidator.java
@@ -14,7 +14,6 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.descriptors.ConnectorDescriptorValidator;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -46,7 +45,7 @@ public class PravegaValidator extends ConnectorDescriptorValidator {
     @Override
     public void validate(DescriptorProperties properties) {
         super.validate(properties);
-        properties.validateValue(CONNECTOR_TYPE(), CONNECTOR_TYPE_VALUE_PRAVEGA, false);
+        properties.validateValue(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE_PRAVEGA, false);
         validateConnectionConfig(properties);
         if (properties.containsKey(CONNECTOR_READER)) {
             validateReaderConfigurations(properties);
@@ -64,17 +63,17 @@ public class PravegaValidator extends ConnectorDescriptorValidator {
         final Map<String, Consumer<String>> streamPropertyValidators = new HashMap<>();
         streamPropertyValidators.put(
                 CONNECTOR_READER_STREAM_INFO_SCOPE,
-                prefix -> properties.validateString(prefix + CONNECTOR_READER_STREAM_INFO_SCOPE, true, 1));
+                prefix -> properties.validateString(prefix, true, 1));
         streamPropertyValidators.put(
                 CONNECTOR_READER_STREAM_INFO_STREAM,
-                prefix -> properties.validateString(prefix + CONNECTOR_READER_STREAM_INFO_STREAM, false, 0));
+                prefix -> properties.validateString(prefix, false, 0));
         streamPropertyValidators.put(
                 CONNECTOR_READER_STREAM_INFO_START_STREAMCUT,
-                prefix -> properties.validateString(prefix + CONNECTOR_READER_STREAM_INFO_START_STREAMCUT, true, 1));
+                prefix -> properties.validateString(prefix, true, 1));
         streamPropertyValidators.put(
                 CONNECTOR_READER_STREAM_INFO_END_STREAMCUT,
-                prefix -> properties.validateString(prefix + CONNECTOR_READER_STREAM_INFO_END_STREAMCUT, true, 1));
-        properties.validateVariableIndexedProperties(CONNECTOR_READER_STREAM_INFO, false, streamPropertyValidators, Arrays.asList(CONNECTOR_READER_STREAM_INFO_STREAM));
+                prefix -> properties.validateString(prefix, true, 1));
+        properties.validateFixedIndexedProperties(CONNECTOR_READER_STREAM_INFO, true, streamPropertyValidators);
 
         // for readers we need default-scope from connection config or reader group scope
         Optional<String> readerGroupScope = properties.getOptionalString(CONNECTOR_READER_READER_GROUP_SCOPE);

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableFactoryTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableFactoryTest.java
@@ -14,7 +14,6 @@ import io.pravega.client.stream.Stream;
 import org.apache.flink.table.api.NoMatchingTableFactoryException;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.descriptors.Json;
 import org.apache.flink.table.descriptors.Schema;
 import org.apache.flink.table.factories.StreamTableSinkFactory;
@@ -67,7 +66,7 @@ public class FlinkPravegaTableFactoryTest {
                 .withSchema(SCHEMA)
                 .inAppendMode();
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(testDesc);
+        final Map<String, String> propertiesMap = testDesc.toProperties();
 
         FlinkPravegaTableFactoryBase tableFactoryBase = new FlinkPravegaStreamTableSourceFactory();
         tableFactoryBase.createFlinkPravegaTableSource(propertiesMap);
@@ -92,7 +91,7 @@ public class FlinkPravegaTableFactoryTest {
                 .withSchema(SCHEMA)
                 .inAppendMode();
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(testDesc);
+        final Map<String, String> propertiesMap = testDesc.toProperties();
 
         FlinkPravegaTableFactoryBase tableFactoryBase = new FlinkPravegaStreamTableSourceFactory();
         tableFactoryBase.createFlinkPravegaTableSource(propertiesMap);
@@ -115,7 +114,7 @@ public class FlinkPravegaTableFactoryTest {
                 .withFormat(JSON)
                 .withSchema(SCHEMA);
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(testDesc);
+        final Map<String, String> propertiesMap = testDesc.toProperties();
 
         final TableSource<?> source = TableFactoryService.find(StreamTableSourceFactory.class, propertiesMap)
                 .createStreamTableSource(propertiesMap);
@@ -138,7 +137,7 @@ public class FlinkPravegaTableFactoryTest {
                 .withSchema(SCHEMA)
                 .inAppendMode();
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(testDesc);
+        final Map<String, String> propertiesMap = testDesc.toProperties();
         TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
                 .createStreamTableSink(propertiesMap);
         fail("stream name validation failed");
@@ -161,7 +160,7 @@ public class FlinkPravegaTableFactoryTest {
                 .withSchema(SCHEMA)
                 .inAppendMode();
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(testDesc);
+        final Map<String, String> propertiesMap = testDesc.toProperties();
         TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
                 .createStreamTableSink(propertiesMap);
         fail("routingKey field name validation failed");
@@ -182,7 +181,7 @@ public class FlinkPravegaTableFactoryTest {
                 .withSchema(SCHEMA)
                 .inAppendMode();
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(testDesc);
+        final Map<String, String> propertiesMap = testDesc.toProperties();
         Map<String, String> test = new HashMap<>(propertiesMap);
         test.put(CONNECTOR_WRITER_MODE, "foo");
         TableFactoryService.find(StreamTableSinkFactory.class, test)
@@ -205,7 +204,7 @@ public class FlinkPravegaTableFactoryTest {
                 .withSchema(SCHEMA)
                 .inAppendMode();
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(testDesc);
+        final Map<String, String> propertiesMap = testDesc.toProperties();
         final TableSink<?> sink = TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
                 .createStreamTableSink(propertiesMap);
         assertNotNull(sink);
@@ -226,7 +225,7 @@ public class FlinkPravegaTableFactoryTest {
                 .withSchema(SCHEMA)
                 .inAppendMode();
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(testDesc);
+        final Map<String, String> propertiesMap = testDesc.toProperties();
         final TableSink<?> sink = TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
                 .createStreamTableSink(propertiesMap);
         assertNotNull(sink);
@@ -246,7 +245,7 @@ public class FlinkPravegaTableFactoryTest {
                 .withSchema(SCHEMA)
                 .inAppendMode();
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(testDesc);
+        final Map<String, String> propertiesMap = testDesc.toProperties();
         TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
                 .createStreamTableSink(propertiesMap);
         fail("table factory validation failed");
@@ -266,7 +265,7 @@ public class FlinkPravegaTableFactoryTest {
                 .withFormat(JSON)
                 .inAppendMode();
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(testDesc);
+        final Map<String, String> propertiesMap = testDesc.toProperties();
         TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
                 .createStreamTableSink(propertiesMap);
         fail("missing schema validation failed");

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableITCase.java
@@ -32,7 +32,6 @@ import org.apache.flink.table.api.Types;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.descriptors.BatchTableDescriptor;
-import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.descriptors.Json;
 import org.apache.flink.table.descriptors.Rowtime;
 import org.apache.flink.table.descriptors.Schema;
@@ -255,7 +254,7 @@ public class FlinkPravegaTableITCase {
                 .withSchema(schema)
                 .inAppendMode();
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(desc);
+        final Map<String, String> propertiesMap = desc.toProperties();
         final TableSource<?> source = TableFactoryService.find(StreamTableSourceFactory.class, propertiesMap)
                 .createStreamTableSource(propertiesMap);
 
@@ -304,7 +303,7 @@ public class FlinkPravegaTableITCase {
                 .withFormat(new Json().failOnMissingField(true).deriveSchema())
                 .withSchema(schema);
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(desc);
+        final Map<String, String> propertiesMap = desc.toProperties();
         final TableSource<?> source = TableFactoryService.find(BatchTableSourceFactory.class, propertiesMap)
                 .createBatchTableSource(propertiesMap);
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableSinkTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableSinkTest.java
@@ -16,7 +16,6 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.descriptors.Json;
 import org.apache.flink.table.descriptors.Rowtime;
 import org.apache.flink.table.descriptors.Schema;
@@ -149,7 +148,7 @@ public class FlinkPravegaTableSinkTest {
                 )
                 .inAppendMode();
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(testDesc);
+        final Map<String, String> propertiesMap = testDesc.toProperties();
         final TableSink<?> sink = TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
                 .createStreamTableSink(propertiesMap);
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkTableITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkTableITCase.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.descriptors.Avro;
 import org.apache.flink.table.descriptors.BatchTableDescriptor;
-import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.descriptors.Json;
 import org.apache.flink.table.descriptors.Schema;
 import org.apache.flink.table.descriptors.StreamTableDescriptor;
@@ -266,7 +265,7 @@ public class FlinkTableITCase {
                 .inAppendMode();
         desc.registerTableSourceAndSink("test");
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(desc);
+        final Map<String, String> propertiesMap = desc.toProperties();
         final TableSink<?> sink = TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
                 .createStreamTableSink(propertiesMap);
         final TableSource<?> source = TableFactoryService.find(StreamTableSourceFactory.class, propertiesMap)
@@ -333,7 +332,7 @@ public class FlinkTableITCase {
                 .withSchema(new Schema().field("category", Types.STRING()).field("value", Types.INT()));
         desc.registerTableSourceAndSink("test");
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(desc);
+        final Map<String, String> propertiesMap = desc.toProperties();
         final TableSink<?> sink = TableFactoryService.find(BatchTableSinkFactory.class, propertiesMap)
                 .createBatchTableSink(propertiesMap);
         final TableSource<?> source = TableFactoryService.find(BatchTableSourceFactory.class, propertiesMap)
@@ -378,7 +377,7 @@ public class FlinkTableITCase {
                 .inAppendMode();
         desc.registerTableSink("test");
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(desc);
+        final Map<String, String> propertiesMap = desc.toProperties();
         final TableSink<?> sink = TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
                 .createStreamTableSink(propertiesMap);
 
@@ -411,7 +410,7 @@ public class FlinkTableITCase {
                 .withSchema(new Schema().field("category", Types.STRING()).field("value", Types.INT()));
         desc.registerTableSink("test");
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(desc);
+        final Map<String, String> propertiesMap = desc.toProperties();
         final TableSink<?> sink = TableFactoryService.find(BatchTableSinkFactory.class, propertiesMap)
                 .createBatchTableSink(propertiesMap);
 
@@ -455,7 +454,7 @@ public class FlinkTableITCase {
                 .inAppendMode();
         desc.registerTableSink("test");
 
-        final Map<String, String> propertiesMap = DescriptorProperties.toJavaMap(desc);
+        final Map<String, String> propertiesMap = desc.toProperties();
         final TableSink<?> sink = TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
                 .createStreamTableSink(propertiesMap);
 


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
- updated Flink version from `1.6.0` to `1.7.2`
- updated Flink scala version from `2.11` to `2.12`
- fixed table API compatibility issues

**Purpose of the change**
To address https://github.com/pravega/flink-connectors/issues/213

**What the code does**
updated flink version for the connector and resolved table API compatibility issues

**How to verify it**
./gradlew clean build should pass
SQL client interaction with Pravega should succeed