### PR TITLE
[Issue-457] Upgrade Pravega to the latest 0.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.9.0-SNAPSHOT
-pravegaVersion=0.9.0-2765.79a6eb7-SNAPSHOT
+pravegaVersion=0.9.0-2766.2515791-SNAPSHOT
 schemaRegistryVersion=0.2.0-50.7d32981-SNAPSHOT
 apacheCommonsVersion=3.7
 

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -119,7 +119,6 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
                     .groupRefreshTimeMillis(this.readerGroupConfig.getGroupRefreshTimeMillis())
                     .disableAutomaticCheckpoints()
                     .startFromCheckpoint(checkpoint)
-                    .readerGroupId(this.readerGroupConfig.getReaderGroupId())
                     .build());
         }
     }

--- a/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
+++ b/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
@@ -133,7 +133,7 @@ public class ReaderCheckpointHookTest {
 
         hook.restoreCheckpoint(1L, checkpoint);
 
-        verify(hook.readerGroup).resetReaderGroup(readerGroupConfig);
+        verify(hook.readerGroup).resetReaderGroup(any(ReaderGroupConfig.class));
     }
 
     static class TestableReaderCheckpointHook extends ReaderCheckpointHook {


### PR DESCRIPTION
Signed-off-by: Charlie <Charlie.L.Chen@dell.com>

**Change log description**

Upgrade pravega version and submodule to the latest commit pravega/pravega@2515791
Remove the readerGroupId specification which is no longer needed in resetReaderGroup() call in ReaderCheckpointHook

**Purpose of the change**
Fixes #457 

**What the code does**
1. Upgrade pravega version and submodule to the latest commit pravega/pravega@2515791
2. Remove the readerGroupId specification in ReaderCheckpointHook

**How to verify it**

`gradlew build` passes
