### PR TITLE
[issue-250] Update Pravega version in r0.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.5.0-SNAPSHOT
-pravegaVersion=0.5.0-2269.6f8a820-SNAPSHOT
+pravegaVersion=0.5.0-2300.352da54-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
  * update pravega version to 0.5.0-2300.352da54-SNAPSHOT
  * update pravega submodule commit to 352da549e729cadf49b88c043d6acd4818045f33

**Purpose of the change**
Fixes https://github.com/pravega/flink-connectors/issues/250

**What the code does**
Pravega version from gradle properties is updated to latest r0.5 snapshot artifact 

**How to verify it**
`./gradlew clean build` should pass