### PR TITLE
[Issue-514] Catch the exact exception for checkTransactionStatus

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -12,6 +12,7 @@
     <allow pkg="org.slf4j"/>
     <allow pkg="org.junit"/>
     <allow pkg="com.google"/>
+    <allow pkg="io.grpc"/>
     <allow pkg="io.pravega"/>
     <allow pkg="lombok"/>
     <allow pkg="org.apache"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ hamcrestVersion=2.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.10.0-SNAPSHOT
-pravegaVersion=0.10.0-2858.0e600c1-SNAPSHOT
+pravegaVersion=0.10.0-2895.8be2afa-SNAPSHOT
 schemaRegistryVersion=0.2.0-50.7d32981-SNAPSHOT
 apacheCommonsVersion=3.7
 

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -18,6 +18,7 @@ import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReaderGroupNotFoundException;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.connectors.flink.serialization.DeserializerFromSchemaRegistry;
@@ -600,8 +601,12 @@ public class FlinkPravegaReader<T>
      * Create the {@link ReaderGroup} for the current configuration.
      */
     private ReaderGroup createReaderGroup() {
-        readerGroupManager.createReaderGroup(this.readerGroupName, readerGroupConfig);
-        readerGroup = readerGroupManager.getReaderGroup(this.readerGroupName);
+        try {
+            readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+        } catch (ReaderGroupNotFoundException e) {
+            readerGroupManager.createReaderGroup(readerGroupName, readerGroupConfig);
+            readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+        }
         return readerGroup;
     }
 

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
@@ -10,6 +10,7 @@
 package io.pravega.connectors.flink;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
@@ -298,7 +299,7 @@ public class FlinkPravegaWriter<T>
                 } catch (TxnFailedException e) {
                     log.error("{} - Transaction {} commit failed.", writerId(), txn.getTxnId());
                 } catch (StatusRuntimeException e) {
-                    if (e.getMessage().contains("Unknown transaction")) {
+                    if (e.getStatus() == Status.NOT_FOUND) {
                         log.error("{} - Transaction {} not found.", writerId(), txn.getTxnId());
                     }
                 }

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
@@ -10,6 +10,7 @@
 package io.pravega.connectors.flink;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.grpc.StatusRuntimeException;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.stream.EventStreamWriter;
@@ -296,7 +297,7 @@ public class FlinkPravegaWriter<T>
                     }
                 } catch (TxnFailedException e) {
                     log.error("{} - Transaction {} commit failed.", writerId(), txn.getTxnId());
-                } catch (RuntimeException e) {
+                } catch (StatusRuntimeException e) {
                     if (e.getMessage().contains("Unknown transaction")) {
                         log.error("{} - Transaction {} not found.", writerId(), txn.getTxnId());
                     }

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -14,6 +14,7 @@ import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReaderGroupNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -82,8 +83,12 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
     // ------------------------------------------------------------------------
     protected void initializeReaderGroup(String readerGroupName, String readerGroupScope, ClientConfig clientConfig) {
         readerGroupManager = ReaderGroupManager.withScope(readerGroupScope, clientConfig);
-        readerGroupManager.createReaderGroup(readerGroupName, readerGroupConfig);
-        readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+        try {
+            readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+        } catch (ReaderGroupNotFoundException e) {
+            readerGroupManager.createReaderGroup(readerGroupName, readerGroupConfig);
+            readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+        }
     }
 
     @Override

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -20,6 +20,7 @@ import io.pravega.client.stream.Position;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReaderGroupNotFoundException;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
@@ -76,6 +77,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -727,7 +729,9 @@ public class FlinkPravegaReaderTest {
             readerGroupManager = mock(ReaderGroupManager.class);
             readerGroup.resetReaderGroup(readerGroupConfig);
             doReturn(new HashSet<>(Arrays.asList(SAMPLE_COMPLETE_STREAM_NAME))).when(readerGroup).getStreamNames();
-            doReturn(readerGroup).when(readerGroupManager).getReaderGroup(readerGroupName);
+            when(readerGroupManager.getReaderGroup(anyString()))
+                    .thenThrow(new ReaderGroupNotFoundException("Reader group not found"))
+                    .thenReturn(readerGroup);
             return readerGroupManager;
         }
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -77,7 +77,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -726,7 +725,7 @@ public class FlinkPravegaReaderTest {
             }
 
             readerGroupManager = mock(ReaderGroupManager.class);
-            doNothing().when(readerGroupManager).createReaderGroup(readerGroupName, readerGroupConfig);
+            readerGroup.resetReaderGroup(readerGroupConfig);
             doReturn(new HashSet<>(Arrays.asList(SAMPLE_COMPLETE_STREAM_NAME))).when(readerGroup).getStreamNames();
             doReturn(readerGroup).when(readerGroupManager).getReaderGroup(readerGroupName);
             return readerGroupManager;

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -403,7 +403,6 @@ public class FlinkPravegaWriterTest {
         }
     }
 
-
     /**
      * Tests the error handling with unknown transaction.
      */

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -9,6 +9,8 @@
  */
 package io.pravega.connectors.flink;
 
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.stream.EventStreamWriter;
@@ -415,9 +417,9 @@ public class FlinkPravegaWriterTest {
                 testHarness.processElement(e1);
                 testHarness.snapshot(1L, 1L);
 
-                Mockito.when(trans.checkStatus()).thenThrow(new RuntimeException("Unknown transaction: abc"));
+                Mockito.when(trans.checkStatus()).thenThrow(new StatusRuntimeException(Status.NOT_FOUND));
                 testHarness.notifyOfCompletedCheckpoint(1L);
-                // RuntimeException with Unknown transaction is caught
+                // StatusRuntimeException with Unknown transaction is caught
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: zhongle.wang <zhongle_wang@dell.com>

**Change log description**

In pravega/pravega#6028, the exception thrown has changed from a general `RuntimeException` to a `StatusRuntimeException`, we need to update the Pravega client version and make the change in the transactional writer.

**Purpose of the change**

Fixes #514 

**What the code does**

Change `RuntimeException` to `StatusRuntimeException`.

**How to verify it**

`./gradlew clean build` passes.
