### PR TITLE
[issue-371] Prepare for 0.7.1 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,8 @@ gradleMkdocsPluginVersion=1.1.0
 jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.7.1-SNAPSHOT
-pravegaVersion=0.7.0
+connectorVersion=0.7.1
+pravegaVersion=0.7.1
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: Guangfeng Xu <Guangfeng.Xu@dell.com>

**Change log description**
Prepare for the 0.7.1 release

**Purpose of the change**
Fix #371 

**What the code does**
Update the connector version into 0.7.1
Update the Pravega client version into 0.7.1

**How to verify it**
`./gradlew clean build` should pass