### PR TITLE
[issue-411] Prepare for 0.8.0 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,8 @@ gradleMkdocsPluginVersion=1.1.0
 jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.8.0-SNAPSHOT
-pravegaVersion=0.8.0-2623.279ac21-SNAPSHOT
+connectorVersion=0.8.0
+pravegaVersion=0.8.0
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
**Change log description**

- Updated Pravega and Connector version to `0.8.0`
- Updated Pravega sub-module commit to `v0.8.0`

**Purpose of the change**
Fixes #411 

**What the code does**
`gradle.properties` and Pravega sub-module configuration changes

**How to verify it**
`./gradlew clean build` should pass
