### PR TITLE
[issue-370] Fix all javadoc "no return" warnings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,4 +11,7 @@ coverage:
   status:
     project:
       default:
+        threshold: 5%
+    patch:
+      default:
         threshold: 20%

--- a/src/main/java/io/pravega/connectors/flink/AbstractReaderBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractReaderBuilder.java
@@ -48,6 +48,7 @@ public abstract class AbstractReaderBuilder<B extends AbstractReaderBuilder> imp
      * The default client configuration is obtained from {@code PravegaConfig.fromDefaults()}.
      *
      * @param pravegaConfig the configuration to use.
+     * @return A builder to configure and create a reader.
      */
     public B withPravegaConfig(PravegaConfig pravegaConfig) {
         this.pravegaConfig = pravegaConfig;
@@ -124,6 +125,8 @@ public abstract class AbstractReaderBuilder<B extends AbstractReaderBuilder> imp
 
     /**
      * Gets the Pravega configuration.
+     *
+     * @return the instance of {@link PravegaConfig}.
      */
     public PravegaConfig getPravegaConfig() {
         Preconditions.checkState(pravegaConfig != null, "A Pravega configuration must be supplied.");
@@ -132,6 +135,8 @@ public abstract class AbstractReaderBuilder<B extends AbstractReaderBuilder> imp
 
     /**
      * Resolves the streams to be provided to the reader, based on the configured default scope.
+     *
+     * @return A list of {@link StreamWithBoundaries} that is ready to be read
      */
     protected List<StreamWithBoundaries> resolveStreams() {
         Preconditions.checkState(!streams.isEmpty(), "At least one stream must be supplied.");
@@ -154,6 +159,8 @@ public abstract class AbstractReaderBuilder<B extends AbstractReaderBuilder> imp
 
     /**
      * getter to fetch the metrics flag.
+     *
+     * @return A boolean if metrics is enabled
      */
     public boolean isMetricsEnabled() {
         return enableMetrics;

--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingReaderBuilder.java
@@ -57,6 +57,7 @@ public abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStream
      * The default value is generated based on other inputs.
      *
      * @param uid the uid to use.
+     * @return A builder to configure and create a streaming reader.
      */
     public B uid(String uid) {
         this.uid = uid;
@@ -69,6 +70,7 @@ public abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStream
      * The default value is taken from the {@link PravegaConfig} {@code defaultScope} property.
      *
      * @param scope the scope name.
+     * @return A builder to configure and create a streaming reader.
      */
     public B withReaderGroupScope(String scope) {
         this.readerGroupScope = Preconditions.checkNotNull(scope);
@@ -79,6 +81,7 @@ public abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStream
      * Configures the reader group name.
      *
      * @param readerGroupName the reader group name.
+     * @return A builder to configure and create a streaming reader.
      */
     public B withReaderGroupName(String readerGroupName) {
         this.readerGroupName = Preconditions.checkNotNull(readerGroupName);
@@ -89,6 +92,7 @@ public abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStream
      * Sets the group refresh time, with a default of 1 second.
      *
      * @param groupRefreshTime The group refresh time
+     * @return A builder to configure and create a streaming reader.
      */
     public B withReaderGroupRefreshTime(Time groupRefreshTime) {
         this.readerGroupRefreshTime = groupRefreshTime;
@@ -99,6 +103,7 @@ public abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStream
      * Sets the timeout for initiating a checkpoint in Pravega.
      *
      * @param checkpointInitiateTimeout The timeout
+     * @return A builder to configure and create a streaming reader.
      */
     public B withCheckpointInitiateTimeout(Time checkpointInitiateTimeout) {
         Preconditions.checkArgument(checkpointInitiateTimeout.getSize() > 0, "timeout must be > 0");
@@ -111,6 +116,7 @@ public abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStream
      * expires (without an event being returned), another call will be made.
      *
      * @param eventReadTimeout The timeout
+     * @return A builder to configure and create a streaming reader.
      */
     public B withEventReadTimeout(Time eventReadTimeout) {
         Preconditions.checkArgument(eventReadTimeout.getSize() > 0, "timeout must be > 0");
@@ -126,6 +132,7 @@ public abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStream
      * This configuration is particularly relevant when multiple checkpoint requests need to be honored (e.g., frequent savepoint requests being triggered concurrently).
      *
      * @param maxOutstandingCheckpointRequest maximum outstanding checkpoint request.
+     * @return A builder to configure and create a streaming reader.
      */
     public B withMaxOutstandingCheckpointRequest(int maxOutstandingCheckpointRequest) {
         this.maxOutstandingCheckpointRequest = maxOutstandingCheckpointRequest;
@@ -201,6 +208,8 @@ public abstract class AbstractStreamingReaderBuilder<T, B extends AbstractStream
      * 1. be stable across savepoints for the same inputs
      * 2. disambiguate one source from another (e.g. in a program that uses numerous instances of {@link FlinkPravegaReader})
      * 3. allow for reconfiguration of the stream cuts and timeouts
+     *
+     * @return A generated reader group ID.
      */
     public String generateUid() {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
@@ -42,6 +42,7 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
      * Sets the writer mode to provide at-least-once or exactly-once guarantees.
      *
      * @param writerMode The writer mode of {@code BEST_EFFORT}, {@code ATLEAST_ONCE}, or {@code EXACTLY_ONCE}.
+     * @return A builder to configure and create a streaming writer.
      */
     public B withWriterMode(PravegaWriterMode writerMode) {
         this.writerMode = writerMode;
@@ -52,6 +53,7 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
      * Enable watermark.
      *
      * @param enableWatermark boolean
+     * @return A builder to configure and create a streaming writer.
      */
     public B enableWatermark(boolean enableWatermark) {
         this.enableWatermark = enableWatermark;
@@ -67,6 +69,7 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
      * This configuration setting sets the lease renewal period.  The default value is 30 seconds.
      *
      * @param period the lease renewal period
+     * @return A builder to configure and create a streaming writer.
      */
     public B withTxnLeaseRenewalPeriod(Time period) {
         Preconditions.checkArgument(period.getSize() > 0, "The timeout must be a positive value.");
@@ -79,6 +82,7 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
      *
      * @param serializationSchema the deserialization schema to use.
      * @param eventRouter the event router to use.
+     * @return An instance of {@link FlinkPravegaWriter}.
      */
     protected FlinkPravegaWriter<T> createSinkFunction(SerializationSchema<T> serializationSchema, PravegaEventRouter<T> eventRouter) {
         Preconditions.checkNotNull(serializationSchema, "serializationSchema");

--- a/src/main/java/io/pravega/connectors/flink/AbstractWriterBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractWriterBuilder.java
@@ -40,6 +40,7 @@ public abstract class AbstractWriterBuilder<B extends AbstractWriterBuilder> imp
      * The default client configuration is obtained from {@code PravegaConfig.fromDefaults()}.
      *
      * @param pravegaConfig the configuration to use.
+     * @return A builder to configure and create a writer.
      */
     public B withPravegaConfig(PravegaConfig pravegaConfig) {
         this.pravegaConfig = pravegaConfig;
@@ -70,6 +71,8 @@ public abstract class AbstractWriterBuilder<B extends AbstractWriterBuilder> imp
 
     /**
      * Gets the Pravega configuration.
+     *
+     * @return the instance of {@link PravegaConfig}.
      */
     public PravegaConfig getPravegaConfig() {
         Preconditions.checkState(pravegaConfig != null, "A Pravega configuration must be supplied.");
@@ -78,6 +81,8 @@ public abstract class AbstractWriterBuilder<B extends AbstractWriterBuilder> imp
 
     /**
      * Resolves the stream to be provided to the writer, based on the configured default scope.
+     *
+     * @return the resolved stream instance.
      */
     public Stream resolveStream() {
         Preconditions.checkState(stream != null, "A stream must be supplied.");
@@ -98,6 +103,8 @@ public abstract class AbstractWriterBuilder<B extends AbstractWriterBuilder> imp
 
     /**
      * getter to fetch the metrics flag.
+     *
+     * @return A boolean if metrics is enabled
      */
     public boolean isMetricsEnabled() {
         return enableMetrics;

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
@@ -174,7 +174,9 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
 
     /**
      * Gets a builder {@link FlinkPravegaInputFormat} to read Pravega streams using the Flink batch API.
+     *
      * @param <T> the element type.
+     * @return A builder to configure and create a batch reader.
      */
     public static <T> Builder<T> builder() {
         return new Builder<>();
@@ -197,6 +199,7 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
          * Sets the deserialization schema.
          *
          * @param deserializationSchema The deserialization schema
+         * @return A builder to configure and create a batch reader.
          */
         public Builder<T> withDeserializationSchema(DeserializationSchema<T> deserializationSchema) {
             this.deserializationSchema = deserializationSchema;

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaOutputFormat.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaOutputFormat.java
@@ -243,6 +243,7 @@ public class FlinkPravegaOutputFormat<T> extends RichOutputFormat<T> {
          * Sets the serialization schema.
          *
          * @param serializationSchema The serialization schema
+         * @return A builder to configure and create a batch writer.
          */
         public Builder<T> withSerializationSchema(SerializationSchema<T> serializationSchema) {
             this.serializationSchema = serializationSchema;
@@ -253,6 +254,7 @@ public class FlinkPravegaOutputFormat<T> extends RichOutputFormat<T> {
          * Sets the event router.
          *
          * @param eventRouter the event router which produces a key per event.
+         * @return A builder to configure and create a batch writer.
          */
         public Builder<T> withEventRouter(PravegaEventRouter<T> eventRouter) {
             this.eventRouter = eventRouter;
@@ -266,6 +268,8 @@ public class FlinkPravegaOutputFormat<T> extends RichOutputFormat<T> {
 
         /**
          * Builds the {@link FlinkPravegaOutputFormat}.
+         *
+         * @return An instance of {@link FlinkPravegaOutputFormat}
          */
         public FlinkPravegaOutputFormat<T> build() {
             Preconditions.checkNotNull(serializationSchema, "serializationSchema");

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -609,6 +609,8 @@ public class FlinkPravegaReader<T>
 
     /**
      * Create the {@link ReaderGroupManager} for the current configuration.
+     *
+     * @return An instance of {@link ReaderGroupManager}
      */
     protected ReaderGroupManager createReaderGroupManager() {
         if (readerGroupManager == null) {
@@ -620,6 +622,8 @@ public class FlinkPravegaReader<T>
 
     /**
      * Create the {@link EventStreamClientFactory} for the current configuration.
+     *
+     * @return An instance of {@link EventStreamClientFactory}
      */
     protected EventStreamClientFactory createEventStreamClientFactory() {
         if (eventStreamClientFactory == null) {
@@ -631,7 +635,9 @@ public class FlinkPravegaReader<T>
 
     /**
      * Create the {@link EventStreamReader} for the current configuration.
+     *
      * @param readerId the readerID to use.
+     * @return An instance of {@link EventStreamReader}
      */
     protected EventStreamReader<T> createEventStreamReader(String readerId) {
         return createPravegaReader(
@@ -648,7 +654,9 @@ public class FlinkPravegaReader<T>
 
     /**
      * Gets a builder for {@link FlinkPravegaReader} to read Pravega streams using the Flink streaming API.
+     *
      * @param <T> the element type.
+     * @return A new builder of {@link FlinkPravegaReader}
      */
     public static <T> FlinkPravegaReader.Builder<T> builder() {
         return new Builder<>();
@@ -709,7 +717,9 @@ public class FlinkPravegaReader<T>
 
         /**
          * Builds a {@link FlinkPravegaReader} based on the configuration.
+         *
          * @throws IllegalStateException if the configuration is invalid.
+         * @return An instance of {@link FlinkPravegaReader}
          */
         public FlinkPravegaReader<T> build() {
             FlinkPravegaReader<T> reader = buildSourceFunction();

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSink.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSink.java
@@ -67,7 +67,7 @@ public class FlinkPravegaTableSink implements AppendStreamTableSink<Row>, BatchT
     /**
      * Creates a copy of the sink for configuration purposes.
      */
-    protected FlinkPravegaTableSink createCopy() {
+    private FlinkPravegaTableSink createCopy() {
         return new FlinkPravegaTableSink(writerFactory, outputFormatFactory, schema);
     }
 

--- a/src/main/java/io/pravega/connectors/flink/PravegaConfig.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaConfig.java
@@ -49,6 +49,8 @@ public class PravegaConfig implements Serializable {
 
     /**
      * Gets a configuration based on defaults obtained from the local environment.
+     *
+     * @return A default instance of {@link PravegaConfig}
      */
     public static PravegaConfig fromDefaults() {
         return new PravegaConfig(System.getProperties(), System.getenv(), ParameterTool.fromMap(Collections.emptyMap()));
@@ -58,6 +60,7 @@ public class PravegaConfig implements Serializable {
      * Gets a configuration based on defaults obtained from the local environment plus the given program parameters.
      *
      * @param params the parameters to use.
+     * @return An instance of {@link PravegaConfig}
      */
     public static PravegaConfig fromParams(ParameterTool params) {
         return new PravegaConfig(System.getProperties(), System.getenv(), params);
@@ -67,6 +70,8 @@ public class PravegaConfig implements Serializable {
 
     /**
      * Gets the {@link ClientConfig} to use with the Pravega client.
+     *
+     * @return The Pravega {@link ClientConfig}
      */
     public ClientConfig getClientConfig() {
         ClientConfig.ClientConfigBuilder builder = ClientConfig.builder()
@@ -137,6 +142,7 @@ public class PravegaConfig implements Serializable {
      * Configures the Pravega controller RPC URI.
      *
      * @param controllerURI The URI.
+     * @return current instance of PravegaConfig.
      */
     public PravegaConfig withControllerURI(URI controllerURI) {
         this.controllerURI = controllerURI;
@@ -157,6 +163,7 @@ public class PravegaConfig implements Serializable {
      * Configures the default Pravega scope, to resolve unqualified stream names and to support reader groups.
      *
      * @param scope The scope to use (with lowest priority).
+     * @return current instance of PravegaConfig.
      */
     public PravegaConfig withDefaultScope(String scope) {
         if (this.defaultScope == null) {
@@ -169,6 +176,7 @@ public class PravegaConfig implements Serializable {
      * Configures the self-defined Pravega scope.
      *
      * @param scope The scope to use (with highest priority).
+     * @return current instance of PravegaConfig.
      */
     public PravegaConfig withScope(String scope) {
         this.defaultScope = scope;
@@ -177,6 +185,8 @@ public class PravegaConfig implements Serializable {
 
     /**
      * Gets the default Pravega scope.
+     *
+     * @return current default scope name.
      */
     @Nullable
     public String getDefaultScope() {
@@ -191,6 +201,7 @@ public class PravegaConfig implements Serializable {
      * Configures the Pravega credentials to use.
      *
      * @param credentials a credentials object.
+     * @return current instance of PravegaConfig.
      */
     public PravegaConfig withCredentials(Credentials credentials) {
         this.credentials = credentials;
@@ -201,6 +212,7 @@ public class PravegaConfig implements Serializable {
      * Enables or disables TLS hostname validation (default: true).
      *
      * @param validateHostname a boolean indicating whether to validate the hostname on incoming requests.
+     * @return current instance of PravegaConfig.
      */
     public PravegaConfig withHostnameValidation(boolean validateHostname) {
         this.validateHostname = validateHostname;

--- a/src/main/java/io/pravega/connectors/flink/serialization/WrappingSerializer.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/WrappingSerializer.java
@@ -18,6 +18,8 @@ public interface WrappingSerializer<T>  {
 
     /**
      * Gets the wrapped Pravega Serializer.
+     *
+     * @return a Pravega {@link Serializer}.
      */
     Serializer<T> getWrappedSerializer();
 }

--- a/src/main/java/io/pravega/connectors/flink/table/descriptors/Pravega.java
+++ b/src/main/java/io/pravega/connectors/flink/table/descriptors/Pravega.java
@@ -338,7 +338,9 @@ public class Pravega extends ConnectorDescriptor {
 
         /**
          * Sets the field name to use as a Pravega event routing key.
+         *
          * @param fieldName the field name.
+         * @return A builder to configure and create a writer.
          */
         public TableSinkWriterBuilder withRoutingKeyField(String fieldName) {
             this.routingKeyFieldName = fieldName;
@@ -347,7 +349,9 @@ public class Pravega extends ConnectorDescriptor {
 
         /**
          * Pass the serialization schema to be used.
+         *
          * @param serializationSchema the serialization schema.
+         * @return A builder to configure and create a writer.
          */
         public TableSinkWriterBuilder withSerializationSchema(SerializationSchema<Row> serializationSchema) {
             this.serializationSchema = serializationSchema;
@@ -361,7 +365,9 @@ public class Pravega extends ConnectorDescriptor {
 
         /**
          * Creates the sink function based on the given table schema and current builder state.
+         *
          * @param tableSchema the schema of the sink table
+         * @return An instance of {@link FlinkPravegaWriter}.
          */
         public FlinkPravegaWriter<Row> createSinkFunction(TableSchema tableSchema) {
             Preconditions.checkState(routingKeyFieldName != null, "The routing key field must be provided.");
@@ -372,7 +378,9 @@ public class Pravega extends ConnectorDescriptor {
 
         /**
          * Creates FlinkPravegaOutputFormat based on the given table schema and current builder state.
+         *
          * @param tableSchema the schema of the sink table
+         * @return An instance of {@link FlinkPravegaOutputFormat}.
          */
         public FlinkPravegaOutputFormat<Row> createOutputFormat(TableSchema tableSchema) {
             Preconditions.checkState(routingKeyFieldName != null, "The routing key field must be provided.");


### PR DESCRIPTION
Signed-off-by: Brian Zhou <b.zhou@dell.com>

**Change log description**
- Fix all javadoc "no return" warnings

**Purpose of the change**
Fixes #370 

**What the code does**
- Fix all javadoc no return warnings
- Adjust the code coverage constraint.

**How to verify it**
`./gradlew clean build` passes
Should cherry-pick to all `0.9` branches.
