### PR TITLE
[issue-263] Supporting multiple versions of Apache Flink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ cache:
 stages:
   - name: build
   - name: snapshot
-    if: branch = master AND NOT (type = pull_request)
+    # master or release branch
+    if: (branch = master OR branch =~ /^r[0-9]\.[0-9][\S]*/) AND NOT (type = pull_request)
 
 jobs:
   include:

--- a/build.gradle
+++ b/build.gradle
@@ -108,10 +108,11 @@ test {
 }
 
 dependencies {
-       compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-       testCompile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-       compileOnly group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
-       testCompile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
+    compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
+    testCompile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
+    compileOnly group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
+    testCompile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
+
     compile(group: 'io.pravega', name: 'pravega-client', version: pravegaVersion) {
         exclude group:  'org.slf4j', module: 'slf4j-api'
 

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -26,7 +26,12 @@ compileJava {
     ])
 }
 
-archivesBaseName = "pravega-connectors-flink_" + flinkScalaVersion
+def getFlinkMajorMinorVersion() {
+    String ver = flinkVersion
+    return ver.substring(0, ver.lastIndexOf('.'))
+}
+
+archivesBaseName = "pravega-connectors-flink-" + getFlinkMajorMinorVersion() + '_' + flinkScalaVersion
 
 assemble.dependsOn(shadowJar)
 


### PR DESCRIPTION
**Change log description**

- Change the `archiveBaseName` of the project
- Add more travis build branches

**Purpose of the change**
Supporting multiple versions of Apache Flink. 

After this is merged into master, we will create `r0.6-flink1.7` and `r0.6-flink1.8` branch to support Flink 1.7 and 1.8. The master will always be tracking the latest Flink release and the upcoming Pravega release. I'll raise a PR for Flink 1.9 connector into master. 

Future pull requests should target to `master` branch first if the issue is not related to a specific Flink version. We'll then cherrypick it into other release branches.

**What the code does**

Change `archiveBaseName` by adding a MajorMinor version of Flink in the middle.
Allow all Flink versions release branches into the travis build.

**How to verify it**
`./gradle clean build` should pass