### PR TITLE
[issue-261] Update to Pravega 0.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.6.0-SNAPSHOT
-pravegaVersion=0.6.0-50.51c766c-SNAPSHOT
+pravegaVersion=0.6.0-50.f6fe3a4-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatTest.java
@@ -14,8 +14,8 @@ import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.Stream;
 import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.runtime.util.DirectExecutorService;
 import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.runtime.util.DirectExecutorService;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -191,7 +192,7 @@ public class FlinkPravegaOutputFormatTest {
                 .build();
 
         FlinkPravegaOutputFormat<String> spyFlinkPravegaOutputFormat = spy(flinkPravegaOutputFormat);
-        doReturn(clientFactory).when(spyFlinkPravegaOutputFormat).createClientFactory(stream.getScope(), clientConfig);
+        doReturn(clientFactory).when(spyFlinkPravegaOutputFormat).createClientFactory(anyString(), any());
         return spyFlinkPravegaOutputFormat;
     }
 


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
Pravega version bumped to 0.6.0-50.f6fe3a4-SNAPSHOT
Fix failed tests.

**Purpose of the change**
Fixes #261 

**What the code does**
Updates the Pravega version from both gradle configuration as well as the sub-module
Updates the tests with a new `clientFactory` to avoid `RetriesExhaustedException` 

**How to verify it**
./gradlew clean build should pass