### PR TITLE
[issue-326] Prepare for 0.6.2 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,8 @@ gradleMkdocsPluginVersion=1.1.0
 jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.6.2-SNAPSHOT
-pravegaVersion=0.6.1
+connectorVersion=0.6.2
+pravegaVersion=0.6.2
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Prepare for the `0.6.2` release

**Purpose of the change**
Fix #326 

**What the code does**
Update the connector version into `0.6.2`
Update the Pravega client version into `0.6.2`

**How to verify it**
`./gradlew clean build` passes
Target to `r0.6`, should cherry-pick to all `0.6` branch