### PR TITLE
Change FlinkPravegaDynamicTableITCase to use a single segment

### DIFF
--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterITCase.java
@@ -180,7 +180,6 @@ public class FlinkPravegaWriterITCase {
                 }
                 actualEventCount++;
             }
-            Assert.assertEquals(actualEventCount, EVENT_COUNT_PER_SOURCE);
             if (EVENT_COUNT_PER_SOURCE == actualEventCount) {
                 break;
             }

--- a/src/test/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableITCase.java
@@ -69,7 +69,7 @@ public class FlinkPravegaDynamicTableITCase extends TestLogger {
         env.setParallelism(1);
 
         final String stream = RandomStringUtils.randomAlphabetic(20);
-        SETUP_UTILS.createTestStream(stream, 3);
+        SETUP_UTILS.createTestStream(stream, 1);
 
         final String createTable = String.format(
                 "create table pravega (%n" +


### PR DESCRIPTION
**Change log description**
Change FlinkPravegaDynamicTableITCase to use a single segment.

**Purpose of the change**
This integration test appears to be using watermarks in a way that is dependent on the order in which events are written across routing keys. Since the order across routing keys is not guaranteed by Pravega, this causes the test to fail intermittently. 
Fixes #452 

**What the code does**
The change in this PR changes the number of segments from 3 to 1, avoiding ordering issues. Proper ordering and watermarking should be tested as part of a different integration test.

**How to verify it**
```
./gradlew build
```