### PR TITLE
[issue-331] Make connector Generated ID consistent among checkpoints

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
@@ -190,15 +190,13 @@ abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStreamingRead
      * Generate a UID for the source, to distinguish the state associated with the checkpoint hook.  A good generated UID will:
      * 1. be stable across savepoints for the same inputs
      * 2. disambiguate one source from another (e.g. in a program that uses numerous instances of {@link FlinkPravegaReader})
-     * 3. allow for reconfiguration of the timeouts
+     * 3. allow for reconfiguration of the stream cuts and timeouts
      */
     String generateUid() {
         StringBuilder sb = new StringBuilder();
         sb.append(readerGroupScope).append('\n');
         resolveStreams().forEach(s -> sb
                 .append(s.getStream().getScopedName())
-                .append('/').append(s.getFrom().hashCode())
-                .append('/').append(s.getTo().hashCode())
                 .append('\n'));
         return Integer.toString(sb.toString().hashCode());
     }

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -80,8 +80,10 @@ public class FlinkPravegaReaderTest {
 
     private static final String SAMPLE_SCOPE = "scope";
     private static final String SAMPLE_STREAM_NAME = "stream";
+    private static final String SAMPLE_STREAM_NAME_2 = "stream-2";
     private static final String SAMPLE_COMPLETE_STREAM_NAME = SAMPLE_SCOPE + '/' + SAMPLE_STREAM_NAME;
     private static final Stream SAMPLE_STREAM = Stream.of(SAMPLE_SCOPE, SAMPLE_STREAM_NAME);
+    private static final Stream SAMPLE_STREAM_2 = Stream.of(SAMPLE_SCOPE, SAMPLE_STREAM_NAME_2);
     private static final Segment SAMPLE_SEGMENT = new Segment(SAMPLE_SCOPE, SAMPLE_STREAM.getStreamName(), 1);
     private static final StreamCut SAMPLE_CUT = new StreamCutImpl(SAMPLE_STREAM, Collections.singletonMap(SAMPLE_SEGMENT, 42L));
     private static final StreamCut SAMPLE_CUT2 = new StreamCutImpl(SAMPLE_STREAM, Collections.singletonMap(SAMPLE_SEGMENT, 1024L));
@@ -413,23 +415,17 @@ public class FlinkPravegaReaderTest {
 
         TestableStreamingReaderBuilder builder2 = new TestableStreamingReaderBuilder()
                 .withReaderGroupScope(SAMPLE_SCOPE)
-                .forStream(SAMPLE_STREAM, SAMPLE_CUT, StreamCut.UNBOUNDED)
+                .forStream(SAMPLE_STREAM, SAMPLE_CUT, SAMPLE_CUT2)
                 .withEventReadTimeout(Time.seconds(42L));
         String uid2 = builder2.generateUid();
 
         TestableStreamingReaderBuilder builder3 = new TestableStreamingReaderBuilder()
                 .withReaderGroupScope(SAMPLE_SCOPE)
-                .forStream(SAMPLE_STREAM, SAMPLE_CUT2, StreamCut.UNBOUNDED);
+                .forStream(SAMPLE_STREAM_2);
         String uid3 = builder3.generateUid();
-
-        TestableStreamingReaderBuilder builder4 = new TestableStreamingReaderBuilder()
-                .withReaderGroupScope(SAMPLE_SCOPE)
-                .forStream(SAMPLE_STREAM, SAMPLE_CUT, SAMPLE_CUT2);
-        String uid4 = builder4.generateUid();
 
         assertEquals(uid1, uid2);
         assertNotEquals(uid1, uid3);
-        assertNotEquals(uid1, uid4);
     }
 
     // endregion


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Make connector Generated ID consistent among checkpoints

**Purpose of the change**
Fixes #331 

**What the code does**
- Removed the stream cuts info in `generateUid` function because checkpoint restore will change the starting streamcut
- Changed unit tests for `generateUid`

**How to verify it**
`./gradlew clean build` passes. 
Target to master, should cherry-pick to all `0.7` branch