### PR TITLE
[issue-440] Make schema registry dependencies optional and clean up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,8 @@ dependencies {
     // provided by application if needed
     compileOnly group: 'io.pravega', name: 'schemaregistry-serializers', classifier: 'all', version: schemaRegistryVersion
 
+    compileOnly group: 'org.slf4j', name: 'slf4j-api', version: slf4jApiVersion // provided by flink-runtime
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: apacheCommonsVersion
     compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion // not needed at runtime
     annotationProcessor 'org.projectlombok:lombok:' + lombokVersion
     compileOnly group: 'org.apache.flink', name: 'flink-streaming-java_'+flinkScalaVersion, version: flinkVersion // provided by application

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ plugins {
     id "com.github.spotbugs"
 }
 apply plugin: 'eclipse'
+apply plugin: 'org.ajoberstar.grgit'
 apply from: 'gradle/idea.gradle'
 apply from: 'gradle/java.gradle'
 apply from: 'gradle/checkstyle.gradle'
@@ -36,9 +37,7 @@ apply from: 'gradle/spotbugs.gradle'
 apply from: 'gradle/jacoco.gradle'
 apply from: 'gradle/maven.gradle'
 apply from: 'gradle/bintray.gradle'
-apply plugin: 'org.ajoberstar.grgit'
 apply from: 'gradle/mkdocs.gradle'
-apply from: 'gradle/jacoco.gradle'
 
 gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {
@@ -101,61 +100,42 @@ test {
 
 dependencies {
     compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-    testCompileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-    compileOnly group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
-    testCompileOnly group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
 
     compile(group: 'io.pravega', name: 'pravega-client', version: pravegaVersion) {
         exclude group:  'org.slf4j', module: 'slf4j-api'
-
-        // lombok should be compileOnly
-        exclude group: 'org.projectlombok', module: 'lombok'
-
-        // pravega-shared pulls in curator which isn't needed on the client
-        exclude group: 'org.apache.curator', module: 'curator-recipes'
     }
 
-    // schema registry dependencies
+    // provided by application if needed
     compileOnly group: 'io.pravega', name: 'schemaregistry-serializers', classifier: 'all', version: schemaRegistryVersion
 
-    compileOnly group: 'org.slf4j', name: 'slf4j-api', version: slf4jApiVersion // provided by flink-runtime
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: apacheCommonsVersion
     compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion // not needed at runtime
     annotationProcessor 'org.projectlombok:lombok:' + lombokVersion
-    compileOnly group: 'org.apache.flink', name: 'flink-streaming-scala_'+flinkScalaVersion, version: flinkVersion // provided by application
+    compileOnly group: 'org.apache.flink', name: 'flink-streaming-java_'+flinkScalaVersion, version: flinkVersion // provided by application
 
     compileOnly group: 'org.apache.flink', name: 'flink-table-planner_'+flinkScalaVersion, version: flinkVersion // provided by application
     compileOnly group: 'org.apache.flink', name: 'flink-table-planner-blink_'+flinkScalaVersion, version: flinkVersion // provided by application
     compileOnly group: 'org.apache.flink', name: 'flink-table-api-java-bridge_'+flinkScalaVersion, version: flinkVersion // provided by application
 
-    compileOnly group: 'org.apache.flink', name: 'flink-json', version: flinkVersion
-    compileOnly group: 'org.apache.flink', name: 'flink-avro', version: flinkVersion
-    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion // provided by flink-runtime
-
     testAnnotationProcessor 'org.projectlombok:lombok:' + lombokVersion
-    testCompile group: 'junit', name: 'junit', version: junitVersion
-    testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
-    testCompile group: 'org.apache.flink', name: 'flink-tests', version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-core', classifier: 'tests', version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-test-utils_'+flinkScalaVersion, version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-core', classifier: 'tests', version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-streaming-java_'+flinkScalaVersion, classifier: 'tests', version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-runtime_'+flinkScalaVersion, classifier: 'tests', version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-table-common', classifier: 'tests', version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-json', version: flinkVersion
-    testCompile group: 'org.apache.flink', name: 'flink-avro', version: flinkVersion
-    testCompile group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion
+    testCompile (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
+        exclude group:  'org.slf4j', module: 'slf4j-api'
+    }
     testCompile (group: 'io.pravega', name: 'schemaregistry-server', version: schemaRegistryVersion) {
         transitive = false
     }
-    testCompile group: 'io.pravega', name: 'schemaregistry-serializers', classifier: 'all', version: schemaRegistryVersion
+    testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+    testCompile group: 'org.apache.flink', name: 'flink-core', classifier: 'tests', version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-tests', version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-test-utils_'+flinkScalaVersion, version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-runtime_'+flinkScalaVersion, classifier: 'tests', version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-table-common', classifier: 'tests', version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-streaming-java_'+flinkScalaVersion, classifier: 'tests', version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-json', version: flinkVersion
+    testCompile group: 'org.apache.flink', name: 'flink-avro', version: flinkVersion
 
     //  configuring the shaded pom dependencies
     shadowOnly group: 'org.slf4j', name: 'slf4j-api', version: slf4jApiVersion
     shadowOnly group: 'org.apache.flink', name: 'flink-streaming-java_'+flinkScalaVersion, version: flinkVersion
-    shadowOnly group: 'org.apache.flink', name: 'flink-table', version: flinkVersion
-    shadowOnly group: 'org.apache.flink', name: 'flink-json', version: flinkVersion
-    shadowOnly group: 'org.apache.flink', name: 'flink-avro', version: flinkVersion
 }
 
 shadowJar {

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -14,12 +14,8 @@
     <allow pkg="com.google"/>
     <allow pkg="io.pravega"/>
     <allow pkg="lombok"/>
-    <allow pkg="com.fasterxml.jackson"/>
     <allow pkg="org.apache"/>
     <allow pkg="edu.umd.cs.findbugs"/>
-
-    <!-- flink dependencies -->
-    <allow pkg="scala"/>
 
     <!-- test dependencies -->
     <allow pkg="org.mockito"/>

--- a/src/main/java/io/pravega/connectors/flink/PravegaConfig.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaConfig.java
@@ -11,8 +11,6 @@ package io.pravega.connectors.flink;
 
 import io.pravega.client.ClientConfig;
 import io.pravega.client.stream.Stream;
-import io.pravega.schemaregistry.client.SchemaRegistryClientConfig;
-import io.pravega.schemaregistry.serializer.shared.credentials.PravegaCredentialProvider;
 import io.pravega.shared.security.auth.Credentials;
 import lombok.Data;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -104,6 +102,7 @@ public class PravegaConfig implements Serializable {
         final PravegaConfig that = (PravegaConfig) o;
         return validateHostname == that.validateHostname &&
                 controllerURI.equals(that.controllerURI) &&
+                schemaRegistryURI.equals(that.schemaRegistryURI) &&
                 defaultScope.equals(that.defaultScope) &&
                 Objects.equals(credentials, that.credentials) &&
                 Objects.equals(trustStore, that.trustStore);
@@ -111,28 +110,7 @@ public class PravegaConfig implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(controllerURI, defaultScope, credentials, validateHostname, trustStore);
-    }
-
-    /**
-     * Gets the schema registry client.
-     *
-     * @return the configuration for schema registry client
-     */
-    public SchemaRegistryClientConfig getSchemaRegistryClientConfig() {
-        Preconditions.checkNotNull(defaultScope, "Default Scope should be set for schema registry client");
-        Preconditions.checkNotNull(schemaRegistryURI, "Schema Registry URI should be set for schema registry client");
-
-        SchemaRegistryClientConfig.SchemaRegistryClientConfigBuilder builder = SchemaRegistryClientConfig.builder()
-                .schemaRegistryUri(schemaRegistryURI);
-
-        if (credentials != null) {
-            builder.authentication(credentials.getAuthenticationType(), credentials.getAuthenticationToken());
-        } else {
-            builder.authentication(new PravegaCredentialProvider(getClientConfig()));
-        }
-
-        return builder.build();
+        return Objects.hash(controllerURI, schemaRegistryURI, defaultScope, credentials, validateHostname, trustStore);
     }
 
     /**
@@ -230,6 +208,16 @@ public class PravegaConfig implements Serializable {
         return defaultScope;
     }
 
+    /**
+     * Gets the Pravega schema registry URI.
+     *
+     * @return Pravega schema registry URI.
+     */
+    @Nullable
+    public URI getSchemaRegistryUri() {
+        return schemaRegistryURI;
+    }
+
     // endregion
 
     // region Security
@@ -243,6 +231,16 @@ public class PravegaConfig implements Serializable {
     public PravegaConfig withCredentials(Credentials credentials) {
         this.credentials = credentials;
         return this;
+    }
+
+    /**
+     * Gets the Pravega schema registry URI.
+     *
+     * @return Pravega schema registry URI.
+     */
+    @Nullable
+    public Credentials getCredentials() {
+        return credentials;
     }
 
     /**

--- a/src/main/java/io/pravega/connectors/flink/PravegaConfig.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaConfig.java
@@ -102,8 +102,8 @@ public class PravegaConfig implements Serializable {
         final PravegaConfig that = (PravegaConfig) o;
         return validateHostname == that.validateHostname &&
                 controllerURI.equals(that.controllerURI) &&
-                schemaRegistryURI.equals(that.schemaRegistryURI) &&
                 defaultScope.equals(that.defaultScope) &&
+                Objects.equals(schemaRegistryURI, that.schemaRegistryURI) &&
                 Objects.equals(credentials, that.credentials) &&
                 Objects.equals(trustStore, that.trustStore);
     }

--- a/src/main/java/io/pravega/connectors/flink/serialization/DeserializerFromSchemaRegistry.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/DeserializerFromSchemaRegistry.java
@@ -13,6 +13,7 @@ package io.pravega.connectors.flink.serialization;
 import com.google.protobuf.DynamicMessage;
 import io.pravega.client.stream.Serializer;
 import io.pravega.connectors.flink.PravegaConfig;
+import io.pravega.connectors.flink.util.SchemaRegistryUtils;
 import io.pravega.schemaregistry.client.SchemaRegistryClient;
 import io.pravega.schemaregistry.client.SchemaRegistryClientConfig;
 import io.pravega.schemaregistry.client.SchemaRegistryClientFactory;
@@ -44,7 +45,7 @@ public class DeserializerFromSchemaRegistry<T> implements Serializer<T>, Seriali
     private transient Serializer<T> serializer;
 
     public DeserializerFromSchemaRegistry(PravegaConfig pravegaConfig, String group, Class<T> tClass) {
-        Preconditions.checkNotNull(pravegaConfig.getSchemaRegistryClientConfig().getSchemaRegistryUri());
+        Preconditions.checkNotNull(pravegaConfig.getSchemaRegistryUri());
         this.pravegaConfig = pravegaConfig;
         this.group = group;
         this.tClass = tClass;
@@ -54,7 +55,7 @@ public class DeserializerFromSchemaRegistry<T> implements Serializer<T>, Seriali
     @SuppressWarnings("unchecked")
     private void initialize() {
         synchronized (this) {
-            SchemaRegistryClientConfig schemaRegistryClientConfig = pravegaConfig.getSchemaRegistryClientConfig();
+            SchemaRegistryClientConfig schemaRegistryClientConfig = SchemaRegistryUtils.getSchemaRegistryClientConfig(pravegaConfig);
             SerializationFormat format;
 
             try (SchemaRegistryClient schemaRegistryClient = SchemaRegistryClientFactory.withNamespace(

--- a/src/main/java/io/pravega/connectors/flink/serialization/JsonSerializer.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/JsonSerializer.java
@@ -9,8 +9,8 @@
  */
 package io.pravega.connectors.flink.serialization;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.pravega.client.stream.Serializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/main/java/io/pravega/connectors/flink/util/SchemaRegistryUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/SchemaRegistryUtils.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.connectors.flink.util;
+
+import io.pravega.connectors.flink.PravegaConfig;
+import io.pravega.schemaregistry.client.SchemaRegistryClientConfig;
+import io.pravega.schemaregistry.serializer.shared.credentials.PravegaCredentialProvider;
+import org.apache.flink.util.Preconditions;
+
+public class SchemaRegistryUtils {
+
+    /**
+     * Gets the schema registry client.
+     *
+     * @param pravegaConfig Pravega configuration
+     * @return the configuration for schema registry client
+     */
+    public static SchemaRegistryClientConfig getSchemaRegistryClientConfig(PravegaConfig pravegaConfig) {
+        Preconditions.checkNotNull(pravegaConfig.getDefaultScope(), "Default Scope should be set for schema registry client");
+        Preconditions.checkNotNull(pravegaConfig.getSchemaRegistryUri(), "Schema Registry URI should be set for schema registry client");
+
+        SchemaRegistryClientConfig.SchemaRegistryClientConfigBuilder builder = SchemaRegistryClientConfig.builder()
+                .schemaRegistryUri(pravegaConfig.getSchemaRegistryUri());
+
+        if (pravegaConfig.getCredentials() != null) {
+            builder.authentication(pravegaConfig.getCredentials().getAuthenticationType(), pravegaConfig.getCredentials().getAuthenticationToken());
+        } else {
+            builder.authentication(new PravegaCredentialProvider(pravegaConfig.getClientConfig()));
+        }
+
+        return builder.build();
+    }
+}


### PR DESCRIPTION
**Change log description**
Make schema registry dependencies optional and clean up the dependencies

**Purpose of the change**
Fixes #440 

**What the code does**
- Make schema registry dependencies optional by moving the related logic to a new class `SchemaRegistryUtils`
- Fixes the missing `schemaRegistryUri` check in the `equals` and `hashcode` function of `PravegaConfig`
- Clean up the dependency list, remove some redundant dependencies
- Clean up the showdowOnly list, this one is going to the pom file.

**How to verify it**
`./gradlew clean build` passes
Target to master, should only cherry-pick to `r0.9-flink1.10` branch