### PR TITLE
[issue-261] Update to latest Pravega 0.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.6.0-SNAPSHOT
-pravegaVersion=0.6.0-50.f6fe3a4-SNAPSHOT
+pravegaVersion=0.6.0-50.cd6bfe7-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
Pravega version bumped to `0.6.0-50.cd6bfe7-SNAPSHOT`

**Purpose of the change**
Fixes #261

**What the code does**
Updates the Pravega version from both gradle configuration as well as the sub-module

**How to verify it**
`./gradlew clean build` should pass