### PR TITLE
[issue-313] Fix-testRestore-bug

### DIFF
--- a/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
+++ b/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
@@ -110,8 +110,7 @@ public class ReaderCheckpointHookTest {
     @Test
     public void testRestore() throws Exception {
         ReaderGroup readerGroup = mock(ReaderGroup.class);
-        ReaderGroupConfig readerGroupConfig = mock(ReaderGroupConfig.class);
-        TestableReaderCheckpointHook hook = new TestableReaderCheckpointHook(HOOK_UID, readerGroup, Time.minutes(1), readerGroupConfig);
+
         Checkpoint checkpoint = mock(Checkpoint.class);
         CheckpointImpl checkpointImpl = mock(CheckpointImpl.class);
 
@@ -120,11 +119,16 @@ public class ReaderCheckpointHookTest {
                 .put(Stream.of(SCOPE, "s1"), getStreamCut("s1"))
                 .put(Stream.of(SCOPE, "s2"), getStreamCut("s2")).build());
 
-        hook.restoreCheckpoint(1L, checkpoint);
-        readerGroupConfig = ReaderGroupConfig.builder()
+        ReaderGroupConfig readerGroupConfig = ReaderGroupConfig.builder()
                 .disableAutomaticCheckpoints()
                 .startFromCheckpoint(checkpoint)
                 .build();
+
+        TestableReaderCheckpointHook hook = new TestableReaderCheckpointHook(HOOK_UID, readerGroup, Time.minutes(1),
+                readerGroupConfig);
+
+        hook.restoreCheckpoint(1L, checkpoint);
+
         verify(readerGroup).resetReaderGroup(readerGroupConfig);
     }
 


### PR DESCRIPTION
Signed-off-by: AlexanderZhao1 <Alexander_Zhao@dell.com>

**Change log description**

* `ReaderCheckpointHookTest.java`

**Purpose of the change**

fix #313 

**What the code does**
The default value of `groupRefreshTimeMillis` and `maxOutstandingCheckpointRequest` is not set in ReaderGroupConfig, but set in ReaderGroupConfigBuilder. So the original test code will raise an ZeroValueError.

So Instead of using mock(ReaderGroupConfig.class) to init a ReaderGroupConfig instance, 
we can use ReaderGroupConfigBuilder to build a ReaderGroupConfig instance with `maxOutstandingCheckpointRequest` and  `groupRefreshTimeMillis` default values.

**How to verify it**

`./gradlew clean build ` should pass