### PR TITLE
[issue-328] Update Connector version to 0.6.3-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ gradleMkdocsPluginVersion=1.1.0
 jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.6.2
+connectorVersion=0.6.3-SNAPSHOT
 pravegaVersion=0.6.2
 apacheCommonsVersion=3.7
 


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
Update connector version to `0.6.3-SNAPSHOT`

**Purpose of the change**
Fixes #328 

**What the code does**
`gradle.properties` changes

**How to verify it**
`./gradlew clean build` should pass
Target to `r0.6`, should cherry-pick to all `0.6` branch