### PR TITLE
[Issue-496] best practice of `optional`

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -554,13 +554,9 @@ public class FlinkPravegaReader<T>
             builder.append("scope=").append(scope).append(", ");
             builder.append("stream=").append(stream).append(", segments={");
 
-            readerGroup
-                    .getStreamCuts()
-                    .entrySet()
-                    .stream()
+            readerGroup.getStreamCuts().entrySet().stream()
                     .filter(e -> e.getKey().getStreamName().equals(stream) &&
-                            e.getKey().getScope().equals(scope))
-                    .findFirst()
+                            e.getKey().getScope().equals(scope)).findFirst()
                     .ifPresent(streamStreamCutEntry -> builder.append(streamStreamCutEntry.getValue().toString()));
 
             builder.append("}");

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -21,7 +21,6 @@ import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Stream;
-import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.connectors.flink.serialization.DeserializerFromSchemaRegistry;
 import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
@@ -49,8 +48,6 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedValue;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -556,15 +553,16 @@ public class FlinkPravegaReader<T>
             StringBuilder builder = new StringBuilder();
             builder.append("scope=").append(scope).append(", ");
             builder.append("stream=").append(stream).append(", segments={");
-            Map<Stream, StreamCut> streamCuts = readerGroup.getStreamCuts();
-            Optional<Map.Entry<Stream, StreamCut>> optionalStreamCutEntry =
-                    streamCuts.entrySet().stream()
-                            .filter(e -> e.getKey().getStreamName().equals(stream) &&
-                                    e.getKey().getScope().equals(scope))
-                            .findFirst();
-            if (optionalStreamCutEntry.isPresent()) {
-                builder.append(optionalStreamCutEntry.get().getValue().toString());
-            }
+
+            readerGroup
+                    .getStreamCuts()
+                    .entrySet()
+                    .stream()
+                    .filter(e -> e.getKey().getStreamName().equals(stream) &&
+                            e.getKey().getScope().equals(scope))
+                    .findFirst()
+                    .ifPresent(streamStreamCutEntry -> builder.append(streamStreamCutEntry.getValue().toString()));
+
             builder.append("}");
             return builder.toString();
         }

