### PR TITLE
[issue-134] FlinkPravegWriterITCase testExactlyOnceWriter fails randomly

### DIFF
--- a/src/test/java/io/pravega/connectors/flink/ThrottledIntegerGeneratingSource.java
+++ b/src/test/java/io/pravega/connectors/flink/ThrottledIntegerGeneratingSource.java
@@ -99,13 +99,16 @@ public class ThrottledIntegerGeneratingSource
         // note: this indicates that to handle finite jobs with 2PC outputs more
         // easily, we need a primitive like "finish-with-checkpoint" in Flink
 
+        // FLIP-34 will address this shortcomings which will take care of completing a savepoint/checkpoint
+        // when the task is finishing successfully ensuring the end-to-end exactly once guarantee for the sink
+
         final long lastCheckpoint;
         synchronized (ctx.getCheckpointLock()) {
             lastCheckpoint = this.lastCheckpointTriggered;
         }
 
         synchronized (this.blocker) {
-            while (this.lastCheckpointConfirmed <= lastCheckpoint + 1) {
+            while (this.lastCheckpointConfirmed <= lastCheckpoint + 4) {
                 this.blocker.wait();
             }
         }


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
  * updated source simulator to wait for few more checkpoints to finish before closing down

**Purpose of the change**
To address the issue https://github.com/pravega/flink-connectors/issues/134

**What the code does**
The source simulator waits for the few number of checkpoint operations to complete giving enough time for the sink operator to commit the ongoing transaction.

**How to verify it**
./gradlew clean build should not fail for the `testExactlyOnceWriter` test case