### PR TITLE
[issue-291] Update connector version to 0.6.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ gradleMkdocsPluginVersion=1.1.0
 jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.6.0
+connectorVersion=0.6.1-SNAPSHOT
 pravegaVersion=0.6.0
 apacheCommonsVersion=3.7
 


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Update connector version to `0.6.1-SNAPSHOT`

**Purpose of the change**
Fixes #291 

**What the code does**
`gradle.properties` changes

**How to verify it**
`./gradlew clean build` should pass