### PR TITLE
[issue-265] Reader side: Implement watermark with Pravega (for master branch aka. Flink 1.9)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@
 language: java
 install: true
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 # the secure configurations in env: section is for BINTRAY_USER=<USER> and BINTRAY_KEY=<KEY> properties
 # which will be used for publishing artifacts to snapshot repository
@@ -55,5 +55,5 @@ notifications:
       secure: Gv0RJx1Sa/y5fmvLNwY+2ivfWZYCM0ekrr6UAHqsegnid6P/DFZrSrfSpwvcVh2OVNH8DHLV0BoiuDJ7amtl1eMDMXz5/lLz8tFWFKaHv4yDSadm8ILY/KnYUoP4IRuM3NyKQmBrmZB9Or5KFXboG6ex6UkgbuYy0Zyl6syEe168Iw8hlCRx26Jei7/y+8eE2MIGFh09TLRZ/944YbULum9H3KQLYv8nFdPc7GmR5AK461fnwZ7iYjb7MXkCctE5Vml3p9+2Qliv1ZJqNsQeKmSFW6IhiP6pNZ1V8VJEWMQmX/nBr9745l/N+CoLQz9ajLonlxn9xHdWms4TEu1ynFk6uxEJjlcpXcvcEaKhqAKcTMl0GMMRab2m+/Vt3S/VutJnVXQmnhZGT9glLFQHwcdHNqM/LEbXtyisB7zmGImUQpF2InCwO25IXug5gv64IfOHGMzL56yNIhbRgBY9Ud4Tux+pmkV5ZxJiBkul7/FiHQX7tQLUrzQosD0oyCOmaWD7kmbt15A0TOkLgup4HE+sSS1ASwisa7J2+HsbI3Upy3rNVKuIJP0L4KSTn4HSlDlMLLcWM+nz/YCEfuwSRXJTIstotNYHdsLUZAZSYAX7ejpeiuBRed4a4AlCROeKbKKwCcSvqCOjmCaPTpwJAGeJByOXLL2hfQzpDMKCIKM=
   email:
     - tom.kaitchuck@dell.com
-    - vijayaraghavan.srinivasaraghavan@emc.com
+    - brian.zhou@emc.com
     - fpj@pravega.io

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ usePravegaVersionSubModule=false
 
 # These properties are only needed for publishing to maven central
 # Pravega Signing Key
-signing.keyId=05949AF6
+signing.keyId=F56ED3A7
 # This will be defaulted to ~/.gnupg/secring.gpg if not provided as a command line property
 signing.secretKeyRingFile=
 

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -62,6 +62,6 @@ tasks.withType(Test) {
     testLogging.showStackTraces = true
     testLogging.events = ["PASSED", "FAILED"]
     maxParallelForks = System.properties['maxParallelForks'] ? System.properties['maxParallelForks'].toInteger() : 1
-    minHeapSize = "128m"
-    maxHeapSize = "512m"
+    minHeapSize = "512m"
+    maxHeapSize = "2048m"
 }

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaJsonTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaJsonTableSource.java
@@ -9,11 +9,13 @@
  */
 package io.pravega.connectors.flink;
 
+import io.pravega.connectors.flink.watermark.AssignerWithTimeWindows;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.descriptors.ConnectorDescriptor;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.SerializedValue;
 
 import java.util.function.Supplier;
 
