### PR TITLE
[issue-300] Prepare for the 0.6.1 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,10 +77,6 @@ repositories {
         maven {
             url "https://oss.jfrog.org/jfrog-dependencies"
         }
-        // temp direpository for Pravega 0.6.1 RC
-        maven {
-            url "https://oss.sonatype.org/content/repositories/iopravega-1058/"
-        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ gradleMkdocsPluginVersion=1.1.0
 jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.6.1-SNAPSHOT
+connectorVersion=0.6.1
 pravegaVersion=0.6.1
 apacheCommonsVersion=3.7
 


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Prepare for the `0.6.1` release

**Purpose of the change**
Fix #300 

**What the code does**
Remove the temp maven repository and update the connector version into `0.6.1`

**How to verify it**
`./gradlew clean build` passes
Target to `r0.6`, should cherry-pick to all `0.6` branch