### PR TITLE
[Issue-491] Wrong count number of the artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # pull all the commits, so the commit count of the artifact name will be correct
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1
@@ -54,6 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # see comments above
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1


### PR DESCRIPTION
Signed-off-by: zhongle.wang <zhongle_wang@dell.com>

**Change log description**

A typical name of the artiface should be something like 0.10.0-1.ff9f6d1-SNAPSHOT. With the [version]-[commit count]-[commit sha]-SNAPSHOT format. But for artifacts produced by Github Actions, the commit count are always set to 1. This is caused by the `depth==1` clone, so we change it to unlimited.

**Purpose of the change**

Fixes #491 

**What the code does**

Add a parameter to specify the clone depth to be unlimited.

**How to verify it**

Artifacts build by the new yaml should have the corret commit count.

See the `List of artifacts` section of this [run](https://github.com/thekingofcity/flink-connectors/runs/2359587611).