@@ -82,6 +84,11 @@ public class FlinkPravegaJsonTableSource extends FlinkPravegaTableSource {
                     io.pravega.connectors.flink.serialization.JsonRowDeserializationSchema(jsonSchemaToReturnType(getTableSchema()));
             deserSchema.setFailOnMissingField(failOnMissingField);
             return deserSchema;
+        }
+
+        @Override
+        protected SerializedValue<AssignerWithTimeWindows<Row>> getAssignerWithTimeWindows() {
+            return null;
         }
 
         /**

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -20,10 +20,13 @@ import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
+import io.pravega.connectors.flink.watermark.AssignerWithTimeWindows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Gauge;
@@ -32,8 +35,14 @@ import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
 import org.apache.flink.streaming.api.checkpoint.ExternallyInducedSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.SerializedValue;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -95,6 +104,9 @@ public class FlinkPravegaReader<T>
     // The supplied event deserializer.
     final DeserializationSchema<T> deserializationSchema;
 
+    // The supplied event timestamp and watermark assigner.
+    final SerializedValue<AssignerWithTimeWindows<T>> assignerWithTimeWindows;
+
     // the timeout for reading events from Pravega
     final Time eventReadTimeout;
 
@@ -136,13 +148,16 @@ public class FlinkPravegaReader<T>
      * @param readerGroupScope          The reader group scope name.
      * @param readerGroupName           The reader group name.
      * @param deserializationSchema     The implementation to deserialize events from Pravega streams.
+     * @param assignerWithTimeWindows   The serialized value of the implementation to extract timestamp from deserialized events (only in event-time mode).
      * @param eventReadTimeout          The event read timeout.
      * @param checkpointInitiateTimeout The checkpoint initiation timeout.
      * @param enableMetrics             Flag to indicate whether metrics needs to be enabled or not.
      */
     protected FlinkPravegaReader(String hookUid, ClientConfig clientConfig,
                                  ReaderGroupConfig readerGroupConfig, String readerGroupScope, String readerGroupName,
-                                 DeserializationSchema<T> deserializationSchema, Time eventReadTimeout, Time checkpointInitiateTimeout,
+                                 DeserializationSchema<T> deserializationSchema,
+                                 SerializedValue<AssignerWithTimeWindows<T>> assignerWithTimeWindows,
+                                 Time eventReadTimeout, Time checkpointInitiateTimeout,
                                  boolean enableMetrics) {
 
         this.hookUid = Preconditions.checkNotNull(hookUid, "hookUid");
@@ -154,6 +169,7 @@ public class FlinkPravegaReader<T>
         this.eventReadTimeout = Preconditions.checkNotNull(eventReadTimeout, "eventReadTimeout");
         this.checkpointInitiateTimeout = Preconditions.checkNotNull(checkpointInitiateTimeout, "checkpointInitiateTimeout");
         this.enableMetrics = enableMetrics;
+        this.assignerWithTimeWindows = assignerWithTimeWindows;
     }
 
     /**
@@ -164,6 +180,57 @@ public class FlinkPravegaReader<T>
         //       See https://github.com/pravega/flink-connectors/issues/130.
         log.info("Creating reader group: {}/{} for the Flink job", this.readerGroupScope, this.readerGroupName);
         createReaderGroup();
+        if (isEventTimeMode()) {
+            Preconditions.checkArgument(readerGroup.getStreamNames().size() == 1,
+                    "Only 1 Pravega stream is allowed in the event-time mode");
+
+        }
+    }
+
+    private boolean isEventTimeMode() {
+        return assignerWithTimeWindows != null;
+    }
+
+    private long autoWatermarkInterval() {
+        return getRuntimeContext().getExecutionConfig().getAutoWatermarkInterval();
+    }
+
+    private class PeriodicWatermarkEmitter implements ProcessingTimeCallback {
+
+        private EventStreamReader<?> pravegaReader;
+        private final SourceContext<?> ctx;
+        private final ProcessingTimeService timerService;
+        private long lastWatermarkTimestamp;
+        private AssignerWithTimeWindows<?> userAssigner;
+
+        protected PeriodicWatermarkEmitter(
+                EventStreamReader<?> pravegaReader, SourceContext<?> ctx, ClassLoader userCodeClassLoader,
+                ProcessingTimeService timerService) throws Exception {
+            this.pravegaReader = Preconditions.checkNotNull(pravegaReader);
+            this.ctx = Preconditions.checkNotNull(ctx);
+            this.timerService = Preconditions.checkNotNull(timerService);
+            this.lastWatermarkTimestamp = Long.MIN_VALUE;
+            this.userAssigner = assignerWithTimeWindows.deserializeValue(userCodeClassLoader);
+        }
+
+        protected void start() {
+            timerService.registerTimer(timerService.getCurrentProcessingTime() + autoWatermarkInterval(), this);
+        }
+
+        @Override
+        public void onProcessingTime(long timestamp) {
+            Stream stream = Stream.of(readerGroup.getStreamNames().iterator().next());
+            Watermark watermark = userAssigner.getWatermark(pravegaReader.getCurrentTimeWindow(stream));
+
+            if (watermark != null && watermark.getTimestamp() > lastWatermarkTimestamp) {
+                lastWatermarkTimestamp = watermark.getTimestamp();
+                log.debug("Emit watermark with timestamp: {}", watermark.getTimestamp());
+                ctx.emitWatermark(watermark);
+            }
+
+            // schedule the next watermark
+            timerService.registerTimer(timerService.getCurrentProcessingTime() + autoWatermarkInterval(), this);
+        }
     }
 
     // ------------------------------------------------------------------------
@@ -182,6 +249,23 @@ public class FlinkPravegaReader<T>
 
             log.info("Starting Pravega reader '{}' for controller URI {}", readerId, this.clientConfig.getControllerURI());
 
+            long previousTimestamp = Long.MIN_VALUE;
+            AssignerWithTimeWindows<T> assigner = null;
+            // If it is event time, register a watermark emitter
+            if (isEventTimeMode()) {
+                assigner = assignerWithTimeWindows.deserializeValue(getRuntimeContext().getUserCodeClassLoader());
+                PeriodicWatermarkEmitter periodicEmitter = new PeriodicWatermarkEmitter(
+                        pravegaReader,
+                        ctx,
+                        getRuntimeContext().getUserCodeClassLoader(),
+                        ((StreamingRuntimeContext) getRuntimeContext()).getProcessingTimeService());
+
+                log.info("Periodic Watermark Emitter for Reader ID: {} has started with an interval of {}", readerId,
+                        autoWatermarkInterval());
+
+                periodicEmitter.start();
+            }
+
             // main work loop, which this task is running
             while (this.running) {
                 final EventRead<T> eventRead = pravegaReader.readNextEvent(eventReadTimeout.toMilliseconds());
@@ -198,7 +282,13 @@ public class FlinkPravegaReader<T>
                     }
 
                     synchronized (ctx.getCheckpointLock()) {
-                        ctx.collect(event);
+                        if (isEventTimeMode()) {
+                            long currentTimestamp = assigner.extractTimestamp(event, previousTimestamp);
+                            ctx.collectWithTimestamp(event, currentTimestamp);
+                            previousTimestamp = currentTimestamp;
+                        } else {
+                            ctx.collect(event);
+                        }
                     }
                 }
 
@@ -206,6 +296,10 @@ public class FlinkPravegaReader<T>
                 if (eventRead.isCheckpoint()) {
                     triggerCheckpoint(eventRead.getCheckpointName());
                 }
+            }
+
+            if (isEventTimeMode()) {
+                ctx.emitWatermark(Watermark.MAX_WATERMARK);
             }
         }
     }
@@ -225,6 +319,11 @@ public class FlinkPravegaReader<T>
         createReaderGroup();
         if (enableMetrics) {
             registerMetrics();
+        }
+        if (isEventTimeMode()) {
+            Preconditions.checkArgument(autoWatermarkInterval() > 0,
+                    "Periodic watermark interval should be positive, " +
+                            "please use env.getConfig().setAutoWatermarkInterval() to set a positive number. Recommended value: 10000");
         }
     }
 
@@ -473,6 +572,7 @@ public class FlinkPravegaReader<T>
     public static class Builder<T> extends AbstractStreamingReaderBuilder<T, Builder<T>> {
 
         private DeserializationSchema<T> deserializationSchema;
+        private SerializedValue<AssignerWithTimeWindows<T>> assignerWithTimeWindows;
 
         protected Builder<T> builder() {
             return this;
@@ -482,16 +582,38 @@ public class FlinkPravegaReader<T>
          * Sets the deserialization schema.
          *
          * @param deserializationSchema The deserialization schema
+         * @return Builder instance.
          */
         public Builder<T> withDeserializationSchema(DeserializationSchema<T> deserializationSchema) {
             this.deserializationSchema = deserializationSchema;
             return builder();
         }
 
