### PR TITLE
[issue-267] Update Connector version to 0.5.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,8 @@ gradleMkdocsPluginVersion=1.1.0
 jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.5.1-SNAPSHOT
-pravegaVersion=0.5.0
+connectorVersion=0.5.1
+pravegaVersion=0.5.1
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Updated Pravega and Connector version to `0.5.1`
- Updated Pravega sub-module commit to `v0.5.1`

**Purpose of the change**
Fixes #267 
 
**What the code does**
gradle.properties and Pravega sub-module configuration changes

**How to verify it**
./gradlew clean build should pass
