### PR TITLE
[issue-266] Writer side: Implement watermark with Pravega (for master branch aka. Flink 1.9)

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
@@ -27,10 +27,12 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
     private static final long DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS = 30000; // 30 seconds
 
     protected PravegaWriterMode writerMode;
+    protected boolean enableWatermark;
     protected Time txnLeaseRenewalPeriod;
 
     protected AbstractStreamingWriterBuilder() {
         writerMode = PravegaWriterMode.ATLEAST_ONCE;
+        enableWatermark = false;
         txnLeaseRenewalPeriod = Time.milliseconds(DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS);
     }
 
@@ -41,6 +43,16 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
      */
     public B withWriterMode(PravegaWriterMode writerMode) {
         this.writerMode = writerMode;
+        return builder();
+    }
+
+    /**
+     * Enable watermark.
+     *
+     * @param enableWatermark boolean
+     */
+    public B enableWatermark(boolean enableWatermark) {
+        this.enableWatermark = enableWatermark;
         return builder();
     }
 
@@ -76,6 +88,7 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
                 eventRouter,
                 writerMode,
                 txnLeaseRenewalPeriod.toMilliseconds(),
+                enableWatermark,
                 isMetricsEnabled());
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -183,7 +183,6 @@ public class FlinkPravegaReader<T>
         if (isEventTimeMode()) {
             Preconditions.checkArgument(readerGroup.getStreamNames().size() == 1,
                     "Only 1 Pravega stream is allowed in the event-time mode");
-
         }
     }
 
@@ -262,7 +261,6 @@ public class FlinkPravegaReader<T>
 
                 log.info("Periodic Watermark Emitter for Reader ID: {} has started with an interval of {}", readerId,
                         autoWatermarkInterval());
-
                 periodicEmitter.start();
             }
 
@@ -595,6 +593,7 @@ public class FlinkPravegaReader<T>
          * @param assignerWithTimeWindows The timestamp and watermark assigner.
          * @return Builder instance.
          */
