### PR TITLE
[issue-368] Ensure BatchClient not escaping null pointer exception

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.8.0-SNAPSHOT
-pravegaVersion=0.8.0-2508.30406cf-SNAPSHOT
+pravegaVersion=0.8.0-2540.5314cfd-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
Update the dependency and submodule to the latest commit `5314cfd`.

**Purpose of the change**
Fixes #368 

**What the code does**
Update the 0.8 connector to the latest Pravega client to include the fix https://github.com/pravega/pravega/pull/4767.

**How to verify it**
`./gradlew clean build` passes
Target to `master`, should cherry-pick to all `0.8` branches