### PR TITLE
[issue-282] Recover failed by Pravega checkpoint failure

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.6.0-SNAPSHOT
-pravegaVersion=0.6.0-50.fdc5698-SNAPSHOT
+pravegaVersion=0.6.0-50.5a60e36-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -124,7 +124,9 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
 
         synchronized (scheduledExecutorLock) {
             if (scheduledExecutorService != null ) {
+                log.info("Closing Scheduled Executor for hook {}", hookUid);
                 scheduledExecutorService.shutdownNow();
+                scheduledExecutorService = null;
             }
         }
     }
@@ -141,6 +143,7 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
     private void ensureScheduledExecutorExists() {
         synchronized (scheduledExecutorLock) {
             if (scheduledExecutorService == null) {
+                log.info("Creating Scheduled Executor for hook {}", hookUid);
                 scheduledExecutorService = createScheduledExecutorService();
             }
         }

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -149,7 +149,7 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
     protected ScheduledExecutorService createScheduledExecutorService() {
         return Executors.newScheduledThreadPool(DEFAULT_CHECKPOINT_THREAD_POOL_SIZE);
     }
-    
+
     protected ScheduledExecutorService getScheduledExecutorService() {
         return this.scheduledExecutorService;
     }


### PR DESCRIPTION
**Change log description**
Change checkpoint scheduler from one-per-checkpoint to a long-lived executorService
Bump pravega version to `0.6.0-50.5a60e36-SNAPSHOT`

**Purpose of the change**
Change implementation in `ReaderCheckpointHook` and fix tests in `ReaderCheckpointHookTest`

**What the code does**
Change to a long-lived executorService to prevent the `ScheduledExecutorService` shutdown too early.

**How to verify it**
`./gradlew clean build` should pass.