### PR TITLE
[issues-338] Streaming Connector TOC invalid anchor links

### DIFF
--- a/documentation/src/docs/streaming.md
+++ b/documentation/src/docs/streaming.md
@@ -18,7 +18,7 @@ for use with the Flink Streaming API. See the below sections for details.
   - [Input Stream(s)](#input-streams)
   - [Parallelism](#parallelism)
   - [Checkpointing](#checkpointing)
-  - [Timestamp Extraction | Watermark Emission](#timestamp-extraction-watermark-emission)
+  - [Timestamp Extraction \ Watermark Emission](#timestamp-extraction-watermark-emission)
   - [Stream Cuts](#streamcuts)
   - [Historical Stream Processing](#historical-stream-processing)
 - [FlinkPravegaWriter](#flinkpravegawriter)
@@ -101,7 +101,7 @@ The checkpoint mechanism works as a two-step process:
    - The [master hook](https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.html) handler from the job manager initiates the [`triggerCheckpoint`](https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.html#triggerCheckpoint-long-long-java.util.concurrent.Executor-) request to  the `ReaderCheckpointHook` that was registered with the Job Manager during `FlinkPravegaReader` source initialization. The `ReaderCheckpointHook` handler notifies Pravega to checkpoint the current reader state. This is a non-blocking call which returns a `future` once Pravega readers are done with the checkpointing.
    - A `CheckPoint` event will be sent by Pravega as part of the data stream flow and on receiving the event, the `FlinkPravegaReader` will initiate [`triggerCheckpoint`](https://github.com/apache/flink/blob/master/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java#L73) request to effectively let Flink continue and complete the checkpoint process.
 
-### Timestamp Extraction | Watermark Emission
+### Timestamp Extraction \ Watermark Emission
 
 Flink requires the events’ timestamps (each element in the stream needs to have its event timestamp assigned). This is achieved by accessing/extracting the timestamp from some field in the element. These are used to tell the system about progress in event time.
 

--- a/documentation/src/docs/streaming.md
+++ b/documentation/src/docs/streaming.md
@@ -18,7 +18,7 @@ for use with the Flink Streaming API. See the below sections for details.
   - [Input Stream(s)](#input-streams)
   - [Parallelism](#parallelism)
   - [Checkpointing](#checkpointing)
-  - [Timestamp Extraction / Watermark Emission](#timestamp-extraction-watermark-emission)
+  - [Timestamp Extraction / Watermark Emission](#timestamp-extraction-%2F-watermark-emission)
   - [Stream Cuts](#streamcuts)
   - [Historical Stream Processing](#historical-stream-processing)
 - [FlinkPravegaWriter](#flinkpravegawriter)

--- a/documentation/src/docs/streaming.md
+++ b/documentation/src/docs/streaming.md
@@ -18,7 +18,7 @@ for use with the Flink Streaming API. See the below sections for details.
   - [Input Stream(s)](#input-streams)
   - [Parallelism](#parallelism)
   - [Checkpointing](#checkpointing)
-  - [Timestamp Extraction \ Watermark Emission](#timestamp-extraction-watermark-emission)
+  - [Timestamp Extraction, Watermark Emission](#timestamp-extraction-watermark-emission)
   - [Stream Cuts](#streamcuts)
   - [Historical Stream Processing](#historical-stream-processing)
 - [FlinkPravegaWriter](#flinkpravegawriter)
@@ -101,7 +101,7 @@ The checkpoint mechanism works as a two-step process:
    - The [master hook](https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.html) handler from the job manager initiates the [`triggerCheckpoint`](https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.html#triggerCheckpoint-long-long-java.util.concurrent.Executor-) request to  the `ReaderCheckpointHook` that was registered with the Job Manager during `FlinkPravegaReader` source initialization. The `ReaderCheckpointHook` handler notifies Pravega to checkpoint the current reader state. This is a non-blocking call which returns a `future` once Pravega readers are done with the checkpointing.
    - A `CheckPoint` event will be sent by Pravega as part of the data stream flow and on receiving the event, the `FlinkPravegaReader` will initiate [`triggerCheckpoint`](https://github.com/apache/flink/blob/master/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java#L73) request to effectively let Flink continue and complete the checkpoint process.
 
-### Timestamp Extraction \ Watermark Emission
+### Timestamp Extraction, Watermark Emission
 
 Flink requires the events’ timestamps (each element in the stream needs to have its event timestamp assigned). This is achieved by accessing/extracting the timestamp from some field in the element. These are used to tell the system about progress in event time.
 

--- a/documentation/src/docs/streaming.md
+++ b/documentation/src/docs/streaming.md
@@ -101,7 +101,7 @@ The checkpoint mechanism works as a two-step process:
    - The [master hook](https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.html) handler from the job manager initiates the [`triggerCheckpoint`](https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.html#triggerCheckpoint-long-long-java.util.concurrent.Executor-) request to  the `ReaderCheckpointHook` that was registered with the Job Manager during `FlinkPravegaReader` source initialization. The `ReaderCheckpointHook` handler notifies Pravega to checkpoint the current reader state. This is a non-blocking call which returns a `future` once Pravega readers are done with the checkpointing.
    - A `CheckPoint` event will be sent by Pravega as part of the data stream flow and on receiving the event, the `FlinkPravegaReader` will initiate [`triggerCheckpoint`](https://github.com/apache/flink/blob/master/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java#L73) request to effectively let Flink continue and complete the checkpoint process.
 
-### Timestamp Extraction / Watermark Emission
+### Timestamp Extraction | Watermark Emission
 
 Flink requires the events’ timestamps (each element in the stream needs to have its event timestamp assigned). This is achieved by accessing/extracting the timestamp from some field in the element. These are used to tell the system about progress in event time.
 

--- a/documentation/src/docs/streaming.md
+++ b/documentation/src/docs/streaming.md
@@ -18,7 +18,7 @@ for use with the Flink Streaming API. See the below sections for details.
   - [Input Stream(s)](#input-streams)
   - [Parallelism](#parallelism)
   - [Checkpointing](#checkpointing)
-  - [Timestamp Extraction / Watermark Emission](#timestamp-extraction--watermark-emission)
+  - [Timestamp Extraction / Watermark Emission](#timestamp-extraction-watermark-emission)
   - [Stream Cuts](#streamcuts)
   - [Historical Stream Processing](#historical-stream-processing)
 - [FlinkPravegaWriter](#flinkpravegawriter)

--- a/documentation/src/docs/streaming.md
+++ b/documentation/src/docs/streaming.md
@@ -18,7 +18,7 @@ for use with the Flink Streaming API. See the below sections for details.
   - [Input Stream(s)](#input-streams)
   - [Parallelism](#parallelism)
   - [Checkpointing](#checkpointing)
-  - [Timestamp Extraction / Watermark Emission](#timestamp-extraction-/-watermark-emission)
+  - [Timestamp Extraction / Watermark Emission](#timestamp-extraction-watermark-emission)
   - [Stream Cuts](#streamcuts)
   - [Historical Stream Processing](#historical-stream-processing)
 - [FlinkPravegaWriter](#flinkpravegawriter)

--- a/documentation/src/docs/streaming.md
+++ b/documentation/src/docs/streaming.md
@@ -16,14 +16,14 @@ for use with the Flink Streaming API. See the below sections for details.
 - [FlinkPravegaReader](#flinkpravegareader)
   - [Parameters](#parameters)
   - [Input Stream(s)](#input-streams)
-  - [Parallelism](#parallelism)
+  - [Reader Parallelism](#reader-parallelism)
   - [Checkpointing](#checkpointing)
   - [Timestamp Extraction (Watermark Emission)](#timestamp-extraction-watermark-emission)
   - [Stream Cuts](#streamcuts)
   - [Historical Stream Processing](#historical-stream-processing)
 - [FlinkPravegaWriter](#flinkpravegawriter)
   - [Parameters](#parameters-1)
-  - [Parallelism](#parallelism-1)
+  - [Writer Parallelism](#writer-parallelism)
   - [Event Routing](#event-routing)
   - [Event Time Ordering](#event-time-ordering)
   - [Watermark](#watermark)
@@ -84,7 +84,7 @@ A stream may be specified in one of three ways:
  2. As a string containing an unqualified name, in the form `stream`. Such streams are resolved to the default scope.
  3. As an instance of `io.pravega.client.stream.Stream`, e.g. `Stream.of("my-scope", "my-stream")`.
 
-### Parallelism
+### Reader Parallelism
 
 The `FlinkPravegaReader` supports parallelization. Use the `setParallelism` method to of `Datastream` to configure the number of parallel instances to execute.  The parallel instances consume the stream in a coordinated manner, each consuming one or more stream segments.
 
@@ -171,7 +171,7 @@ A builder API is provided to construct an instance of `FlinkPravegaWriter`. See 
 |`enableWatermark`|true or false to enable/disable emitting Flink watermark in event-time semantics to Pravega streams.|
 |`enableMetrics`|true or false to enable/disable reporting Pravega metrics. Metrics is enabled by default.|
 
-### Parallelism
+### Writer Parallelism
 `FlinkPravegaWriter` supports parallelization. Use the `setParallelism` method to configure the number of parallel instances to execute.
 
 ### Event Routing

--- a/documentation/src/docs/streaming.md
+++ b/documentation/src/docs/streaming.md
@@ -18,7 +18,7 @@ for use with the Flink Streaming API. See the below sections for details.
   - [Input Stream(s)](#input-streams)
   - [Parallelism](#parallelism)
   - [Checkpointing](#checkpointing)
-  - [Timestamp Extraction / Watermark Emission](#timestamp-extraction-%2F-watermark-emission)
+  - [Timestamp Extraction / Watermark Emission](#timestamp-extraction)
   - [Stream Cuts](#streamcuts)
   - [Historical Stream Processing](#historical-stream-processing)
 - [FlinkPravegaWriter](#flinkpravegawriter)

--- a/documentation/src/docs/streaming.md
+++ b/documentation/src/docs/streaming.md
@@ -18,7 +18,7 @@ for use with the Flink Streaming API. See the below sections for details.
   - [Input Stream(s)](#input-streams)
   - [Parallelism](#parallelism)
   - [Checkpointing](#checkpointing)
-  - [Timestamp Extraction / Watermark Emission](#timestamp-extraction-watermark-emission)
+  - [Timestamp Extraction / Watermark Emission](#timestamp-extraction-/-watermark-emission)
   - [Stream Cuts](#streamcuts)
   - [Historical Stream Processing](#historical-stream-processing)
 - [FlinkPravegaWriter](#flinkpravegawriter)

--- a/documentation/src/docs/streaming.md
+++ b/documentation/src/docs/streaming.md
@@ -18,7 +18,7 @@ for use with the Flink Streaming API. See the below sections for details.
   - [Input Stream(s)](#input-streams)
   - [Parallelism](#parallelism)
   - [Checkpointing](#checkpointing)
-  - [Timestamp Extraction / Watermark Emission](#timestamp-extraction)
+  - [Timestamp Extraction | Watermark Emission](#timestamp-extraction-watermark-emission)
   - [Stream Cuts](#streamcuts)
   - [Historical Stream Processing](#historical-stream-processing)
 - [FlinkPravegaWriter](#flinkpravegawriter)

--- a/documentation/src/docs/streaming.md
+++ b/documentation/src/docs/streaming.md
@@ -18,7 +18,7 @@ for use with the Flink Streaming API. See the below sections for details.
   - [Input Stream(s)](#input-streams)
   - [Parallelism](#parallelism)
   - [Checkpointing](#checkpointing)
-  - [Timestamp Extraction, Watermark Emission](#timestamp-extraction-watermark-emission)
+  - [Timestamp Extraction (Watermark Emission)](#timestamp-extraction-watermark-emission)
   - [Stream Cuts](#streamcuts)
   - [Historical Stream Processing](#historical-stream-processing)
 - [FlinkPravegaWriter](#flinkpravegawriter)
@@ -101,7 +101,7 @@ The checkpoint mechanism works as a two-step process:
    - The [master hook](https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.html) handler from the job manager initiates the [`triggerCheckpoint`](https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.html#triggerCheckpoint-long-long-java.util.concurrent.Executor-) request to  the `ReaderCheckpointHook` that was registered with the Job Manager during `FlinkPravegaReader` source initialization. The `ReaderCheckpointHook` handler notifies Pravega to checkpoint the current reader state. This is a non-blocking call which returns a `future` once Pravega readers are done with the checkpointing.
    - A `CheckPoint` event will be sent by Pravega as part of the data stream flow and on receiving the event, the `FlinkPravegaReader` will initiate [`triggerCheckpoint`](https://github.com/apache/flink/blob/master/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java#L73) request to effectively let Flink continue and complete the checkpoint process.
 
-### Timestamp Extraction, Watermark Emission
+### Timestamp Extraction (Watermark Emission)
 
 Flink requires the events’ timestamps (each element in the stream needs to have its event timestamp assigned). This is achieved by accessing/extracting the timestamp from some field in the element. These are used to tell the system about progress in event time.
 


### PR DESCRIPTION
**Change log description**

**1. Changes under"FlinkPravegaReader" section:**
- "Parallelism" -> "Reader Parallelism";
- "Timestamp Extraction / Watermark Emission" -> "Timestamp Extraction (Watermark Emission)";

**2. Changes under"FlinkPravegaWriter" section:**
- "Parallelism" -> "Writer Parallelism";
 
**Purpose of the change**

Some anchor links within "Steaming Connector" page's table of contents were working in GitHub, but weren't in pravega.io. The invalid anchor links are listed within "Change Log Description".
- ["Streaming Connector" page on pravega.io](http://pravega.io/connectors/flink/docs/latest/streaming)
- ["Streaming Connector" page on GitHub](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/streaming.md)

The changes should make the anchor links work on both GitHub and pravega.io table of contents.

**What the code does**
The PR changes some anchor links and headers - those are listed in "Change Log Description" section.

**How to verify it**
You could verify that updated link is working within "Timestamp Extraction / Watermark Emission" section instantly:
  1. [current "Timestamp Extraction / Watermark Emission" link (redirects to TOC, not to the target section)](http://pravega.io/connectors/flink/docs/latest/streaming/#timestamp-extraction--watermark-emission), 
  2. [updated "Timestamp Extraction / Watermark Emission" link (redirects to the target section)](http://pravega.io/connectors/flink/docs/latest/streaming/#timestamp-extraction-watermark-emission)

For verification of other changes, I suppose you should re-generate the pravega.io's HTML pages.