### PR TITLE
[issue-298] Fix tests that transaction timeout should be greater than 10 seconds

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
@@ -24,7 +24,7 @@ import org.apache.flink.util.Preconditions;
 public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStreamingWriterBuilder> extends AbstractWriterBuilder<B> {
 
     // the numbers below are picked based on the default max settings in Pravega
-    private static final long DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS = 30000; // 30 seconds
+    protected static final long DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS = 30000; // 30 seconds
 
     protected PravegaWriterMode writerMode;
     protected boolean enableWatermark;

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 
+import static io.pravega.connectors.flink.AbstractStreamingWriterBuilder.DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -679,7 +680,8 @@ public class FlinkPravegaWriterTest {
 
     private FlinkPravegaWriter<Integer> spySinkFunction(EventStreamClientFactory clientFactory, PravegaEventRouter<Integer> eventRouter, boolean enableWatermark, PravegaWriterMode writerMode) {
         FlinkPravegaWriter<Integer> writer = spy(new FlinkPravegaWriter<>(
-                MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME), new IntegerSerializationSchema(), eventRouter, writerMode, 30, enableWatermark, true));
+                MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME), new IntegerSerializationSchema(),
+                eventRouter, writerMode, DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS, enableWatermark, true));
         Mockito.doReturn(clientFactory).when(writer).createClientFactory(MOCK_SCOPE_NAME, MOCK_CLIENT_CONFIG);
         return writer;
     }


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Force transaction timeout to be greater than 10 seconds

**Purpose of the change**
Fixes #298 

**What the code does**
Change the default txn timeout in mock sink function from `30ms` to `30s` 

**How to verify it**
`./gradlew clean build` passes

Target to master, should cherry-pick to all `0.7` and `0.6` branch