### PR TITLE
[issue-319] Handle TruncatedDataException in the reader

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -20,6 +20,7 @@ import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.connectors.flink.watermark.AssignerWithTimeWindows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.ExecutionConfig;
@@ -267,7 +268,13 @@ public class FlinkPravegaReader<T>
 
             // main work loop, which this task is running
             while (this.running) {
-                final EventRead<T> eventRead = pravegaReader.readNextEvent(eventReadTimeout.toMilliseconds());
+                EventRead<T> eventRead;
+                try {
+                    eventRead = pravegaReader.readNextEvent(eventReadTimeout.toMilliseconds());
+                } catch (TruncatedDataException e) {
+                    // Data is truncated, Force the reader going forward to the next available event
+                    continue;
+                }
                 final T event = eventRead.getEvent();
 
                 // emit the event, if one was carried

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -21,6 +21,7 @@ import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.TimeWindow;
+import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.client.stream.impl.EventReadImpl;
 import io.pravega.client.stream.impl.StreamCutImpl;
 import io.pravega.connectors.flink.utils.IntegerDeserializationSchema;
@@ -155,6 +156,38 @@ public class FlinkPravegaReaderTest {
             validateMetricGroup(scopeString, ONLINE_READERS_METRICS_GAUGE, readerGroupMetricGroup);
             validateMetricGroup(scopeString, UNREAD_BYTES_METRICS_GAUGE, readerGroupMetricGroup);
 
+        }
+    }
+
+    /**
+     * Tests the behavior of {@code run()} with TruncatedDataException.
+     */
+    @Test
+    public void testTruncated() throws Exception {
+        TestableFlinkPravegaReader<Integer> reader = createReader();
+
+        try (StreamSourceOperatorTestHarness<Integer, TestableFlinkPravegaReader<Integer>> testHarness =
+                     createTestHarness(reader, 1, 1, 0, TimeCharacteristic.ProcessingTime)) {
+            testHarness.open();
+
+            // prepare a sequence of events
+            TestEventGenerator<Integer> evts = new TestEventGenerator<>();
+            when(reader.eventStreamReader.readNextEvent(anyLong()))
+                    .thenReturn(evts.event(1))
+                    .thenThrow(new TruncatedDataException())
+                    .thenReturn(evts.event(2))
+                    .thenReturn(evts.event(TestDeserializationSchema.END_OF_STREAM));
+
+            // run the source
+            testHarness.run();
+
+            // verify that the event stream was read until the end of stream
+            verify(reader.eventStreamReader, times(4)).readNextEvent(anyLong());
+            Queue<Object> actual = testHarness.getOutput();
+            Queue<Object> expected = new ConcurrentLinkedQueue<>();
+            expected.add(record(1));
+            expected.add(record(2));
+            TestHarnessUtil.assertOutputEquals("Unexpected output", expected, actual);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Handle TruncatedDataException in the reader

**Purpose of the change**
Fixes #319 

**What the code does**
Let the reader call `readNextEvent` again when catching `TruncatedDataException`
Add tests to verify the exception is caught and read can go on as nornal

**How to verify it**
`./gradlew clean build` passes
Target to master, should cherry-pick to all `0.7` and `0.6` branch