### PR TITLE
[issue-316] Update Pravega version to latest master

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.7.0-SNAPSHOT
-pravegaVersion=0.7.0-50.719995b-SNAPSHOT
+pravegaVersion=0.7.0-50.be42b9d-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'

--- a/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
@@ -218,8 +218,6 @@ public final class SetupUtils {
         streamManager.createScope(this.scope);
         streamManager.createStream(this.scope, streamName,
                 StreamConfiguration.builder()
-                        .scope(this.scope)
-                        .streamName(streamName)
                         .scalingPolicy(ScalingPolicy.fixed(numSegments))
                         .build());
         log.info("Created stream: " + streamName);


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Bump the Pravega version and fix compile errors

**Purpose of the change**
Fixes #316 

**What the code does**
Update `gradle.properties` and submodule
Delete the scope and stream settings in the `StreamConfiguration` builder

**How to verify it**
`./gradlew clean build` passes
Target to master, should cherry-pick to all `0.7` branch