### PR TITLE
[issue-304] Remove deprecated resetReadersToCheckpoint API

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -98,13 +98,17 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
         return checkpointResult;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void restoreCheckpoint(long checkpointId, Checkpoint checkpoint) throws Exception {
         // checkpoint can be null when restoring from a savepoint that
         // did not include any state for that particular reader name
         if (checkpoint != null) {
-            this.readerGroup.resetReadersToCheckpoint(checkpoint);
+            this.readerGroup.resetReaderGroup(ReaderGroupConfig.
+                    builder().
+                    disableAutomaticCheckpoints().
+                    startFromCheckpoint(checkpoint).
+                    build());
+
         }
     }
 

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -110,7 +110,6 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
                     .disableAutomaticCheckpoints()
                     .startFromCheckpoint(checkpoint)
                     .build());
-
         }
     }
 

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -103,11 +103,13 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
         // checkpoint can be null when restoring from a savepoint that
         // did not include any state for that particular reader name
         if (checkpoint != null) {
-            this.readerGroup.resetReaderGroup(ReaderGroupConfig.
-                    builder().
-                    disableAutomaticCheckpoints().
-                    startFromCheckpoint(checkpoint).
-                    build());
+             this.readerGroup.resetReaderGroup(ReaderGroupConfig
+                    .builder()
+                    .maxOutstandingCheckpointRequest(this.readerGroupConfig.getMaxOutstandingCheckpointRequest())
+                    .groupRefreshTimeMillis(this.readerGroupConfig.getGroupRefreshTimeMillis())
+                    .disableAutomaticCheckpoints()
+                    .startFromCheckpoint(checkpoint)
+                    .build());
 
         }
     }

--- a/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
+++ b/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
@@ -12,8 +12,14 @@ package io.pravega.connectors.flink;
 import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.impl.CheckpointImpl;
+import io.pravega.client.stream.impl.StreamCutImpl;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.segment.impl.Segment;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
 import java.util.concurrent.Callable;
@@ -35,6 +41,7 @@ import static org.mockito.Mockito.when;
 public class ReaderCheckpointHookTest {
 
     private static final String HOOK_UID = "test";
+    private static final String SCOPE = "scope";
 
     @Test
     public void testConstructor() throws Exception {
@@ -101,15 +108,27 @@ public class ReaderCheckpointHookTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testRestore() throws Exception {
         ReaderGroup readerGroup = mock(ReaderGroup.class);
+
         ReaderGroupConfig readerGroupConfig = mock(ReaderGroupConfig.class);
+
         TestableReaderCheckpointHook hook = new TestableReaderCheckpointHook(HOOK_UID, readerGroup, Time.minutes(1), readerGroupConfig);
 
         Checkpoint checkpoint = mock(Checkpoint.class);
+        CheckpointImpl checkpointImpl = mock(CheckpointImpl.class);
+
+        when(checkpoint.asImpl()).thenReturn(checkpointImpl);
+        when(checkpointImpl.getPositions()).thenReturn(ImmutableMap.<Stream, StreamCut>builder()
+                .put(Stream.of(SCOPE, "s1"), getStreamCut("s1"))
+                .put(Stream.of(SCOPE, "s2"), getStreamCut("s2")).build());
+
         hook.restoreCheckpoint(1L, checkpoint);
-        verify(readerGroup).resetReadersToCheckpoint(checkpoint);
+        readerGroupConfig = ReaderGroupConfig.builder()
+                .disableAutomaticCheckpoints()
+                .startFromCheckpoint(checkpoint)
+                .build();
+        verify(readerGroup).resetReaderGroup(readerGroupConfig);
     }
 
     static class TestableReaderCheckpointHook extends ReaderCheckpointHook {
@@ -136,5 +155,21 @@ public class ReaderCheckpointHookTest {
                 scheduledCallable.call();
             }
         }
+    }
+
+    private StreamCut getStreamCut(String streamName) {
+
+        return getStreamCut(streamName, 10L);
+
+    }
+
+    private StreamCut getStreamCut(String streamName, long offset) {
+
+        ImmutableMap<Segment, Long> positions = ImmutableMap.<Segment, Long>builder().put(new Segment(SCOPE,
+
+                streamName, 0), offset).build();
+
+        return new StreamCutImpl(Stream.of(SCOPE, streamName), positions);
+
     }
 }

