### PR TITLE
[Issue-343] Inclusive vs. Exclusive Watermarks

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/watermark/LowerBoundAssigner.java
+++ b/src/main/java/io/pravega/connectors/flink/watermark/LowerBoundAssigner.java
@@ -31,7 +31,7 @@ public abstract class LowerBoundAssigner<T> implements AssignerWithTimeWindows<T
         }
         return timeWindow.getLowerTimeBound() == Long.MIN_VALUE ?
                 new Watermark(Long.MIN_VALUE) :
-                new Watermark(timeWindow.getLowerTimeBound() - 1L);
+                new Watermark(timeWindow.getLowerTimeBound());
     }
 }
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -310,11 +310,11 @@ public class FlinkPravegaReaderTest {
             Queue<Object> actual = testHarness.getOutput();
             Queue<Object> expected = new ConcurrentLinkedQueue<>();
             expected.add(record(1, 1));
-            // emit watermark (1 - 1 = 0)
-            expected.add(watermark(0));
-            expected.add(record(2, 2));
-            // emit watermark (2 - 1 = 1)
+            // emit watermark 1
             expected.add(watermark(1));
+            expected.add(record(2, 2));
+            // emit watermark 2
+            expected.add(watermark(2));
             // automatic watermark at the end of stream
             expected.add(watermark(Long.MAX_VALUE));
 


### PR DESCRIPTION
**Change log description**

- Change the code of `LowerBoundAssigner` so that it doesn't subtract one from the lower bound to determine the watermark
- Change the test code corresponding to `LowerBoundAssigner`

**Purpose of the change**
Fix #343 

**What the code does**
Flink treats the watermark in an inclusive manner, so the -1 subtraction should be removed to comply with that expectation.

**How to verify it**
`./gradlew clean build` should pass