### PR TITLE
[issue-299] Remove getStreamNames call when calculating Watermark

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -197,6 +197,7 @@ public class FlinkPravegaReader<T>
     private class PeriodicWatermarkEmitter implements ProcessingTimeCallback {
 
         private EventStreamReader<?> pravegaReader;
+        private Stream stream;
         private final SourceContext<?> ctx;
         private final ProcessingTimeService timerService;
         private long lastWatermarkTimestamp;
@@ -206,6 +207,7 @@ public class FlinkPravegaReader<T>
                 EventStreamReader<?> pravegaReader, SourceContext<?> ctx, ClassLoader userCodeClassLoader,
                 ProcessingTimeService timerService) throws Exception {
             this.pravegaReader = Preconditions.checkNotNull(pravegaReader);
+            this.stream = Stream.of(readerGroup.getStreamNames().iterator().next());
             this.ctx = Preconditions.checkNotNull(ctx);
             this.timerService = Preconditions.checkNotNull(timerService);
             this.lastWatermarkTimestamp = Long.MIN_VALUE;
@@ -218,7 +220,6 @@ public class FlinkPravegaReader<T>
 
         @Override
         public void onProcessingTime(long timestamp) {
-            Stream stream = Stream.of(readerGroup.getStreamNames().iterator().next());
             Watermark watermark = userAssigner.getWatermark(pravegaReader.getCurrentTimeWindow(stream));
 
             if (watermark != null && watermark.getTimestamp() > lastWatermarkTimestamp) {


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Remove `getStreamNames` call when calculating Watermark

**Purpose of the change**
Fixes #299 

**What the code does**
Move call to calculate Stream into `PeriodicWatermarkEmitter` constructor

**How to verify it**
`./gradlew clean build` passes

Target to master, should cherry-pick to all `0.7` and `0.6` branch