### PR TITLE
Issue 394: Increase Codecov project check threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+#
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+coverage:
+  status:
+    project:
+      default:
+        threshold: 20%


### PR DESCRIPTION
**Change log description**
Adds a `.codecov.yml` file to set the project check threshold to allow 20% drops in coverage.

**Purpose of the change**
Fixes #394 Allow drops in percentage of coverage checks.

**What the code does**
Allows 20% drops in coverage.

**How to verify it**
This PR's project check should pass even though this branch is failing in another PR.