--- a/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSink.java
+++ b/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSink.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
@@ -56,7 +57,7 @@ public class FlinkPravegaDynamicTableSink implements DynamicTableSink {
     private final boolean enableWatermarkPropagation;
 
     // Pravega routing key field name
-    private final Optional<String> routingKeyFieldName;
+    @Nullable private final String routingKeyFieldName;
 
     /**
      * Creates a Pravega {@link DynamicTableSink}.

--- a/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSink.java
+++ b/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSink.java
@@ -29,7 +29,6 @@ import org.apache.flink.util.Preconditions;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -57,7 +56,8 @@ public class FlinkPravegaDynamicTableSink implements DynamicTableSink {
     private final boolean enableWatermarkPropagation;
 
     // Pravega routing key field name
-    @Nullable private final String routingKeyFieldName;
+    @Nullable
+    private final String routingKeyFieldName;
 
     /**
      * Creates a Pravega {@link DynamicTableSink}.
@@ -81,7 +81,7 @@ public class FlinkPravegaDynamicTableSink implements DynamicTableSink {
                                         PravegaWriterMode writerMode,
                                         long txnLeaseRenewalIntervalMillis,
                                         boolean enableWatermarkPropagation,
-                                        Optional<String> routingKeyFieldName) {
+                                        @Nullable String routingKeyFieldName) {
         this.tableSchema = Preconditions.checkNotNull(tableSchema, "Table schema must not be null.");
         this.encodingFormat = Preconditions.checkNotNull(encodingFormat, "Encoding format must not be null.");
         this.pravegaConfig = Preconditions.checkNotNull(pravegaConfig, "Pravega config must not be null.");
@@ -107,9 +107,10 @@ public class FlinkPravegaDynamicTableSink implements DynamicTableSink {
                 .enableWatermark(enableWatermarkPropagation)
                 .withTxnLeaseRenewalPeriod(Time.milliseconds(txnLeaseRenewalIntervalMillis));
 
-        routingKeyFieldName.ifPresent(name -> {
-            writerBuilder.withEventRouter(new RowDataBasedRouter(name, tableSchema));
-        });
+        if (routingKeyFieldName != null) {
+            writerBuilder.withEventRouter(new RowDataBasedRouter(routingKeyFieldName, tableSchema));
+        }
+
         return SinkFunctionProvider.of(writerBuilder.build());
     }
 

--- a/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSource.java
@@ -194,7 +194,7 @@ public class FlinkPravegaDynamicTableSource implements ScanTableSource {
                 Objects.equals(readerGroupName, that.readerGroupName) &&
                 pravegaConfig.equals(that.pravegaConfig) &&
                 streams.equals(that.streams) &&
-                uid.equals(that.uid);
+                Objects.equals(uid, that.uid);
     }
 
     @Override

--- a/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSource.java
@@ -39,7 +39,8 @@ public class FlinkPravegaDynamicTableSource implements ScanTableSource {
     private final DecodingFormat<DeserializationSchema<RowData>> decodingFormat;
 
     // The reader group name to coordinate the parallel readers. This should be unique for a Flink job.
-    @Nullable private final String readerGroupName;
+    @Nullable
+    private final String readerGroupName;
 
     // Pravega connection configuration
     private final PravegaConfig pravegaConfig;
@@ -60,7 +61,8 @@ public class FlinkPravegaDynamicTableSource implements ScanTableSource {
     private final int maxOutstandingCheckpointRequest;
 
     // Uid of the table source to identify the checkpoint state
-    @Nullable private final String uid;
+    @Nullable
+    private final String uid;
 
     // Flag to determine streaming or batch read
     private final boolean isStreamingReader;
@@ -134,12 +136,7 @@ public class FlinkPravegaDynamicTableSource implements ScanTableSource {
                 readerBuilder.forStream(stream.getStream(), stream.getFrom(), stream.getTo());
             }
 
-            Optional.ofNullable(uid)
-                    .or(()-> Optional.of(readerBuilder.generateUid()))
-                    .map(readerBuilder::uid);
-            Optional.ofNullable(uid)
-                    .map(readerBuilder::uid)
-                    .orElseGet(()-> readerBuilder.uid(readerBuilder.generateUid()));
+            readerBuilder.uid(uid == null ? readerBuilder.generateUid() : uid);
 
             return SourceFunctionProvider.of(readerBuilder.build(), isBounded);
         } else {

--- a/src/main/java/io/pravega/connectors/flink/dynamic/table/PravegaOptions.java
+++ b/src/main/java/io/pravega/connectors/flink/dynamic/table/PravegaOptions.java
@@ -308,8 +308,8 @@ public class PravegaOptions {
         return tableOptions.get(SCAN_READER_GROUP_NAME);
     }
 
-    public static Optional<String> getUid(ReadableConfig tableOptions) {
-        return tableOptions.getOptional(SCAN_UID);
+    public static String getUid(ReadableConfig tableOptions) {
+        return tableOptions.get(SCAN_UID);
     }
 
     public static long getReaderGroupRefreshTimeMillis(ReadableConfig tableOptions) {
@@ -381,7 +381,7 @@ public class PravegaOptions {
         return tableOptions.get(SINK_ENABLE_WATERMARK_PROPAGATION);
     }
 
-    public static Optional<String> getRoutingKeyField(ReadableConfig tableOptions) {
-        return tableOptions.getOptional(SINK_ROUTINGKEY_FIELD_NAME);
+    public static String getRoutingKeyField(ReadableConfig tableOptions) {
+        return tableOptions.get(SINK_ROUTINGKEY_FIELD_NAME);
     }
 }

--- a/src/test/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableFactoryTest.java
+++ b/src/test/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableFactoryTest.java
@@ -58,7 +58,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
@@ -137,7 +136,7 @@ public class FlinkPravegaDynamicTableFactoryTest extends TestLogger {
                 5000L,
                 TIMEOUT_MILLIS,
                 3,
-                Optional.empty(),
+                null,
                 true,
                 false);
 
@@ -180,7 +179,7 @@ public class FlinkPravegaDynamicTableFactoryTest extends TestLogger {
                 5000L,
                 TIMEOUT_MILLIS,
                 3,
-                Optional.empty(),
+                null,
                 true,
                 false);
 
@@ -204,7 +203,7 @@ public class FlinkPravegaDynamicTableFactoryTest extends TestLogger {
                 5000L,
                 TIMEOUT_MILLIS,
                 3,
-                Optional.empty(),
+                null,
                 true,
                 false);
 
@@ -247,7 +246,7 @@ public class FlinkPravegaDynamicTableFactoryTest extends TestLogger {
                 5000L,
                 TIMEOUT_MILLIS,
                 3,
-                Optional.empty(),
+                null,
                 false,
                 false);
 
@@ -272,7 +271,7 @@ public class FlinkPravegaDynamicTableFactoryTest extends TestLogger {
                 5000L,
                 TIMEOUT_MILLIS,
                 3,
-                Optional.empty(),
+                null,
                 false,
                 false);
 
@@ -312,7 +311,7 @@ public class FlinkPravegaDynamicTableFactoryTest extends TestLogger {
                 PravegaWriterMode.EXACTLY_ONCE,
                 LEASE_MILLIS,
                 false,
-                Optional.of(NAME)
+                NAME
         );
         assertEquals(expectedSink, actualSink);
     }
@@ -345,7 +344,7 @@ public class FlinkPravegaDynamicTableFactoryTest extends TestLogger {
                 PravegaWriterMode.EXACTLY_ONCE,
                 LEASE_MILLIS,
                 false,
-                Optional.of(NAME)
+                NAME
         );
 
         DynamicTableSink.SinkRuntimeProvider provider =


### PR DESCRIPTION
**Change log description**

Java 8's Optional was mainly intended for return values from methods, and not for properties of Java classes, as described in [Optional in Java SE 8](https://blog.joda.org/2014/11/optional-in-java-se-8.html):

> > Of course, people will do what they want. But we did have a clear intention when adding this feature, and it was not to be a general purpose Maybe or Some type, as much as many people would have liked us to do so. **Our intention was to provide a limited mechanism for library method return types** where there needed to be a clear way to represent "no result", and using null for such was overwhelmingly likely to cause errors.
>
>The key here is the focus on use as a return type. The class is definitively not intended for use as a property of a Java Bean. Witness to this is that `Optional` [does not implement](http://mail.openjdk.java.net/pipermail/jdk8-dev/2013-September/003274.html) `Serializable`, which is generally necessary for widespread use as a property of an object.

---

This is referenced from [Is it a good practice to use Optional as an attribute in a class?](https://stackoverflow.com/questions/29033518/is-it-a-good-practice-to-use-optional-as-an-attribute-in-a-class)

**Purpose of the change**

Fixes #496 

**What the code does**

Use `@Nullable` instead of `Optional<T>` for class fields and function parameters.

**How to verify it**

`./gradlew clean build` passes.


