### PR TITLE
[issue-433] Make event router optional

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
@@ -86,7 +86,6 @@ public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStream
      */
     protected FlinkPravegaWriter<T> createSinkFunction(SerializationSchema<T> serializationSchema, PravegaEventRouter<T> eventRouter) {
         Preconditions.checkNotNull(serializationSchema, "serializationSchema");
-        Preconditions.checkNotNull(eventRouter, "eventRouter");
         return new FlinkPravegaWriter<>(
                 getPravegaConfig().getClientConfig(),
                 resolveStream(),

--- a/src/main/java/io/pravega/connectors/flink/table/descriptors/Pravega.java
+++ b/src/main/java/io/pravega/connectors/flink/table/descriptors/Pravega.java
@@ -370,9 +370,11 @@ public class Pravega extends ConnectorDescriptor {
          * @return An instance of {@link FlinkPravegaWriter}.
          */
         public FlinkPravegaWriter<Row> createSinkFunction(TableSchema tableSchema) {
-            Preconditions.checkState(routingKeyFieldName != null, "The routing key field must be provided.");
             Preconditions.checkState(serializationSchema != null, "The serializationSchema must be provided.");
-            PravegaEventRouter<Row> eventRouter = new FlinkPravegaTableSink.RowBasedRouter(routingKeyFieldName, tableSchema.getFieldNames(), tableSchema.getFieldDataTypes());
+            PravegaEventRouter<Row> eventRouter = null;
+            if (routingKeyFieldName != null) {
+                eventRouter = new FlinkPravegaTableSink.RowBasedRouter(routingKeyFieldName, tableSchema.getFieldNames(), tableSchema.getFieldDataTypes());
+            }
             return createSinkFunction(serializationSchema, eventRouter);
         }
 
@@ -383,9 +385,11 @@ public class Pravega extends ConnectorDescriptor {
          * @return An instance of {@link FlinkPravegaOutputFormat}.
          */
         public FlinkPravegaOutputFormat<Row> createOutputFormat(TableSchema tableSchema) {
-            Preconditions.checkState(routingKeyFieldName != null, "The routing key field must be provided.");
             Preconditions.checkState(serializationSchema != null, "The serializationSchema must be provided.");
-            PravegaEventRouter<Row> eventRouter = new FlinkPravegaTableSink.RowBasedRouter(routingKeyFieldName, tableSchema.getFieldNames(), tableSchema.getFieldDataTypes());
+            PravegaEventRouter<Row> eventRouter = null;
+            if (routingKeyFieldName != null) {
+                eventRouter = new FlinkPravegaTableSink.RowBasedRouter(routingKeyFieldName, tableSchema.getFieldNames(), tableSchema.getFieldDataTypes());
+            }
             return new FlinkPravegaOutputFormat<>(
                     getPravegaConfig().getClientConfig(),
                     resolveStream(),

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.util.Preconditions;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
@@ -51,6 +52,7 @@ public class FlinkPravegaUtils {
         // a keyed stream is used to ensure that all elements for a given key are forwarded to the same writer instance.
         // the parallelism must match between the ordering operator and the sink operator to ensure that
         // a forwarding strategy (as opposed to a rebalancing strategy) is used by Flink between the two operators.
+        Preconditions.checkNotNull(writer.getEventRouter(), "Event router should not be null");
         return stream
                 .keyBy(new PravegaEventRouterKeySelector<>(writer.getEventRouter()))
                 .transform("reorder", stream.getType(), new EventTimeOrderingOperator<>()).setParallelism(parallelism).forward()

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatTest.java
@@ -86,23 +86,10 @@ public class FlinkPravegaOutputFormatTest {
 
     /**
      * Testing the builder for right configurations.
-     * Should fail since we don't pass {@link PravegaEventRouter}
-     */
-    @Test(expected = NullPointerException.class)
-    public void testBuilderForFailure2() {
-        FlinkPravegaOutputFormat.<String>builder()
-                .withSerializationSchema(serializationSchema)
-                .withPravegaConfig(pravegaConfig)
-                .forStream(stream)
-                .build();
-    }
-
-    /**
-     * Testing the builder for right configurations.
      * Should fail since we don't pass {@link Stream}
      */
     @Test(expected = IllegalStateException.class)
-    public void testBuilderForFailure3() {
+    public void testBuilderForFailure2() {
         FlinkPravegaOutputFormat.<String>builder()
                 .withEventRouter(eventRouter)
                 .withSerializationSchema(serializationSchema)

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterITCase.java
@@ -11,7 +11,6 @@ package io.pravega.connectors.flink;
 
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
-import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.TimeWindow;
 import io.pravega.connectors.flink.util.FlinkPravegaUtils;
@@ -109,23 +108,13 @@ public class FlinkPravegaWriterITCase {
     private List<Integer> readAllEvents(final String streamName) throws Exception {
         Preconditions.checkNotNull(streamName);
 
-        // TODO: Remove the end marker workaround once the following issue is fixed:
-        // https://github.com/pravega/pravega/issues/408
-        final int streamEndMarker = 99999;
-
-        // Write the end marker.
-        @Cleanup
-        EventStreamWriter<Integer> eventWriter = SETUP_UTILS.getIntegerWriter(streamName);
-        eventWriter.writeEvent("fixedkey", streamEndMarker);
-        eventWriter.flush();
-
         // Read all data from the stream.
         @Cleanup
         EventStreamReader<Integer> consumer = SETUP_UTILS.getIntegerReader(streamName);
         List<Integer> elements = new ArrayList<>();
         while (true) {
             Integer event = consumer.readNextEvent(1000).getEvent();
-            if (event == null || event == streamEndMarker) {
+            if (event == null) {
                 log.info("Reached end of stream: " + streamName);
                 break;
             }
@@ -210,7 +199,6 @@ public class FlinkPravegaWriterITCase {
                 .forStream(streamName)
                 .withPravegaConfig(SETUP_UTILS.getPravegaConfig())
                 .withSerializationSchema(new IntSerializer())
-                .withEventRouter(event -> "fixedkey")
                 .withWriterMode(PravegaWriterMode.ATLEAST_ONCE)
                 .enableWatermark(true)
                 .build();
@@ -337,7 +325,6 @@ public class FlinkPravegaWriterITCase {
                     .forStream(streamName)
                     .withPravegaConfig(SETUP_UTILS.getPravegaConfig())
                     .withSerializationSchema(new IntSerializer())
-                    .withEventRouter(event -> "fixedkey")
                     .withWriterMode(PravegaWriterMode.EXACTLY_ONCE)
                     .withTxnLeaseRenewalPeriod(Time.seconds(30))
                     .enableWatermark(true)

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -85,7 +85,7 @@ public class FlinkPravegaWriterTest {
     public void testOpenClose() throws Exception {
         EventStreamWriter<Integer> pravegaWriter = mockEventStreamWriter();
         EventStreamClientFactory clientFactory = mockClientFactory(pravegaWriter);
-        FlinkPravegaWriter<Integer> sinkFunction = spySinkFunction(clientFactory, new FixedEventRouter<>(), false, PravegaWriterMode.ATLEAST_ONCE);
+        FlinkPravegaWriter<Integer> sinkFunction = spySinkFunction(clientFactory, null, false, PravegaWriterMode.ATLEAST_ONCE);
 
         try {
             try (StreamSinkOperatorTestHarness<Integer> testHarness = createTestHarness(sinkFunction)) {


### PR DESCRIPTION
**Change log description**
- Make event router optional

**Purpose of the change**
Fixes #433 

**What the code does**
Make event router nullable for `FlinkPravegaWriter` and `FlinkPravegaOutputFormat`, and use random routing to write data when event router is null.

**How to verify it**
`./gradlew clean build` passes