### PR TITLE
[issue-350] Remove trivial comments and change improper comments

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/watermark/LowerBoundAssigner.java
+++ b/src/main/java/io/pravega/connectors/flink/watermark/LowerBoundAssigner.java
@@ -22,7 +22,7 @@ public abstract class LowerBoundAssigner<T> implements AssignerWithTimeWindows<T
     @Override
     public abstract long extractTimestamp(T element, long previousElementTimestamp);
 
-    // built-in watermark implementation which emits the lower bound - 1
+    // built-in watermark implementation which emits the lower bound
     @Override
     public Watermark getWatermark(TimeWindow timeWindow) {
         // There is no LowerBound watermark if we're near the head of the stream

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -310,10 +310,8 @@ public class FlinkPravegaReaderTest {
             Queue<Object> actual = testHarness.getOutput();
             Queue<Object> expected = new ConcurrentLinkedQueue<>();
             expected.add(record(1, 1));
-            // emit watermark 1
             expected.add(watermark(1));
             expected.add(record(2, 2));
-            // emit watermark 2
             expected.add(watermark(2));
             // automatic watermark at the end of stream
             expected.add(watermark(Long.MAX_VALUE));


### PR DESCRIPTION
**Change log description**

- Remove trivial comments at `FlinkPravegaReaderTest.java`
- Change improper comments at `LowerBoundAssigner.java`

**Purpose of the change**
Fix #350 

**What the code does**
Make the codes more clear.

**How to verify it**
`./gradlew clean build` should pass.