--- a/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
+++ b/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
@@ -110,11 +110,10 @@ public class ReaderCheckpointHookTest {
     @Test
     public void testRestore() throws Exception {
         ReaderGroup readerGroup = mock(ReaderGroup.class);
-
         ReaderGroupConfig readerGroupConfig = mock(ReaderGroupConfig.class);
-
+        
         TestableReaderCheckpointHook hook = new TestableReaderCheckpointHook(HOOK_UID, readerGroup, Time.minutes(1), readerGroupConfig);
-
+        
         Checkpoint checkpoint = mock(Checkpoint.class);
         CheckpointImpl checkpointImpl = mock(CheckpointImpl.class);
 
@@ -158,18 +157,12 @@ public class ReaderCheckpointHookTest {
     }
 
     private StreamCut getStreamCut(String streamName) {
-
         return getStreamCut(streamName, 10L);
-
     }
 
     private StreamCut getStreamCut(String streamName, long offset) {
-
         ImmutableMap<Segment, Long> positions = ImmutableMap.<Segment, Long>builder().put(new Segment(SCOPE,
-
                 streamName, 0), offset).build();
-
         return new StreamCutImpl(Stream.of(SCOPE, streamName), positions);
-
     }
 }

--- a/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
+++ b/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
@@ -111,7 +111,6 @@ public class ReaderCheckpointHookTest {
     public void testRestore() throws Exception {
         ReaderGroup readerGroup = mock(ReaderGroup.class);
         ReaderGroupConfig readerGroupConfig = mock(ReaderGroupConfig.class);
-        
         TestableReaderCheckpointHook hook = new TestableReaderCheckpointHook(HOOK_UID, readerGroup, Time.minutes(1), readerGroupConfig);
         
         Checkpoint checkpoint = mock(Checkpoint.class);
@@ -158,8 +157,8 @@ public class ReaderCheckpointHookTest {
 
     private StreamCut getStreamCut(String streamName) {
         return getStreamCut(streamName, 10L);
-    }
 
+    }
     private StreamCut getStreamCut(String streamName, long offset) {
         ImmutableMap<Segment, Long> positions = ImmutableMap.<Segment, Long>builder().put(new Segment(SCOPE,
                 streamName, 0), offset).build();

--- a/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
+++ b/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
@@ -112,7 +112,6 @@ public class ReaderCheckpointHookTest {
         ReaderGroup readerGroup = mock(ReaderGroup.class);
         ReaderGroupConfig readerGroupConfig = mock(ReaderGroupConfig.class);
         TestableReaderCheckpointHook hook = new TestableReaderCheckpointHook(HOOK_UID, readerGroup, Time.minutes(1), readerGroupConfig);
-        
         Checkpoint checkpoint = mock(Checkpoint.class);
         CheckpointImpl checkpointImpl = mock(CheckpointImpl.class);
 
@@ -157,8 +156,8 @@ public class ReaderCheckpointHookTest {
 
     private StreamCut getStreamCut(String streamName) {
         return getStreamCut(streamName, 10L);
-
     }
+
     private StreamCut getStreamCut(String streamName, long offset) {
         ImmutableMap<Segment, Long> positions = ImmutableMap.<Segment, Long>builder().put(new Segment(SCOPE,
                 streamName, 0), offset).build();


### PR DESCRIPTION
Signed-off-by: AlexanderZhao1 <Alexander_Zhao@dell.com>

**Change log description**

* Deleted the depcreated resetReadersToCheckpoint API
* modified ReaderCheckpointHookTest.java

**Purpose of the change**
fix #304

**What the code does**

* Deleted the depcreated `resetReadersToCheckpoint API`, use `resetReaderGroup#ReaderGroupConfig` instead 

*  New API needs CheckpointImpl to be added to Checkpoint
  
reference: [ReaderGroupConfigTest](https://github.com/pravega/pravega/blob/195f247cdfd8168c427ab76fb2040c5ae4689438/client/src/test/java/io/pravega/client/stream/ReaderGroupConfigTest.java)

**How to verify it**
`./gradlew clean build` passes
