### PR TITLE
[issue-366] Remove check in getWatermark.

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/watermark/LowerBoundAssigner.java
+++ b/src/main/java/io/pravega/connectors/flink/watermark/LowerBoundAssigner.java
@@ -29,9 +29,7 @@ public abstract class LowerBoundAssigner<T> implements AssignerWithTimeWindows<T
         if (timeWindow == null || timeWindow.isNearHeadOfStream()) {
             return null;
         }
-        return timeWindow.getLowerTimeBound() == Long.MIN_VALUE ?
-                new Watermark(Long.MIN_VALUE) :
-                new Watermark(timeWindow.getLowerTimeBound());
+        return new Watermark(timeWindow.getLowerTimeBound());
     }
 }
 


### PR DESCRIPTION
Signed-off-by: AlexanderZhao1 <Alexander_Zhao@dell.com>

**Change log description**
`io.pravega.connectors.flink.watermark.LowerBoundAssigner`

**Purpose of the change**
After we fixed #343, we can directly return new Watermark(timeWindow.getLowerTimeBound()) instead of having check.

**What the code does**
Fixes #366 
**How to verify it**
`./gradlew clean build` should pass
