### PR TITLE
[issue-413] Ensure the reader name below the length limit

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -62,7 +62,11 @@ public class FlinkPravegaUtils {
      * @return the generated default reader name.
      */
     public static String getReaderName(final String taskName, final int index, final int total) {
-        String readerName = "flink-task-" + taskName + "-" + index + "-" + total;
+        String shortTaskName = "";
+        if (taskName.length() >= 200) {
+            shortTaskName = taskName.substring(0, 200);
+        }
+        String readerName = "flink-task-" + shortTaskName + "-" + index + "-" + total;
         readerName = StringUtils.removePattern(readerName, "[^\\p{Alnum}\\.\\-]");
         return readerName;
     }

--- a/src/test/java/io/pravega/connectors/flink/util/FlinkPravegaUtilsTest.java
+++ b/src/test/java/io/pravega/connectors/flink/util/FlinkPravegaUtilsTest.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink.util;
+
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+public class FlinkPravegaUtilsTest {
+
+    @Test
+    public void testGetReaderName() {
+        String testStr = new String(new char[256]).replace('\0', 'a');
+        assertTrue(FlinkPravegaUtils.getReaderName(testStr, 1,1).length() < 256);
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/util/FlinkPravegaUtilsTest.java
+++ b/src/test/java/io/pravega/connectors/flink/util/FlinkPravegaUtilsTest.java
@@ -17,6 +17,6 @@ public class FlinkPravegaUtilsTest {
     @Test
     public void testGetReaderName() {
         String testStr = new String(new char[256]).replace('\0', 'a');
-        assertTrue(FlinkPravegaUtils.getReaderName(testStr, 1,1).length() < 256);
+        assertTrue(FlinkPravegaUtils.getReaderName(testStr, 1, 1).length() < 256);
     }
 }


### PR DESCRIPTION
**Change log description**
Add a check and truncate for too-long task name to generate reader ID.

**Purpose of the change**
Fixes #413 

**What the code does**
Pravega client 0.8 added a length check of 256 of the reader ID. But in SQL use cases, there will be long SQL queries to be the task name for the reader, which may violate this check. Add a check and truncate for too-long task name to generate reader ID.


**How to verify it**
`./gradlew clean build ` passes
