### PR TITLE
[issue-416] Retry close when InterruptedException is caught in Pravega reader

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ pravegaVersion=0.8.0
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
-usePravegaVersionSubModule=false
+usePravegaVersionSubModule=true
 
 # These properties are only needed for publishing to maven central
 # Pravega Signing Key

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,11 +30,11 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.8.0
-pravegaVersion=0.8.0
+pravegaVersion=0.8.1-2644.ca6290d-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
-usePravegaVersionSubModule=true
+usePravegaVersionSubModule=false
 
 # These properties are only needed for publishing to maven central
 # Pravega Signing Key

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -10,6 +10,7 @@
 package io.pravega.connectors.flink;
 
 import io.pravega.client.EventStreamClientFactory;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
@@ -360,7 +361,7 @@ public class FlinkPravegaReader<T>
 
     @Override
     public void close() throws Exception {
-        Throwable lastThrowable = null;
+        Throwable ex = null;
         if (eventStreamClientFactory != null) {
             try {
                 log.info("Closing Pravega eventStreamClientFactory");
@@ -370,7 +371,7 @@ public class FlinkPravegaReader<T>
                     log.warn("Interrupted while waiting for eventStreamClientFactory to close, retrying ...");
                     eventStreamClientFactory.close();
                 } else {
-                    lastThrowable = e;
+                    ex = ExceptionUtils.firstOrSuppressed(e, ex);
                 }
             }
         }
@@ -383,7 +384,7 @@ public class FlinkPravegaReader<T>
                     log.warn("Interrupted while waiting for ReaderGroupManager to close, retrying ...");
                     readerGroupManager.close();
                 } else {
-                    lastThrowable = e;
+                    ex = ExceptionUtils.firstOrSuppressed(e, ex);
                 }
             }
         }
@@ -396,12 +397,12 @@ public class FlinkPravegaReader<T>
                     log.warn("Interrupted while waiting for ReaderGroup to close, retrying ...");
                     readerGroup.close();
                 } else {
-                    lastThrowable = e;
+                    ex = ExceptionUtils.firstOrSuppressed(e, ex);
                 }
             }
         }
-        if (lastThrowable != null && lastThrowable instanceof Exception) {
-            throw (Exception) lastThrowable;
+        if (ex != null && ex instanceof Exception) {
+            throw (Exception) ex;
         }
     }
 


### PR DESCRIPTION
**Change log description**
- Update Pravega to use submodule to pick up the fix needed (https://github.com/pravega/pravega/pull/5226)
- Retry close when InterruptedException is caught in Pravega reader
- Record the last exception in close method and throw it 

**Purpose of the change**
Fixes #416 

**What the code does**
A "cleaner" close for `FlinkPravegaReader`

**How to verify it**
Tested locally with Flink and Pravega standalone cluster with reader application, no more GRPC threads after the job cancel.
`./gradlew clean build` passes
Target to `r0.8` now, should cherry-pick to all `0.8` branches.