### PR TITLE
[issue-241] Update Pravega version to latest master

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.6.0-SNAPSHOT
-pravegaVersion=0.5.0-2223.ce3ba81-SNAPSHOT
+pravegaVersion=0.6.0-50.51c766c-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
  * Pravega version bumped to 0.6.0-50.51c766c-SNAPSHOT

**Purpose of the change**
Fixes https://github.com/pravega/flink-connectors/issues/241

**What the code does**
updates the Pravega version from both gradle configuration as well as the sub-module

**How to verify it**
./gradlew clean build should pass