### PR TITLE
[issue-245] Update Pravega version in r0.5 branch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.5.0-SNAPSHOT
-pravegaVersion=0.5.0-2223.ce3ba81-SNAPSHOT
+pravegaVersion=0.5.0-2269.6f8a820-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatTest.java
@@ -191,7 +191,7 @@ public class FlinkPravegaOutputFormatTest {
                 .build();
 
         FlinkPravegaOutputFormat<String> spyFlinkPravegaOutputFormat = spy(flinkPravegaOutputFormat);
-        doReturn(clientFactory).when(spyFlinkPravegaOutputFormat).createClientFactory(stream.getScope(), clientConfig);
+        doReturn(clientFactory).when(spyFlinkPravegaOutputFormat).createClientFactory(anyString(), anyObject());
         return spyFlinkPravegaOutputFormat;
     }
 


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
- Updated Pravega version to 0.5.0-2269.6f8a820-SNAPSHOT

**Purpose of the change**
Fixes https://github.com/pravega/flink-connectors/issues/245

**What the code does**
bumped Pravega version to the latest from Pravega `r0.5` branch in preparation of `r0.5` release

**How to verify it**
`./gradlew clean build` should pass