### PR TITLE
[issue-300] Prepare for 0.6.1 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,10 @@ repositories {
         maven {
             url "https://oss.jfrog.org/jfrog-dependencies"
         }
+        // temp direpository for Pravega 0.6.1 RC
+        maven {
+            url "https://oss.sonatype.org/content/repositories/iopravega-1058/"
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.6.1-SNAPSHOT
-pravegaVersion=0.6.0
+pravegaVersion=0.6.1
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Bump the Pravega version and submodule to the latest `0.6.1-rc`

**Purpose of the change**
Fixes #300 

**What the code does**
Update `gradle.properties` and submodule

**How to verify it**
`./gradlew clean build` passes

Target to master, should cherry-pick to all `0.6` branch