### PR TITLE
[issue-295] Increase the DEFAULT_MAX_OUTSTANDING_CHECKPOINT_REQUEST

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
@@ -31,7 +31,7 @@ abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStreamingRead
 
     private static final Time DEFAULT_EVENT_READ_TIMEOUT = Time.seconds(1);
     private static final Time DEFAULT_CHECKPOINT_INITIATE_TIMEOUT = Time.seconds(5);
-    private static final int  DEFAULT_MAX_OUTSTANDING_CHECKPOINT_REQUEST = 3;
+    private static final int  DEFAULT_MAX_OUTSTANDING_CHECKPOINT_REQUEST = 10;
 
     protected String uid;
     protected String readerGroupScope;


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
Increase the `DEFAULT_MAX_OUTSTANDING_CHECKPOINT_REQUEST` from 3 to 10

**Purpose of the change**
Fixes #295 

**What the code does**
Mentioned above. Will cherry-pick into all the `r0.6` branches. 

**How to verify it**
`./gradlew clean build` passes