### PR TITLE
[Issue-514] Catch the exact exception for checkTransactionStatus

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -12,6 +12,7 @@
     <allow pkg="org.slf4j"/>
     <allow pkg="org.junit"/>
     <allow pkg="com.google"/>
+    <allow pkg="io.grpc"/>
     <allow pkg="io.pravega"/>
     <allow pkg="lombok"/>
     <allow pkg="org.apache"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jacocoVersion=0.8.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.10.0-SNAPSHOT
-pravegaVersion=0.10.0-2858.0e600c1-SNAPSHOT
+pravegaVersion=0.10.0-2895.8be2afa-SNAPSHOT
 schemaRegistryVersion=0.2.0-50.7d32981-SNAPSHOT
 apacheCommonsVersion=3.7
 

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaBatchTableSourceSinkFactory.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaBatchTableSourceSinkFactory.java
@@ -24,7 +24,7 @@ import static io.pravega.connectors.flink.table.descriptors.Pravega.CONNECTOR_VE
 /**
  * A batch table source factory implementation of {@link BatchTableSourceFactory} to access Pravega streams.
  *
- * @deprecated Please use the new Table API {@link io.pravega.connectors.flink.dynamic.table.FlinkPravegaDynamicTableFactory}
+ * @deprecated Upgrade Flink to 1.11 or greater and use `FlinkPravegaDynamicTableFactory` instead.
  */
 @Deprecated
 public class FlinkPravegaBatchTableSourceSinkFactory extends FlinkPravegaTableFactoryBase implements

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -18,6 +18,7 @@ import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReaderGroupNotFoundException;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.TruncatedDataException;
@@ -604,7 +605,12 @@ public class FlinkPravegaReader<T>
      */
     private ReaderGroup createReaderGroup() {
         readerGroupManager.createReaderGroup(this.readerGroupName, readerGroupConfig);
-        readerGroup = readerGroupManager.getReaderGroup(this.readerGroupName);
+        try {
+            readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+        } catch (ReaderGroupNotFoundException e) {
+            readerGroupManager.createReaderGroup(readerGroupName, readerGroupConfig);
+            readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+        }
         return readerGroup;
     }
 

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -604,7 +604,6 @@ public class FlinkPravegaReader<T>
      * Create the {@link ReaderGroup} for the current configuration.
      */
     private ReaderGroup createReaderGroup() {
-        readerGroupManager.createReaderGroup(this.readerGroupName, readerGroupConfig);
         try {
             readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
         } catch (ReaderGroupNotFoundException e) {

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaStreamTableSourceSinkFactory.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaStreamTableSourceSinkFactory.java
@@ -26,7 +26,7 @@ import static org.apache.flink.table.descriptors.StreamTableDescriptorValidator.
 /**
  * A stream table source factory implementation of {@link StreamTableSourceFactory} to access Pravega streams.
  *
- * @deprecated Please use the new Table API {@link io.pravega.connectors.flink.dynamic.table.FlinkPravegaDynamicTableFactory}
+ * @deprecated Upgrade Flink to 1.11 or greater and use `FlinkPravegaDynamicTableFactory` instead.
  */
 @Deprecated
 public class FlinkPravegaStreamTableSourceSinkFactory extends FlinkPravegaTableFactoryBase implements

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSink.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSink.java
@@ -34,7 +34,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * An append-only table sink to emit a streaming table as a Pravega stream.
  *
- * @deprecated Please use the new Table API {@link io.pravega.connectors.flink.dynamic.table.FlinkPravegaDynamicTableSink}
+ * @deprecated Upgrade Flink to 1.11 or greater and use `FlinkPravegaDynamicTableFactory` instead.
  */
 @Deprecated
 public class FlinkPravegaTableSink implements AppendStreamTableSink<Row>, BatchTableSink<Row> {

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaTableSource.java
@@ -40,7 +40,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A {@link TableSource} to read Pravega streams using the Flink Table API.
  *
  * Supports both stream and batch environments.
- * @deprecated Please use the new Table API {@link io.pravega.connectors.flink.dynamic.table.FlinkPravegaDynamicTableSource}
+ * @deprecated Upgrade Flink to 1.11 or greater and use `FlinkPravegaDynamicTableFactory` instead.
  */
 @Deprecated
 public class FlinkPravegaTableSource implements StreamTableSource<Row>, BatchTableSource<Row>,

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -85,7 +85,6 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
         readerGroupManager = ReaderGroupManager.withScope(readerGroupScope, clientConfig);
         try {
             readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
-            readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
         } catch (ReaderGroupNotFoundException e) {
             readerGroupManager.createReaderGroup(readerGroupName, readerGroupConfig);
             readerGroup = readerGroupManager.getReaderGroup(readerGroupName);

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -14,6 +14,7 @@ import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReaderGroupNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -82,8 +83,13 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
     // ------------------------------------------------------------------------
     protected void initializeReaderGroup(String readerGroupName, String readerGroupScope, ClientConfig clientConfig) {
         readerGroupManager = ReaderGroupManager.withScope(readerGroupScope, clientConfig);
-        readerGroupManager.createReaderGroup(readerGroupName, readerGroupConfig);
-        readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+        try {
+            readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+            readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+        } catch (ReaderGroupNotFoundException e) {
+            readerGroupManager.createReaderGroup(readerGroupName, readerGroupConfig);
+            readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+        }
     }
 
     @Override

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -20,6 +20,7 @@ import io.pravega.client.stream.Position;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReaderGroupNotFoundException;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
@@ -75,8 +76,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -694,9 +695,11 @@ public class FlinkPravegaReaderTest {
             }
 
             readerGroupManager = mock(ReaderGroupManager.class);
-            doNothing().when(readerGroupManager).createReaderGroup(readerGroupName, readerGroupConfig);
+            readerGroup.resetReaderGroup(readerGroupConfig);
             doReturn(new HashSet<>(Arrays.asList(SAMPLE_COMPLETE_STREAM_NAME))).when(readerGroup).getStreamNames();
-            doReturn(readerGroup).when(readerGroupManager).getReaderGroup(readerGroupName);
+            when(readerGroupManager.getReaderGroup(anyString()))
+                    .thenThrow(new ReaderGroupNotFoundException("Reader group not found"))
+                    .thenReturn(readerGroup);
             return readerGroupManager;
         }
 


### PR DESCRIPTION
Signed-off-by: zhongle.wang <zhongle_wang@dell.com>

**Change log description**

In pravega/pravega#6028, the exception thrown has changed from a general `RuntimeException` to a `StatusRuntimeException`, we need to update the Pravega client version and make the change in the transactional writer.

**Purpose of the change**

Fixes #514 

**What the code does**

Change `RuntimeException` to `StatusRuntimeException`.

**How to verify it**

`./gradlew clean build` passes.
