### PR TITLE
[issue-403] Update the Pravega to the latest version before 0.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.8.0-SNAPSHOT
-pravegaVersion=0.8.0-2598.6acd317-SNAPSHOT
+pravegaVersion=0.8.0-2623.279ac21-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: Brian Zhou <b.zhou@dell.com>

**Change log description**
Update the Pravega to the latest version before 0.8

**Purpose of the change**
Fixes #403 

**What the code does**
Update both the dependency and the submodule to commit 279ac21

**How to verify it**
`./gradlew clean build` passes
Should cherry-pick to all `0.8` branches