+
         public Builder<T> withTimestampAssigner(AssignerWithTimeWindows<T> assignerWithTimeWindows) {
             try {
                 ClosureCleaner.clean(assignerWithTimeWindows, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableFactoryBase.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableFactoryBase.java
@@ -107,6 +107,7 @@ public abstract class FlinkPravegaTableFactoryBase {
         properties.add(CONNECTOR_WRITER_STREAM);
         properties.add(CONNECTOR_WRITER_MODE);
         properties.add(CONNECTOR_WRITER_TXN_LEASE_RENEWAL_INTERVAL);
+        properties.add(CONNECTOR_WRITER_ENABLE_WATERMARK);
         properties.add(CONNECTOR_WRITER_ROUTING_KEY_FILED_NAME);
 
         // schema
@@ -166,6 +167,7 @@ public abstract class FlinkPravegaTableFactoryBase {
         return formatFactory.createDeserializationSchema(properties);
     }
 
+    @SuppressWarnings("unchecked")
     protected FlinkPravegaTableSource createFlinkPravegaTableSource(Map<String, String> properties) {
         final DescriptorProperties descriptorProperties = getValidatedProperties(properties);
         final TableSchema schema = descriptorProperties.getTableSchema(SCHEMA);
@@ -229,6 +231,7 @@ public abstract class FlinkPravegaTableFactoryBase {
         return flinkPravegaTableSource;
     }
 
+    @SuppressWarnings("unchecked")
     protected FlinkPravegaTableSink createFlinkPravegaTableSink(Map<String, String> properties) {
         final DescriptorProperties descriptorProperties = getValidatedProperties(properties);
         final TableSchema schema = descriptorProperties.getTableSchema(SCHEMA);
@@ -248,6 +251,7 @@ public abstract class FlinkPravegaTableFactoryBase {
             tableSinkWriterBuilder.enableMetrics(connectorConfigurations.getMetrics().get());
         }
         tableSinkWriterBuilder.withPravegaConfig(connectorConfigurations.getPravegaConfig());
+        tableSinkWriterBuilder.enableWatermark(connectorConfigurations.getWatermark());
         tableSinkWriterBuilder.withRoutingKeyField(connectorConfigurations.getRoutingKey());
         tableSinkWriterBuilder.withSerializationSchema(serializationSchema);
         tableSinkWriterBuilder.forStream(connectorConfigurations.getWriterStream());

--- a/src/main/java/io/pravega/connectors/flink/Pravega.java
+++ b/src/main/java/io/pravega/connectors/flink/Pravega.java
@@ -86,6 +86,7 @@ public class Pravega extends ConnectorDescriptor {
     public static final String CONNECTOR_WRITER_MODE_VALUE_EXACTLY_ONCE = "exactly_once";
     public static final String CONNECTOR_WRITER_MODE_VALUE_ATLEAST_ONCE = "atleast_once";
     public static final String CONNECTOR_WRITER_TXN_LEASE_RENEWAL_INTERVAL = "connector.writer.txn-lease-renewal-interval";
+    public static final String CONNECTOR_WRITER_ENABLE_WATERMARK = "connector.writer.enable-watermark";
     public static final String CONNECTOR_WRITER_ROUTING_KEY_FILED_NAME = "connector.writer.routingkey-field-name";
 
     private TableSourceReaderBuilder tableSourceReaderBuilder = null;
@@ -176,6 +177,7 @@ public class Pravega extends ConnectorDescriptor {
             properties.putString(CONNECTOR_WRITER_MODE, CONNECTOR_WRITER_MODE_VALUE_EXACTLY_ONCE);
         }
 
+        properties.putBoolean(CONNECTOR_WRITER_ENABLE_WATERMARK, tableSinkWriterBuilder.enableWatermark);
         properties.putLong(CONNECTOR_WRITER_TXN_LEASE_RENEWAL_INTERVAL, tableSinkWriterBuilder.txnLeaseRenewalPeriod.toMilliseconds());
 
         if (tableSinkWriterBuilder.routingKeyFieldName != null) {

--- a/src/main/java/io/pravega/connectors/flink/PravegaValidator.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaValidator.java
@@ -19,23 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO_END_STREAMCUT;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO_START_STREAMCUT;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_TYPE_VALUE_PRAVEGA;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_CONNECTION_CONFIG_CONTROLLER_URI;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_CONNECTION_CONFIG_DEFAULT_SCOPE;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO_SCOPE;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO_STREAM;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_READER_GROUP_SCOPE;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_SCOPE;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_STREAM;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_ROUTING_KEY_FILED_NAME;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_MODE;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_MODE_VALUE_EXACTLY_ONCE;
-import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_MODE_VALUE_ATLEAST_ONCE;
+import static io.pravega.connectors.flink.Pravega.*;
 
 /**
  * Pravega descriptor validation implementation for validating the Pravega reader and writer configurations.

--- a/src/main/java/io/pravega/connectors/flink/util/ConnectorConfigurations.java
+++ b/src/main/java/io/pravega/connectors/flink/util/ConnectorConfigurations.java
@@ -49,6 +49,7 @@ import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO_S
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO_START_STREAMCUT;
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_STREAM_INFO_STREAM;
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_READER_USER_TIMESTAMP_ASSIGNER;
+import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_ENABLE_WATERMARK;
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_MODE;
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_MODE_VALUE_ATLEAST_ONCE;
 import static io.pravega.connectors.flink.Pravega.CONNECTOR_WRITER_MODE_VALUE_EXACTLY_ONCE;
@@ -93,6 +94,7 @@ public final class ConnectorConfigurations {
     private Stream writerStream;
     private Optional<PravegaWriterMode> writerMode;
     private Optional<Long> txnLeaseRenewalInterval;
+    private Boolean watermark;
     private String routingKey;
 
     private PravegaConfig pravegaConfig;
@@ -197,6 +199,7 @@ public final class ConnectorConfigurations {
         if (!descriptorProperties.containsKey(CONNECTOR_WRITER_ROUTING_KEY_FILED_NAME)) {
             throw new ValidationException("Missing " + CONNECTOR_WRITER_ROUTING_KEY_FILED_NAME + " configuration.");
         }
+        watermark = descriptorProperties.getBoolean(CONNECTOR_WRITER_ENABLE_WATERMARK);
         routingKey = descriptorProperties.getString(CONNECTOR_WRITER_ROUTING_KEY_FILED_NAME);
 
         Optional<String> optionalMode = descriptorProperties.getOptionalString(CONNECTOR_WRITER_MODE);

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableSinkTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaTableSinkTest.java
@@ -129,6 +129,7 @@ public class FlinkPravegaTableSinkTest {
         pravega.tableSinkWriterBuilder()
                 .withRoutingKeyField(cityName)
                 .withWriterMode(PravegaWriterMode.EXACTLY_ONCE)
+                .enableWatermark(true)
                 .forStream(stream)
                 .enableMetrics(true)
                 .withPravegaConfig(pravegaConfig);

--- a/src/test/java/io/pravega/connectors/flink/FlinkTableITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkTableITCase.java
@@ -20,8 +20,11 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
@@ -79,6 +82,24 @@ public class FlinkTableITCase {
         public SampleRecord(String category, int value) {
             this.category = category;
             this.value = value;
+        }
+    }
+
+    /**
+     * A sample POJO to be written as a Row (category,value,timestamp).
+     */
+    @Data
+    public static class SampleRecordWithTimestamp implements Serializable {
+        public String category;
+        public int value;
+        public long timestamp;
+
+        public SampleRecordWithTimestamp() {}
+
+        public SampleRecordWithTimestamp(SampleRecord record) {
+            this.category = record.category;
+            this.value = record.value;
+            this.timestamp = record.value;
         }
     }
 
@@ -379,6 +400,51 @@ public class FlinkTableITCase {
         ConnectTableDescriptor desc = tableEnv.connect(pravega)
                 .withFormat(new Json().failOnMissingField(true).deriveSchema())
                 .withSchema(new Schema().field("category", Types.STRING).field("value", Types.INT))
+                .inAppendMode();
+        desc.registerTableSink("test");
+
+        final Map<String, String> propertiesMap = desc.toProperties();
+        final TableSink<?> sink = TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
+                .createStreamTableSink(propertiesMap);
+
+        tableEnv.registerTableSink("Pravega Sink", sink);
+        table.insertInto("Pravega Sink");
+        env.execute();
+    }
+
+    @Test
+    public void testStreamTableSinkUsingDescriptorWithWatermark() throws Exception {
+        // create a Pravega stream for test purposes
+        Stream stream = Stream.of(setupUtils.getScope(), "testStreamTableSinkUsingDescriptorWithWatermark");
+        this.setupUtils.createTestStream(stream.getStreamName(), 1);
+
+        // create a Flink Table environment
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment().setParallelism(1);
+        env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+        DataStream<SampleRecordWithTimestamp> dataStream = env.fromCollection(SAMPLES)
+                .map(SampleRecordWithTimestamp::new)
+                .assignTimestampsAndWatermarks(new AscendingTimestampExtractor<SampleRecordWithTimestamp>() {
+                    @Override
+                    public long extractAscendingTimestamp(SampleRecordWithTimestamp sampleRecordWithTimestamp) {
+                        return sampleRecordWithTimestamp.getTimestamp();
+                    }
+                });
+
+        Table table = tableEnv.fromDataStream(dataStream, "category, value, UserActionTime.rowtime");
+
+        Pravega pravega = new Pravega();
+        pravega.tableSinkWriterBuilder()
+                .withRoutingKeyField("category")
+                .enableWatermark(true)
+                .forStream(stream)
+                .withPravegaConfig(setupUtils.getPravegaConfig());
+
+        ConnectTableDescriptor desc = tableEnv.connect(pravega)
+                .withFormat(new Json().failOnMissingField(true).deriveSchema())
+                .withSchema(new Schema().field("category", Types.STRING)
+                        .field("value", Types.INT)
+                        .field("timestamp", Types.SQL_TIMESTAMP))
                 .inAppendMode();
         desc.registerTableSink("test");
 

--- a/src/test/java/io/pravega/connectors/flink/utils/FailingMapper.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/FailingMapper.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.connectors.flink.utils;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 
@@ -23,6 +24,7 @@ import java.util.List;
  * where a failure is never triggered (for example because of a too high value for
  * the number of elements to pass before failing).
  */
+@Slf4j
 public class FailingMapper<T> implements MapFunction<T, T>, ListCheckpointed<Integer> {
 
     /**
@@ -45,6 +47,7 @@ public class FailingMapper<T> implements MapFunction<T, T>, ListCheckpointed<Int
     @Override
     public T map(T element) throws Exception {
         if (!restored && ++elementCount > failAtElement) {
+            log.info("Introducing Failure");
             throw new IntentionalException("artificial test failure");
         }
 

--- a/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
@@ -226,6 +226,17 @@ public final class SetupUtils {
     }
 
     /**
+     * Get the stream.
+     *
+     * @param streamName     Name of the test stream.
+     *
+     * @return a Stream
+     */
+    public Stream getStream(final String streamName) {
+        return Stream.of(this.scope, streamName);
+    }
+
+    /**
      * Create a stream writer for writing Integer events.
      *
      * @param streamName    Name of the test stream.


### PR DESCRIPTION
**Change log description**

**Purpose of the change**
Same as the pull request #277 for r0.6-flink1.7, the master branch require only merging PRs rather than cherry-picking, I create this PR for the master branch.

**What the code does**
Same as PR #277 , modified only
- Change from `Types.Long` to `Types.Timestamp` in `testStreamTableSinkUsingDescriptorWithWatermark` to get the test pass.

**How to verify it**