+        /**
+         * Sets the timestamp and watermark assigner.
+         *
+         * @param assignerWithTimeWindows The timestamp and watermark assigner.
+         * @return Builder instance.
+         */
+        public Builder<T> withTimestampAssigner(AssignerWithTimeWindows<T> assignerWithTimeWindows) {
+            try {
+                ClosureCleaner.clean(assignerWithTimeWindows, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
+                this.assignerWithTimeWindows = new SerializedValue<>(assignerWithTimeWindows);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("The given assigner is not serializable", e);
+            }
+            return this;
+        }
+
         @Override
         protected DeserializationSchema<T> getDeserializationSchema() {
             Preconditions.checkState(deserializationSchema != null, "Deserialization schema must not be null.");
             return deserializationSchema;
+        }
+
+        @Override
+        protected SerializedValue<AssignerWithTimeWindows<T>> getAssignerWithTimeWindows() {
+            return assignerWithTimeWindows;
         }
 
         /**

--- a/src/main/java/io/pravega/connectors/flink/util/ConnectorConfigurations.java
+++ b/src/main/java/io/pravega/connectors/flink/util/ConnectorConfigurations.java
@@ -15,10 +15,13 @@ import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.Credentials;
 import io.pravega.connectors.flink.PravegaConfig;
 import io.pravega.connectors.flink.PravegaWriterMode;
+import io.pravega.connectors.flink.watermark.AssignerWithTimeWindows;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.InstantiationUtil;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -45,6 +48,7 @@ import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO_E
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO_SCOPE;
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO_START_STREAMCUT;
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO_STREAM;
+import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_USER_TIMESTAMP_ASSIGNER;
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_MODE;
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_MODE_VALUE_ATLEAST_ONCE;
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_MODE_VALUE_EXACTLY_ONCE;
@@ -82,6 +86,9 @@ public final class ConnectorConfigurations {
     // reader stream info
     private List<StreamWithBoundaries> readerStreams = new ArrayList<>();
 
+    // reader user info
+    private Optional<AssignerWithTimeWindows<Row>> assignerWithTimeWindows;
+
     // writer info
     private Stream writerStream;
     private Optional<PravegaWriterMode> writerMode;
@@ -111,6 +118,7 @@ public final class ConnectorConfigurations {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void populateReaderConfig(DescriptorProperties descriptorProperties) {
         uid = descriptorProperties.getOptionalString(CONNECTOR_READER_READER_GROUP_UID);
         rgScope = descriptorProperties.getOptionalString(CONNECTOR_READER_READER_GROUP_SCOPE);
@@ -118,6 +126,14 @@ public final class ConnectorConfigurations {
         refreshInterval = descriptorProperties.getOptionalLong(CONNECTOR_READER_READER_GROUP_REFRESH_INTERVAL);
         eventReadTimeoutInterval = descriptorProperties.getOptionalLong(CONNECTOR_READER_READER_GROUP_EVENT_READ_TIMEOUT_INTERVAL);
         checkpointInitiateTimeoutInterval = descriptorProperties.getOptionalLong(CONNECTOR_READER_READER_GROUP_CHECKPOINT_INITIATE_TIMEOUT_INTERVAL);
+
+        final Optional<Class<AssignerWithTimeWindows>> assignerClass = descriptorProperties.getOptionalClass(
+                CONNECTOR_READER_USER_TIMESTAMP_ASSIGNER, AssignerWithTimeWindows.class);
+        if (assignerClass.isPresent()) {
+            assignerWithTimeWindows = Optional.of((AssignerWithTimeWindows<Row>) InstantiationUtil.instantiate(assignerClass.get()));
+        } else {
+            assignerWithTimeWindows = Optional.empty();
+        }
 
         if (!defaultScope.isPresent() && !rgScope.isPresent()) {
             throw new ValidationException("Must supply either " + CONNECTOR_READER_READER_GROUP_SCOPE + " or " + CONNECTOR_CONNECTION_CONFIG_DEFAULT_SCOPE);

--- a/src/main/java/io/pravega/connectors/flink/watermark/AssignerWithTimeWindows.java
+++ b/src/main/java/io/pravega/connectors/flink/watermark/AssignerWithTimeWindows.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink.watermark;
+
+import io.pravega.client.stream.TimeWindow;
+import org.apache.flink.annotation.Public;
+import org.apache.flink.streaming.api.functions.TimestampAssigner;
+import org.apache.flink.streaming.api.watermark.Watermark;
+
+import javax.annotation.Nullable;
+
+@Public
+public interface AssignerWithTimeWindows<T> extends TimestampAssigner<T> {
+
+    // app must implement the timestamp extraction
+    @Nullable
+    Watermark getWatermark(TimeWindow window);
+}

--- a/src/main/java/io/pravega/connectors/flink/watermark/LowerBoundAssigner.java
+++ b/src/main/java/io/pravega/connectors/flink/watermark/LowerBoundAssigner.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink.watermark;
+
+import io.pravega.client.stream.TimeWindow;
+import org.apache.flink.streaming.api.watermark.Watermark;
+
+public abstract class LowerBoundAssigner<T> implements AssignerWithTimeWindows<T> {
+
+    private static final long serialVersionUID = 2069173720413829850L;
+
+    public LowerBoundAssigner() {
+    }
+
+    @Override
+    public abstract long extractTimestamp(T element, long previousElementTimestamp);
+
+    // built-in watermark implementation which emits the lower bound - 1
+    @Override
+    public Watermark getWatermark(TimeWindow timeWindow) {
+        // There is no LowerBound watermark if we're near the head of the stream
+        if (timeWindow == null || timeWindow.isNearHeadOfStream()) {
+            return null;
+        }
+        return timeWindow.getLowerTimeBound() == Long.MIN_VALUE ?
+                new Watermark(Long.MIN_VALUE) :
+                new Watermark(timeWindow.getLowerTimeBound() - 1L);
+    }
+}
+

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatITCase.java
@@ -85,14 +85,16 @@ public class FlinkPravegaInputFormatITCase extends AbstractTestBase {
                         eventWriter1,
                         numElements1,
                         numElements1 + 1, // no need to block writer for a batch test
-                        0
+                        0,
+                        false
                 );
 
                 final ThrottledIntegerWriter producer2 = new ThrottledIntegerWriter(
                         eventWriter2,
                         numElements2,
                         numElements2 + 1, // no need to block writer for a batch test
-                        0
+                        0,
+                        false
                 )
         ) {
             // write batch input
@@ -143,7 +145,8 @@ public class FlinkPravegaInputFormatITCase extends AbstractTestBase {
                         eventWriter,
                         numElements,
                         numElements + 1, // no need to block writer for a batch test
-                        0
+                        0,
+                        false
                 )
         ) {
             // write batch input

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderRGStateITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderRGStateITCase.java
@@ -99,7 +99,8 @@ public class FlinkPravegaReaderRGStateITCase extends AbstractTestBase {
                      eventWriter,
                      NUM_STREAM_ELEMENTS,
                      NUM_STREAM_ELEMENTS / 2,
-                     1
+                     1,
+                     false
              )
         ) {
             producer.start();

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointITCase.java
@@ -111,7 +111,8 @@ public class FlinkPravegaReaderSavepointITCase extends TestLogger {
                         eventWriter,
                         numElements,
                         numElements / 2,  // the latest when the thread must be un-throttled
-                        1                 // the initial sleep time per element
+                        1,                 // the initial sleep time per element
+                        false
                 )
 
         ) {

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -20,23 +20,34 @@ import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.TimeWindow;
 import io.pravega.client.stream.impl.EventReadImpl;
 import io.pravega.client.stream.impl.StreamCutImpl;
 import io.pravega.connectors.flink.utils.IntegerDeserializationSchema;
 import io.pravega.connectors.flink.utils.StreamSourceOperatorTestHarness;
+import io.pravega.connectors.flink.watermark.AssignerWithTimeWindows;
+import io.pravega.connectors.flink.watermark.LowerBoundAssigner;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.util.SerializedValue;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.stubbing.Answer;
 
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -52,6 +63,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -66,7 +78,9 @@ import static org.mockito.Mockito.when;
 public class FlinkPravegaReaderTest {
 
     private static final String SAMPLE_SCOPE = "scope";
-    private static final Stream SAMPLE_STREAM = Stream.of(SAMPLE_SCOPE, "stream");
+    private static final String SAMPLE_STREAM_NAME = "stream";
+    private static final String SAMPLE_COMPLETE_STREAM_NAME = SAMPLE_SCOPE + '/' + SAMPLE_STREAM_NAME;
+    private static final Stream SAMPLE_STREAM = Stream.of(SAMPLE_SCOPE, SAMPLE_STREAM_NAME);
     private static final Segment SAMPLE_SEGMENT = new Segment(SAMPLE_SCOPE, SAMPLE_STREAM.getStreamName(), 1);
     private static final StreamCut SAMPLE_CUT = new StreamCutImpl(SAMPLE_STREAM, Collections.singletonMap(SAMPLE_SEGMENT, 42L));
     private static final StreamCut SAMPLE_CUT2 = new StreamCutImpl(SAMPLE_STREAM, Collections.singletonMap(SAMPLE_SEGMENT, 1024L));
@@ -98,7 +112,8 @@ public class FlinkPravegaReaderTest {
     public void testRun() throws Exception {
         TestableFlinkPravegaReader<Integer> reader = createReader();
 
-        try (StreamSourceOperatorTestHarness<Integer, TestableFlinkPravegaReader<Integer>> testHarness = createTestHarness(reader, 1, 1, 0)) {
+        try (StreamSourceOperatorTestHarness<Integer, TestableFlinkPravegaReader<Integer>> testHarness =
+                     createTestHarness(reader, 1, 1, 0, TimeCharacteristic.ProcessingTime)) {
             testHarness.open();
 
             // prepare a sequence of events
@@ -144,6 +159,66 @@ public class FlinkPravegaReaderTest {
     }
 
     /**
+     * Tests the behavior of {@code run()} with watermark.
+     */
+    @Test
+    public void testRunWithWatermark() throws Exception {
+        TestableFlinkPravegaReader<Integer> reader = createReaderWithWatermark(new LowerBoundAssigner<Integer>() {
+            @Override
+            public long extractTimestamp(Integer element, long previousElementTimestamp) {
+                return element;
+            }
+        });
+
+        try (StreamSourceOperatorTestHarness<Integer, TestableFlinkPravegaReader<Integer>> testHarness =
+                     createTestHarness(reader, 1, 1, 0, TimeCharacteristic.EventTime)) {
+            // reset the auto watermark interval to 50 millisecond
+            testHarness.getExecutionConfig().setAutoWatermarkInterval(50);
+            testHarness.open();
+
+            // prepare a sequence of events with processing time progress
+            TestEventGenerator<Integer> evts = new TestEventGenerator<>();
+            when(reader.eventStreamReader.readNextEvent(anyLong()))
+                    .thenAnswer((Answer<EventRead<Integer>>) invocation -> {
+                        testHarness.setProcessingTime(1);
+                        return evts.event(1);
+                    })
+                    .thenAnswer((Answer<EventRead<Integer>>) invocation -> {
+                        testHarness.setProcessingTime(51);
+                        return evts.event(2);
+                    })
+                    .thenAnswer((Answer<EventRead<Integer>>) invocation -> {
+                        testHarness.setProcessingTime(101);
+                        return evts.event(TestDeserializationSchema.END_OF_STREAM);
+                    });
+            when(reader.eventStreamReader.getCurrentTimeWindow(anyObject()))
+                    .thenReturn(new TimeWindow(1L, 2L))
+                    .thenReturn(new TimeWindow(2L, 3L));
+
+            // run the source
+            testHarness.run();
+
+            // verify that the event stream was read until the end of stream
+            verify(reader.eventStreamReader, times(3)).readNextEvent(anyLong());
+            verify(reader.eventStreamReader, times(2)).getCurrentTimeWindow(anyObject());
+
+            Queue<Object> actual = testHarness.getOutput();
+            Queue<Object> expected = new ConcurrentLinkedQueue<>();
+            expected.add(record(1, 1));
+            // emit watermark (1 - 1 = 0)
+            expected.add(watermark(0));
+            expected.add(record(2, 2));
+            // emit watermark (2 - 1 = 1)
+            expected.add(watermark(1));
+            // automatic watermark at the end of stream
+            expected.add(watermark(Long.MAX_VALUE));
+
+            TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
+        }
+    }
+
+
+    /**
      * helper method to validate the metrics
      */
     private void validateMetricGroup(String prefix, String metric, MetricGroup readerGroupMetricGroup) {
@@ -158,7 +233,8 @@ public class FlinkPravegaReaderTest {
     public void testCancellation() throws Exception {
         TestableFlinkPravegaReader<Integer> reader = createReader();
 
-        try (StreamSourceOperatorTestHarness<Integer, TestableFlinkPravegaReader<Integer>> testHarness = createTestHarness(reader, 1, 1, 0)) {
+        try (StreamSourceOperatorTestHarness<Integer, TestableFlinkPravegaReader<Integer>> testHarness =
+                     createTestHarness(reader, 1, 1, 0, TimeCharacteristic.ProcessingTime)) {
             testHarness.open();
 
             // prepare a sequence of events
@@ -183,16 +259,37 @@ public class FlinkPravegaReaderTest {
         ReaderGroupConfig rgConfig = ReaderGroupConfig.builder().stream(SAMPLE_STREAM).build();
         boolean enableMetrics = true;
         return new TestableFlinkPravegaReader<>(
-                "hookUid", clientConfig, rgConfig, SAMPLE_SCOPE, GROUP_NAME, DESERIALIZATION_SCHEMA, READER_TIMEOUT, CHKPT_TIMEOUT, enableMetrics);
+                "hookUid", clientConfig, rgConfig, SAMPLE_SCOPE, GROUP_NAME, DESERIALIZATION_SCHEMA,
+                null, READER_TIMEOUT, CHKPT_TIMEOUT, enableMetrics);
+    }
+
+    /**
+     * Creates a {@link TestableFlinkPravegaReader} with event time and watermarking.
+     */
+    private static TestableFlinkPravegaReader<Integer> createReaderWithWatermark(AssignerWithTimeWindows<Integer> assignerWithTimeWindows) {
+        ClientConfig clientConfig = ClientConfig.builder().build();
+        ReaderGroupConfig rgConfig = ReaderGroupConfig.builder().stream(SAMPLE_STREAM).build();
+        boolean enableMetrics = true;
+
+        try {
+            ClosureCleaner.clean(assignerWithTimeWindows, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
+            SerializedValue<AssignerWithTimeWindows<Integer>> serializedAssigner =
+                    new SerializedValue<>(assignerWithTimeWindows);
+            return new TestableFlinkPravegaReader<>(
+                    "hookUid", clientConfig, rgConfig, SAMPLE_SCOPE, GROUP_NAME, DESERIALIZATION_SCHEMA,
+                    serializedAssigner, READER_TIMEOUT, CHKPT_TIMEOUT, enableMetrics);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("The given assigner is not serializable", e);
+        }
     }
 
     /**
      * Creates a test harness for a {@link SourceFunction}.
      */
     private <T, F extends SourceFunction<T>> StreamSourceOperatorTestHarness<T, F> createTestHarness(
-            F sourceFunction, int maxParallelism, int parallelism, int subtaskIndex) throws Exception {
-        StreamSourceOperatorTestHarness harness = new StreamSourceOperatorTestHarness<>(sourceFunction, maxParallelism, parallelism, subtaskIndex);
-        harness.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
+            F sourceFunction, int maxParallelism, int parallelism, int subtaskIndex, TimeCharacteristic timeCharacteristic) throws Exception {
+        StreamSourceOperatorTestHarness harness = new StreamSourceOperatorTestHarness<T, F>(sourceFunction, maxParallelism, parallelism, subtaskIndex);
+        harness.setTimeCharacteristic(timeCharacteristic);
         return harness;
     }
 
@@ -202,6 +299,21 @@ public class FlinkPravegaReaderTest {
     private static <T> StreamRecord<T> record(T evt) {
         return new StreamRecord<>(evt);
     }
+
+    /**
+     * Creates a {@link StreamRecord} for the given event with a timestamp.
+     */
+    private static <T> StreamRecord<T> record(T evt, long timestamp) {
+        return new StreamRecord<>(evt, timestamp);
+    }
+
+    /**
+     * Creates a {@link Watermark} with a timestamp.
+     */
+    private static Watermark watermark(long timestamp) {
+        return new Watermark(timestamp);
+    }
+
 
     // endregion
 
@@ -330,20 +442,26 @@ public class FlinkPravegaReaderTest {
         final ReaderGroupManager readerGroupManager = mock(ReaderGroupManager.class);
 
         @SuppressWarnings("unchecked")
+        final ReaderGroup readerGroup = mock(ReaderGroup.class);
+
+        @SuppressWarnings("unchecked")
         final EventStreamReader<T> eventStreamReader = mock(EventStreamReader.class);
 
         protected TestableFlinkPravegaReader(String hookUid, ClientConfig clientConfig,
                                              ReaderGroupConfig readerGroupConfig, String readerGroupScope,
                                              String readerGroupName, DeserializationSchema<T> deserializationSchema,
+                                             SerializedValue<AssignerWithTimeWindows<T>> assignerWithTimeWindows,
                                              Time eventReadTimeout, Time checkpointInitiateTimeout,
                                              boolean enableMetrics) {
-            super(hookUid, clientConfig, readerGroupConfig, readerGroupScope, readerGroupName, deserializationSchema, eventReadTimeout, checkpointInitiateTimeout, enableMetrics);
+            super(hookUid, clientConfig, readerGroupConfig, readerGroupScope, readerGroupName, deserializationSchema,
+                    assignerWithTimeWindows, eventReadTimeout, checkpointInitiateTimeout, enableMetrics);
         }
 
         @Override
         protected ReaderGroupManager createReaderGroupManager() {
             doNothing().when(readerGroupManager).createReaderGroup(readerGroupName, readerGroupConfig);
-            doReturn(mock(ReaderGroup.class)).when(readerGroupManager).getReaderGroup(readerGroupName);
+            doReturn(new HashSet<>(Arrays.asList(SAMPLE_COMPLETE_STREAM_NAME))).when(readerGroup).getStreamNames();
+            doReturn(readerGroup).when(readerGroupManager).getReaderGroup(readerGroupName);
             return readerGroupManager;
         }
 
@@ -366,6 +484,11 @@ public class FlinkPravegaReaderTest {
         @Override
         protected DeserializationSchema<Integer> getDeserializationSchema() {
             return DESERIALIZATION_SCHEMA;
+        }
+
+        @Override
+        protected SerializedValue<AssignerWithTimeWindows<Integer>> getAssignerWithTimeWindows() {
+            return null;
         }
     }
 

--- a/src/test/java/io/pravega/connectors/flink/utils/ThrottledIntegerWriter.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/ThrottledIntegerWriter.java
@@ -32,12 +32,14 @@ public class ThrottledIntegerWriter extends CheckedThread implements AutoCloseab
 
     private final Object blocker = new Object();
 
+    private boolean watermarkEnabled;
+
     private volatile boolean throttled;
 
     private volatile boolean running;
 
     public ThrottledIntegerWriter(EventStreamWriter<Integer> eventWriter,
-                                  int numValues, int blockAtNum, int sleepPerElement) {
+                                  int numValues, int blockAtNum, int sleepPerElement, boolean watermarkEnabled) {
 
         super("ThrottledIntegerWriter");
 
@@ -48,6 +50,7 @@ public class ThrottledIntegerWriter extends CheckedThread implements AutoCloseab
 
         this.running = true;
         this.throttled = true;
+        this.watermarkEnabled = watermarkEnabled;
     }
 
     @Override
@@ -71,6 +74,12 @@ public class ThrottledIntegerWriter extends CheckedThread implements AutoCloseab
             }
 
             eventWriter.writeEvent(String.valueOf(i), i).get();
+            if (watermarkEnabled && i % 100 == 0) {
+                eventWriter.noteTime(i);
+            }
+        }
+        if (watermarkEnabled) {
+            eventWriter.noteTime(numValues);
         }
     }
 


### PR DESCRIPTION
**Change log description**

**Purpose of the change**
  Same as the pull request #274 for `r0.6-flink1.7`, the `master` branch require only merging PRs rather than cherry-picking, I create this PR for the master branch.

**What the code does**
  Same as PR #274 , modified only 
- Change `ClosureCleaner.clean(obj, bool)` which is removed since Flink 1.8 into `ClosureCleaner.clean(obj, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, bool)`
- Change `TableValidationUtil` which is removed since Flink 1.9 into `TableSourceValidation`
