### PR TITLE
[issue-288] Don't emit a final watermark when source is stopped

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -295,10 +295,6 @@ public class FlinkPravegaReader<T>
                     triggerCheckpoint(eventRead.getCheckpointName());
                 }
             }
-
-            if (isEventTimeMode()) {
-                ctx.emitWatermark(Watermark.MAX_WATERMARK);
-            }
         }
     }
 


### PR DESCRIPTION
**Change log description**
- Don't emit a final watermark in the reader
Closes #288 

**Purpose of the change**

**What the code does**
Remove the final watermark emit after the source is running

**How to verify it**
`./gradlew clean build` passes