### PR TITLE
Update To Pravega Version 0.6.0-50.fdc5698-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.6.0-SNAPSHOT
-pravegaVersion=0.6.0-50.e04ad5f-SNAPSHOT
+pravegaVersion=0.6.0-50.fdc5698-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
**Change log description**
Updates to latest Pravega Client version that includes commit `2acdc6` that fixes the Pravega Client to use the system TrustStore if no trust store is supplied by the user.

**Purpose of the change**
Without this fix to Pravega Client the user MUST supply a TrustStore even if Pravega is using SSL certificates that would be trusted by the system trust store.  This impacts the usability of the connector in certain scenarios.
