### PR TITLE
[issue-180] Provide method for deserialization with metadata

### DIFF
--- a/documentation/src/docs/serialization.md
+++ b/documentation/src/docs/serialization.md
@@ -47,14 +47,14 @@ Note that the Pravega serializer must implement `java.io.Serializable` to be usa
 Pravega reader client wraps the event with the metadata in an `EventRead` data structure. Some Flink jobs might 
 care about the stream position of the event data which is in `EventRead`, e.g. for indexing purposes. 
 
-`PravegaDeserializationSchema` offers a method to deserialize data with the metadata
+`PravegaDeserializationSchema` offers a method to extract event with the metadata
 ```java
-public T deserializeWithMetadata(EventRead<T> eventRead) {
+public T extractEvent(EventRead<T> eventRead) {
     return eventRead.getEvent();
 }
 ```
 
-The default implementation can be overwritten to involve in metadata structure like `EventPointer` into the deserialization
+The default implementation can be overwritten to involve in metadata structure like `EventPointer` into the event
 by a custom extended `PravegaDeserializationSchema`. For example:
 ```java
 private static class MyJsonDeserializationSchema extends PravegaDeserializationSchema<JsonNode> {
@@ -66,7 +66,7 @@ private static class MyJsonDeserializationSchema extends PravegaDeserializationS
     }
 
     @Override
-    public JsonNode deserializeWithMetadata(EventRead<JsonNode> eventRead) {
+    public JsonNode extractEvent(EventRead<JsonNode> eventRead) {
         JsonNode node = eventRead.getEvent();
         if (includeMetadata) {
             return ((ObjectNode) node).put("eventpointer", eventRead.getEventPointer().toBytes().array());

--- a/documentation/src/docs/serialization.md
+++ b/documentation/src/docs/serialization.md
@@ -42,3 +42,36 @@ DataStream<MyEvent> stream = env.addSource(reader);
 ```  
 
 Note that the Pravega serializer must implement `java.io.Serializable` to be usable in a Flink program.
+
+## Deserialize with metadata
+Pravega reader client wraps the event with the metadata in an `EventRead` data structure. Some Flink jobs might 
+care about the stream position of the event data which is in `EventRead`, e.g. for indexing purposes. 
+
+`PravegaDeserializationSchema` offers a method to deserialize data with the metadata
+```java
+public T deserializeWithMetadata(EventRead<T> eventRead) {
+    return eventRead.getEvent();
+}
+```
+
+The default implementation can be overwritten to involve in metadata structure like `EventPointer` into the deserialization
+by a custom extended `PravegaDeserializationSchema`. For example:
+```java
+private static class MyJsonDeserializationSchema extends PravegaDeserializationSchema<JsonNode> {
+    private boolean includeMetadata;
+
+    public MyJsonDeserializationSchema(boolean includeMetadata) {
+        super(JsonNode.class, new JSONSerializer());
+        this.includeMetadata = includeMetadata;
+    }
+
+    @Override
+    public JsonNode deserializeWithMetadata(EventRead<JsonNode> eventRead) {
+        JsonNode node = eventRead.getEvent();
+        if (includeMetadata) {
+            return ((ObjectNode) node).put("eventpointer", eventRead.getEventPointer().toBytes().array());
+        }
+        return node;
+    }
+}
+```

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -267,8 +267,8 @@ public class FlinkPravegaReader<T>
                 periodicEmitter.start();
             }
 
-            Function<EventRead<T>, T> deserFunc = this.deserializationSchema instanceof PravegaDeserializationSchema ?
-                    ((PravegaDeserializationSchema<T>) deserializationSchema)::deserializeWithMetadata :
+            final Function<EventRead<T>, T> deserFunc = this.deserializationSchema instanceof PravegaDeserializationSchema ?
+                    ((PravegaDeserializationSchema<T>) deserializationSchema)::extractEvent :
                     (eventRead) -> eventRead.getEvent();
 
             // main work loop, which this task is running

--- a/src/main/java/io/pravega/connectors/flink/serialization/PravegaDeserializationSchema.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/PravegaDeserializationSchema.java
@@ -31,7 +31,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * exposes the produced type (TypeInformation) to allow Flink to configure its internal
  * serialization and persistence stack.
  *
