### PR TITLE
[issue-226] Fix incorrect artifact version label

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -26,7 +26,7 @@ compileJava {
     ])
 }
 
-archivesBaseName = "pravega-connectors-flink_2.11"
+archivesBaseName = "pravega-connectors-flink_" + flinkScalaVersion
 
 assemble.dependsOn(shadowJar)
 


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
  * changed archive base name to derive scala version label from gradle properties

**Purpose of the change**
To address https://github.com/pravega/flink-connectors/issues/226

**What the code does**
fixes the connect artifact label to represent correct scala version support 

**How to verify it**
`./gradlew clean install` should produce connector artifact to local maven cache with the name `pravega-connectors-flink_2.12*.jar`