### PR TITLE
[issue-506] Improve the transactional writer

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
@@ -148,6 +148,11 @@ public class FlinkPravegaWriter<T>
         this.enableWatermark = enableWatermark;
         this.enableMetrics = enableMetrics;
         this.writerIdPrefix = UUID.randomUUID().toString();
+
+        if (writerMode == PravegaWriterMode.EXACTLY_ONCE) {
+            super.setTransactionTimeout(txnLeaseRenewalPeriod);
+            super.enableTransactionTimeoutWarnings(0.8);
+        }
     }
 
     /**
@@ -274,8 +279,8 @@ public class FlinkPravegaWriter<T>
                 @SuppressWarnings("unchecked")
                 final Transaction<T> txn = transaction.getTransaction() != null ? transaction.getTransaction() :
                         transactionalWriter.getTxn(UUID.fromString(transaction.transactionId));
-                final Transaction.Status status = txn.checkStatus();
                 try {
+                    final Transaction.Status status = txn.checkStatus();
                     if (status == Transaction.Status.OPEN) {
                         if (enableWatermark && transaction.watermark != null) {
                             txn.commit(transaction.watermark);
@@ -288,6 +293,10 @@ public class FlinkPravegaWriter<T>
                     }
                 } catch (TxnFailedException e) {
                     log.error("{} - Transaction {} commit failed.", writerId(), txn.getTxnId());
+                } catch (RuntimeException e) {
+                    if (e.getMessage().contains("Unknown transaction")) {
+                        log.error("{} - Transaction {} not found.", writerId(), txn.getTxnId());
+                    }
                 }
                 break;
             case ATLEAST_ONCE:
@@ -554,6 +563,13 @@ public class FlinkPravegaWriter<T>
         }
 
         @Override
+        public String toString() {
+            return String.format(
+                    "%s [transactionId=%s, watermark=%s]",
+                    this.getClass().getSimpleName(), transactionId, watermark);
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
@@ -679,6 +695,21 @@ public class FlinkPravegaWriter<T>
         }
     }
 
+    /**
+     * Disables the propagation of exceptions thrown when committing presumably timed out Pravega
+     * transactions during recovery of the job. If a Pravega transaction is timed out, a commit will
+     * never be successful. Hence, use this feature to avoid recovery loops of the Job. Exceptions
+     * will still be logged to inform the user that data loss might have occurred.
+     *
+     * <p>Note that we use {@link System#currentTimeMillis()} to track the age of a transaction.
+     * Moreover, only exceptions thrown during the recovery are caught, i.e., the writer will
+     * attempt at least one commit of the transaction before giving up.
+     */
+    @Override
+    public FlinkPravegaWriter<T> ignoreFailuresAfterTransactionTimeout() {
+        super.ignoreFailuresAfterTransactionTimeout();
+        return this;
+    }
 
     // ------------------------------------------------------------------------
     //  builder

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -88,7 +88,7 @@ public class FlinkPravegaWriterTest {
         FlinkPravegaWriter<Integer> sinkFunction = spySinkFunction(clientFactory, null, false, PravegaWriterMode.ATLEAST_ONCE);
 
         try {
-            try (StreamSinkOperatorTestHarness<Integer> testHarness = createTestHarness(sinkFunction)) {
+            try (StreamSinkOperatorTestHarness<Integer> testHarness = createTestHarness(sinkFunction.ignoreFailuresAfterTransactionTimeout())) {
                 testHarness.open();
 
                 // verify that exceptions don't interfere with close

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -376,6 +376,27 @@ public class FlinkPravegaWriterTest {
         }
     }
 
+
+    /**
+     * Tests the error handling with unknown transaction.
+     */
+    @Test
+    public void testTransactionalWriterCommitWithUnknownId() throws Exception {
+        try (WriterTestContext context = new WriterTestContext(false)) {
+            Transaction<Integer> trans = context.prepareTransaction();
+            try (StreamSinkOperatorTestHarness<Integer> testHarness = createTestHarness(context.txnSinkFunction)) {
+                testHarness.open();
+                StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
+                testHarness.processElement(e1);
+                testHarness.snapshot(1L, 1L);
+
+                Mockito.when(trans.checkStatus()).thenThrow(new RuntimeException("Unknown transaction: abc"));
+                testHarness.notifyOfCompletedCheckpoint(1L);
+                // RuntimeException with Unknown transaction is caught
+            }
+        }
+    }
+
     /**
      * Tests the error handling.
      */


### PR DESCRIPTION
**Change log description**
- Add transaction timeout support
- Handle unknown transaction error and do not let it escape and fail the job
- Add `toString` method in `PravegaTransactionState`

**Purpose of the change**
Fixes #506 

**How to verify it**
`./gradlew clean build` passes
Target to master, should cherry-pick to all `0.10` and `0.9` branch