### PR TITLE
[issue-510] Change to get serialization format from GroupProperties

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/serialization/DeserializerFromSchemaRegistry.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/DeserializerFromSchemaRegistry.java
@@ -60,8 +60,7 @@ public class DeserializerFromSchemaRegistry<T> implements Serializer<T>, Seriali
 
             try (SchemaRegistryClient schemaRegistryClient = SchemaRegistryClientFactory.withNamespace(
                     pravegaConfig.getDefaultScope(), schemaRegistryClientConfig)) {
-                format = schemaRegistryClient.getLatestSchemaVersion(group, null)
-                        .getSchemaInfo().getSerializationFormat();
+                format = schemaRegistryClient.getGroupProperties(group).getSerializationFormat();
             } catch (Exception e) {
                 log.error("Error while closing the schema registry client", e);
                 throw new FlinkRuntimeException(e);


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
The Schema Registry offers a way to get the serialization format from `GroupProperties`. Flink connector can take advantage of it instead of getting it from `SchemaInfo`.

**Purpose of the change**
Fix #510 

**What the code does**
Use `getSerializationFormat` to get serialization format from `GroupProperties` instead of from `SchemaInfo`.

**How to verify it**
`./gradlew clean build` passes
