### PR TITLE
[issue-228] Allow configuring maximum outstanding checkpoint request

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
@@ -29,6 +29,7 @@ abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStreamingRead
 
     private static final Time DEFAULT_EVENT_READ_TIMEOUT = Time.seconds(1);
     private static final Time DEFAULT_CHECKPOINT_INITIATE_TIMEOUT = Time.seconds(5);
+    private static final int  DEFAULT_MAX_OUTSTANDING_CHECKPOINT_REQUEST = 3;
 
     protected String uid;
     protected String readerGroupScope;
@@ -36,10 +37,12 @@ abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStreamingRead
     protected Time readerGroupRefreshTime;
     protected Time checkpointInitiateTimeout;
     protected Time eventReadTimeout;
+    protected int maxOutstandingCheckpointRequest;
 
     protected AbstractStreamingReaderBuilder() {
         this.checkpointInitiateTimeout = DEFAULT_CHECKPOINT_INITIATE_TIMEOUT;
         this.eventReadTimeout = DEFAULT_EVENT_READ_TIMEOUT;
+        this.maxOutstandingCheckpointRequest = DEFAULT_MAX_OUTSTANDING_CHECKPOINT_REQUEST;
     }
 
     /**
@@ -109,6 +112,16 @@ abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStreamingRead
         return builder();
     }
 
+    /**
+     * Configures the maximum outstanding checkpoint request to Pravega.
+     *
+     * @param maxOutstandingCheckpointRequest maximum outstanding checkpoint request.
+     */
+    public B withMaxOutstandingCheckpointRequest(int maxOutstandingCheckpointRequest) {
+        this.maxOutstandingCheckpointRequest = maxOutstandingCheckpointRequest;
+        return builder();
+    }
+
     protected abstract DeserializationSchema<T> getDeserializationSchema();
 
     /**
@@ -145,6 +158,7 @@ abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStreamingRead
         // rgConfig
         ReaderGroupConfig.ReaderGroupConfigBuilder rgConfigBuilder = ReaderGroupConfig
                 .builder()
+                .maxOutstandingCheckpointRequest(this.maxOutstandingCheckpointRequest)
                 .disableAutomaticCheckpoints();
         if (this.readerGroupRefreshTime != null) {
             rgConfigBuilder.groupRefreshTimeMillis(this.readerGroupRefreshTime.toMilliseconds());

--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
@@ -113,8 +113,8 @@ abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStreamingRead
     }
 
     /**
-     * Configures the maximum outstanding checkpoint request to Pravega (default=3).
-     * In situations where an excessive checkpoint request is being triggered to Pravega,
+     * Configures the maximum outstanding checkpoint requests to Pravega (default=3).
+     * Upon requesting more checkpoints than the specified maximum,
      * (say a checkpoint request timesout on the ReaderCheckpointHook but Pravega is still working on it),
      * this configurations allows Pravega to limit any further checkpoint request being made to the ReaderGroup.
      * This configuration is particularly relevant when multiple checkpoint requests need to be honored (e.g., frequent savepoint requests being triggered concurrently).

--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
@@ -113,7 +113,11 @@ abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStreamingRead
     }
 
     /**
-     * Configures the maximum outstanding checkpoint request to Pravega.
+     * Configures the maximum outstanding checkpoint request to Pravega (default=3).
+     * In situations where an excessive checkpoint request is being triggered to Pravega,
+     * (say a checkpoint request timesout on the ReaderCheckpointHook but Pravega is still working on it),
+     * this configurations allows Pravega to limit any further checkpoint request being made to the ReaderGroup.
+     * This configuration can be useful when multiple checkpoint request needs to be honored (e.g., frequent savepoint request being triggered).
      *
      * @param maxOutstandingCheckpointRequest maximum outstanding checkpoint request.
      */

--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
@@ -117,7 +117,7 @@ abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStreamingRead
      * In situations where an excessive checkpoint request is being triggered to Pravega,
      * (say a checkpoint request timesout on the ReaderCheckpointHook but Pravega is still working on it),
      * this configurations allows Pravega to limit any further checkpoint request being made to the ReaderGroup.
-     * This configuration can be useful when multiple checkpoint request needs to be honored (e.g., frequent savepoint request being triggered).
+     * This configuration is particularly relevant when multiple checkpoint requests need to be honored (e.g., frequent savepoint requests being triggered concurrently).
      *
      * @param maxOutstandingCheckpointRequest maximum outstanding checkpoint request.
      */

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -78,6 +78,7 @@ public class FlinkPravegaReaderTest {
     private static final IntegerDeserializationSchema DESERIALIZATION_SCHEMA = new TestDeserializationSchema();
     private static final Time READER_TIMEOUT = Time.seconds(1);
     private static final Time CHKPT_TIMEOUT = Time.seconds(1);
+    private static final int MAX_OUTSTANDING_CHECKPOINT_REQUEST = 5;
 
     // region Source Function Tests
 
@@ -213,6 +214,7 @@ public class FlinkPravegaReaderTest {
                 .forStream(SAMPLE_STREAM, SAMPLE_CUT)
                 .withReaderGroupScope(SAMPLE_SCOPE)
                 .withReaderGroupName(GROUP_NAME)
+                .withMaxOutstandingCheckpointRequest(MAX_OUTSTANDING_CHECKPOINT_REQUEST)
                 .withReaderGroupRefreshTime(GROUP_REFRESH_TIME);
 
         FlinkPravegaReader<Integer> reader = builder.buildSourceFunction();
@@ -220,6 +222,7 @@ public class FlinkPravegaReaderTest {
         assertNotNull(reader.hookUid);
         assertNotNull(reader.clientConfig);
         assertEquals(-1L, reader.readerGroupConfig.getAutomaticCheckpointIntervalMillis());
+        assertEquals(MAX_OUTSTANDING_CHECKPOINT_REQUEST, reader.readerGroupConfig.getMaxOutstandingCheckpointRequest());
         assertEquals(GROUP_REFRESH_TIME.toMilliseconds(), reader.readerGroupConfig.getGroupRefreshTimeMillis());
         assertEquals(GROUP_NAME, reader.readerGroupName);
         assertEquals(Collections.singletonMap(SAMPLE_STREAM, SAMPLE_CUT), reader.readerGroupConfig.getStartingStreamCuts());


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
  * enabled reader to accept maximum outstanding checkpoint request parameter

**Purpose of the change**
To address https://github.com/pravega/flink-connectors/issues/228

**What the code does**
Made changes to `FlinkPravegaReader` builder to accept the maximum outstanding checkpoint request parameter to be used by the `ReaderGroupConfig` 

**How to verify it**
./gradlew clean build should pass