- * <p>An additional method {@link #deserializeWithMetadata(EventRead)} is provided for
+ * <p>An additional method {@link #extractEvent(EventRead)} is provided for
  * applying the metadata in the deserialization. This method can be overriden in the extended class. </p>
  */
 public class PravegaDeserializationSchema<T> 
@@ -138,7 +138,7 @@ public class PravegaDeserializationSchema<T>
      *
      * @return the deserialized event with metadata
      */
-    public T deserializeWithMetadata(EventRead<T> eventRead) {
+    public T extractEvent(EventRead<T> eventRead) {
         return eventRead.getEvent();
     }
 

--- a/src/main/java/io/pravega/connectors/flink/serialization/PravegaDeserializationSchema.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/PravegaDeserializationSchema.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.connectors.flink.serialization;
 
+import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.Serializer;
 
 import java.io.IOException;
@@ -29,6 +30,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>This adapter exposes the Pravega serializer as a Flink Deserialization schema and
  * exposes the produced type (TypeInformation) to allow Flink to configure its internal
  * serialization and persistence stack.
+ *
+ * <p>An additional method {@link #deserializeWithMetadata(EventRead)} is provided for
+ * applying the metadata in the deserialization. This method can be overriden in the extended class. </p>
  */
 public class PravegaDeserializationSchema<T> 
         implements DeserializationSchema<T>, WrappingSerializer<T> {
@@ -124,6 +128,18 @@ public class PravegaDeserializationSchema<T>
     @Override
     public Serializer<T> getWrappedSerializer() {
         return serializer;
+    }
+
+    /**
+     * An method for applying the metadata in deserialization.
+     * Override it in the custom extended {@link PravegaDeserializationSchema} if the Pravega metadata is needed.
+     *
+     * @param eventRead The EventRead structure the client returns which contains metadata
+     *
+     * @return the deserialized event with metadata
+     */
+    public T deserializeWithMetadata(EventRead<T> eventRead) {
+        return eventRead.getEvent();
     }
 
     // ------------------------------------------------------------------------

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -362,7 +362,7 @@ public class FlinkPravegaReaderTest {
 
         return new TestableFlinkPravegaReader<>(
                     "hookUid", clientConfig, rgConfig, SAMPLE_SCOPE, GROUP_NAME,
-                    new TestMetadataDeserializationSchema(includeMetadata),null, READER_TIMEOUT, CHKPT_TIMEOUT, enableMetrics);
+                    new TestMetadataDeserializationSchema(includeMetadata), null, READER_TIMEOUT, CHKPT_TIMEOUT, enableMetrics);
     }
 
     /**

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -188,14 +188,15 @@ public class FlinkPravegaReaderTest {
 
             // verify that the event stream was read until the end of stream
             verify(reader.eventStreamReader, times(2)).readNextEvent(anyLong());
-
             Queue<Object> actual = testHarness.getOutput();
             assertEquals(actual.size(), 1);
-            JsonNode output = ((StreamRecord<JsonNode>) actual.peek()).getValue();
 
+            // verify that the Json event doesn't miss any field
+            JsonNode output = ((StreamRecord<JsonNode>) actual.peek()).getValue();
             assertTrue(output.has("value"));
             assertTrue(output.has("eventpointer"));
 
+            // verify that the Json event contains the right value and EventPointer information
             EventPointer outputEventPointer = EventPointer.fromBytes(
                     ByteBuffer.wrap(output.get("eventpointer").binaryValue()));
             assertEquals(output.get("value").asInt(), 1);

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -49,6 +49,7 @@ import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -188,10 +189,12 @@ public class FlinkPravegaReaderTest {
             assertEquals(actual.size(), 1);
 
             // verify that the event contains the right value and EventPointer information
+            @SuppressWarnings("unchecked")
             IntegerWithEventPointer output = ((StreamRecord<IntegerWithEventPointer>) actual.peek()).getValue();
-            assertEquals(output.getValue().intValue(), 1);
+            assertEquals(output.getValue(), 1);
 
-            EventPointer outputEventPointer = EventPointer.fromBytes(output.getEventPointer().toBytes());
+            EventPointer outputEventPointer = EventPointer.fromBytes(ByteBuffer.wrap(
+                    output.getEventPointerBytes()));
             assertEquals(outputEventPointer, evts.getEventPointer(1));
         }
     }

--- a/src/test/java/io/pravega/connectors/flink/utils/IntegerSerializer.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/IntegerSerializer.java
@@ -11,9 +11,10 @@ package io.pravega.connectors.flink.utils;
 
 import io.pravega.client.stream.Serializer;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 
-public final class IntegerSerializer implements Serializer<Integer> {
+public final class IntegerSerializer implements Serializer<Integer>, Serializable {
     @Override
     public ByteBuffer serialize(Integer value) {
         ByteBuffer result = ByteBuffer.allocate(4).putInt(value);

--- a/src/test/java/io/pravega/connectors/flink/utils/IntegerWithEventPointer.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/IntegerWithEventPointer.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink.utils;
+
+import io.pravega.client.stream.EventPointer;
+
+import java.io.Serializable;
+
+public class IntegerWithEventPointer implements Serializable {
+    public static final int END_OF_STREAM = -1;
+
+    private Integer value;
+    private EventPointer eventPointer;
+
+    public IntegerWithEventPointer() {}
+
+    public IntegerWithEventPointer(Integer value) {
+        this.value = value;
+        this.eventPointer = null;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public EventPointer getEventPointer() {
+        return eventPointer;
+    }
+
+    public void setEventPointer(EventPointer eventPointer) {
+        this.eventPointer = eventPointer;
+    }
+
+    public boolean isEndOfStream() {
+        return value == END_OF_STREAM;
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/utils/IntegerWithEventPointer.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/IntegerWithEventPointer.java
@@ -16,26 +16,26 @@ import java.io.Serializable;
 public class IntegerWithEventPointer implements Serializable {
     public static final int END_OF_STREAM = -1;
 
-    private Integer value;
-    private EventPointer eventPointer;
+    private int value;
+    private byte[] eventPointerBytes;
 
     public IntegerWithEventPointer() {}
 
-    public IntegerWithEventPointer(Integer value) {
+    public IntegerWithEventPointer(int value) {
         this.value = value;
-        this.eventPointer = null;
+        this.eventPointerBytes = null;
     }
 
-    public Integer getValue() {
+    public int getValue() {
         return value;
     }
 
-    public EventPointer getEventPointer() {
-        return eventPointer;
+    public byte[] getEventPointerBytes() {
+        return eventPointerBytes;
     }
 
     public void setEventPointer(EventPointer eventPointer) {
-        this.eventPointer = eventPointer;
+        this.eventPointerBytes = eventPointer.toBytes().array();
     }
 
     public boolean isEndOfStream() {

--- a/src/test/java/io/pravega/connectors/flink/utils/JSONSerializer.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/JSONSerializer.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.pravega.client.stream.Serializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+
+public class JSONSerializer implements Serializer<JsonNode>, Serializable {
+
+    /** Object mapper for parsing the JSON. */
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public ByteBuffer serialize(JsonNode value) {
+        byte[] bytes = new byte[0];
+        try {
+            bytes = objectMapper.writeValueAsBytes(value);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return ByteBuffer.wrap(bytes);
+    }
+
+    @Override
+    public JsonNode deserialize(ByteBuffer serializedValue) {
+        ByteArrayInputStream bin = new ByteArrayInputStream(serializedValue.array(),
+                serializedValue.position(),
+                serializedValue.remaining());
+        JsonNode objectNode = null;
+        try {
+            objectNode = objectMapper.readTree(bin);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return objectNode;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- [issue-180] Provide method for deserialization with metadata

**Purpose of the change**
Fixes #180 

**What the code does**
Provide a method `deserializeWithMetadata` for user to override that can leverage `EventRead` in the deserialization.
Added unit test for the case.

**How to verify it**
`./gradlew clean build` passes
Target to master, should cherry-pick to all `0.7` branch