### PR TITLE
[Issue-455] Increase the default transaction lease renewal time to 120s

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/AbstractStreamingWriterBuilder.java
@@ -26,7 +26,7 @@ import org.apache.flink.util.Preconditions;
 public abstract class AbstractStreamingWriterBuilder<T, B extends AbstractStreamingWriterBuilder> extends AbstractWriterBuilder<B> {
 
     // the numbers below are picked based on the default max settings in Pravega
-    protected static final long DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS = 30000; // 30 seconds
+    protected static final long DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS = 120000; // 120 seconds
 
     public PravegaWriterMode writerMode;
     public boolean enableWatermark;


### PR DESCRIPTION


Signed-off-by: Charlie <Charlie.L.Chen@dell.com>

**Change log description**
Increase the default transaction lease renewal time to 120 seconds

**Purpose of the change**
Fixes #455 

**What the code does**
Set `DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS` = 120000

**How to verify it**

`./gradlew clean build` passes
