### PR TITLE
[issue-323] Make the reader name valid

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.7.0-SNAPSHOT
-pravegaVersion=0.7.0-50.be42b9d-SNAPSHOT
+pravegaVersion=0.7.0-50.e49091f-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.7.0-SNAPSHOT
-pravegaVersion=0.7.0-50.e49091f-SNAPSHOT
+pravegaVersion=0.7.0-50.4bf247f-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -24,6 +24,7 @@ import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.connectors.flink.watermark.AssignerWithTimeWindows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -50,6 +51,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static io.pravega.connectors.flink.util.FlinkPravegaUtils.createPravegaReader;
+import static io.pravega.connectors.flink.util.FlinkPravegaUtils.getReaderName;
 
 /**
  * Flink source implementation for reading from pravega storage.
@@ -240,11 +242,13 @@ public class FlinkPravegaReader<T>
 
     @Override
     public void run(SourceContext<T> ctx) throws Exception {
+        final RuntimeContext runtimeContext = getRuntimeContext();
 
-        final String readerId = getRuntimeContext().getTaskNameWithSubtasks();
+        final String readerId = getReaderName(runtimeContext.getTaskName(), runtimeContext.getIndexOfThisSubtask() + 1,
+                runtimeContext.getNumberOfParallelSubtasks());
 
         log.info("{} : Creating Pravega reader with ID '{}' for controller URI: {}",
-                getRuntimeContext().getTaskNameWithSubtasks(), readerId, this.clientConfig.getControllerURI());
+                runtimeContext.getTaskNameWithSubtasks(), readerId, this.clientConfig.getControllerURI());
 
         try (EventStreamReader<T> pravegaReader = createEventStreamReader(readerId)) {
 
@@ -254,12 +258,12 @@ public class FlinkPravegaReader<T>
             AssignerWithTimeWindows<T> assigner = null;
             // If it is event time, register a watermark emitter
             if (isEventTimeMode()) {
-                assigner = assignerWithTimeWindows.deserializeValue(getRuntimeContext().getUserCodeClassLoader());
+                assigner = assignerWithTimeWindows.deserializeValue(runtimeContext.getUserCodeClassLoader());
                 PeriodicWatermarkEmitter periodicEmitter = new PeriodicWatermarkEmitter(
                         pravegaReader,
                         ctx,
-                        getRuntimeContext().getUserCodeClassLoader(),
-                        ((StreamingRuntimeContext) getRuntimeContext()).getProcessingTimeService());
+                        runtimeContext.getUserCodeClassLoader(),
+                        ((StreamingRuntimeContext) runtimeContext).getProcessingTimeService());
 
                 log.info("Periodic Watermark Emitter for Reader ID: {} has started with an interval of {}", readerId,
                         autoWatermarkInterval());

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -63,7 +63,7 @@ public class FlinkPravegaUtils {
      * @return the generated default reader name.
      */
     public static String getReaderName(final String taskName, final int index, final int total) {
-        String readerName = "Pravega-reader-for-" + taskName + "-" + index + "-" + total;
+        String readerName = "flink-task-" + taskName + "-" + index + "-" + total;
         readerName = StringUtils.removePattern(readerName, "[^\\p{Alnum}\\.\\-]");
         return readerName;
     }

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -20,13 +20,13 @@ import io.pravega.connectors.flink.serialization.WrappingSerializer;
 import lombok.SneakyThrows;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 
 import java.nio.ByteBuffer;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 public class FlinkPravegaUtils {
 
     private FlinkPravegaUtils() {
@@ -55,20 +55,17 @@ public class FlinkPravegaUtils {
     }
 
     /**
-     * Utility method that derives default reader name from stream and scope name.
+     * Utility method that derives the reader name from taskName, index and parallelism.
      *
-     * @param scope The destination streams' scope name.
-     * @param streamNames Set of stream to read, used to generate the reader name.
+     * @param taskName the original task name
+     * @param index the index of the subtask
+     * @param total the total parallelism of the subtask
      * @return the generated default reader name.
      */
-    public static String getDefaultReaderName(final String scope, final Set<String> streamNames) {
-        final String delimiter = "-";
-        final String reader = streamNames.stream().collect(Collectors.joining(delimiter)) + delimiter + scope;
-        int hash = 0;
-        for (int i = 0; i < reader.length(); i++) {
-            hash = reader.charAt(i) + (31 * hash);
-        }
-        return Integer.toString(hash);
+    public static String getReaderName(final String taskName, final int index, final int total) {
+        String readerName = "Pravega-reader-for-" + taskName + "-" + index + "-" + total;
+        readerName = StringUtils.removePattern(readerName, "[^\\p{Alnum}\\.\\-]");
+        return readerName;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Make the reader name valid

**Purpose of the change**
Fixes #323 , remain only the legal characters in `readerId`.

**What the code does**
Bump up the pravega version to the latest master
Removed the unused `getDefaultReaderName` function.
Create a `getReader` function to remove the illegal characters in the reader id.
e.g.
```
Source: Custom Source -> Map -> Map -> Sink: Unnamed (1/1)
```
Changes into
```
Pravega-reader-for-SourceCustomSource-Map-Map-SinkUnnamed-1-1
```
**How to verify it**
`./gradlew clean build` passes
Target to master, should cherry-pick to all `0.7` branch