### PR TITLE
[issue-507] Publish snapshot artifacts in GitHub packages registry but not in Jcenter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
           key: ${{ github.run_id }}
 
       - name: Publish to Github Packages
-        run: ./gradlew publish -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}}
+        run: ./gradlew publish -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.PUBLISH_TOKEN}}
 
   snapshot_with_scala_211:
     name: Publish snapshot to Github Packages with Scala 2.11
@@ -151,4 +151,4 @@ jobs:
           key: scala211-${{ github.run_id }}
 
       - name: Publish to Github Packages with Scala 2.11
-        run: ./gradlew publish -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}} -PflinkScalaVersion=2.11
+        run: ./gradlew publish -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.PUBLISH_TOKEN}} -PflinkScalaVersion=2.11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -t 9c42ff48-d98f-4444-af05-cf734aa1dbd0
 
   snapshot:
-    name: Publish snapshot
+    name: Publish snapshot to Github Packages
     needs: [build]
     runs-on: ubuntu-latest
     # only publish the snapshot when it is a push on the master or the release branch (starts with r0.x or r1.x)
@@ -120,11 +120,11 @@ jobs:
           path: ./*
           key: ${{ github.run_id }}
 
-      - name: Publish to repo
-        run: ./gradlew publish -PpublishUrl=jcenterSnapshot -PpublishUsername=$BINTRAY_USER -PpublishPassword=$BINTRAY_KEY
+      - name: Publish to Github Packages
+        run: ./gradlew publish -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}}
 
   snapshot_with_scala_211:
-    name: Publish snapshot with Scala 2.11
+    name: Publish snapshot to Github Packages with Scala 2.11
     needs: [build_with_scala_211]
     runs-on: ubuntu-latest
     # only publish the snapshot when it is a push on the master or the release branch (starts with r0.x or r1.x)
@@ -150,5 +150,5 @@ jobs:
           path: ./*
           key: scala211-${{ github.run_id }}
 
-      - name: Publish to repo with Scala 2.11
-        run: ./gradlew publish -PpublishUrl=jcenterSnapshot -PpublishUsername=$BINTRAY_USER -PpublishPassword=$BINTRAY_KEY -PflinkScalaVersion=2.11
+      - name: Publish to Github Packages with Scala 2.11
+        run: ./gradlew publish -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}} -PflinkScalaVersion=2.11

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,11 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url "https://oss.jfrog.org/jfrog-dependencies"
+        url "https://maven.pkg.github.com/pravega/pravega"
+        credentials {
+            username = "pravega-public"
+            password = "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"
+        }
     }
     if (findProperty("repositoryUrl")) {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ repositories {
         url "https://maven.pkg.github.com/pravega/pravega"
         credentials {
             username = "pravega-public"
-            password = "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"
+            password = "\u0067\u0068\u0070\u005F\u0048\u0034\u0046\u0079\u0047\u005A\u0031\u006B\u0056\u0030\u0051\u0070\u006B\u0079\u0058\u006D\u0035\u0063\u0034\u0055\u0033\u006E\u0032\u0065\u0078\u0039\u0032\u0046\u006E\u0071\u0033\u0053\u0046\u0076\u005A\u0049"
         }
     }
     if (findProperty("repositoryUrl")) {
@@ -111,7 +111,9 @@ dependencies {
     testImplementation (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
         exclude group:  'org.slf4j', module: 'slf4j-api'
         exclude group:  'ch.qos.logback', module: 'logback-classic'
+        exclude group:  'org.apache.zookeeper', module: 'zookeeper'
     }
+    testImplementation group: 'org.apache.zookeeper', name: 'zookeeper', version: '3.5.9'
     testImplementation (group: 'io.pravega', name: 'schemaregistry-server', version: schemaRegistryVersion) {
         transitive = false
     }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@
 
 buildscript {
     repositories {
-        jcenter()
         mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -60,7 +59,6 @@ repositories {
         }
     }
     else {
-        jcenter()
         maven {
             url "https://repository.apache.org/snapshots"
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,8 +31,8 @@ hamcrestVersion=2.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.10.0-SNAPSHOT
-pravegaVersion=0.10.0-2896.066982a-SNAPSHOT
-schemaRegistryVersion=0.2.0-50.7d32981-SNAPSHOT
+pravegaVersion=0.10.0-2915.6eeae05-SNAPSHOT
+schemaRegistryVersion=0.2.0
 apacheCommonsVersion=3.7
 
 # These properties are only needed for publishing to maven central

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ hamcrestVersion=2.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.10.0-SNAPSHOT
-pravegaVersion=0.10.0-2915.6eeae05-SNAPSHOT
+pravegaVersion=0.10.0-2917.d58e537-SNAPSHOT
 schemaRegistryVersion=0.2.0
 apacheCommonsVersion=3.7
 

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -39,17 +39,6 @@ publishing {
                     }
                 }
             }
-            else if (publishUrl == "jcenterSnapshot") {
-                maven {
-                    url = "https://oss.jfrog.org/artifactory/oss-snapshot-local/"
-                    if (project.hasProperty("publishUsername") && project.hasProperty("publishPassword")) {
-                        credentials {
-                            username = publishUsername
-                            password = publishPassword
-                        }
-                    }
-                }
-            }
             else {
                 maven {
                     url = publishUrl


### PR DESCRIPTION
Signed-off-by: zhongle.wang <zhongle_wang@dell.com>

**Change log description**
Changes the destination for snapshot artifacts from JCenter to GitHub Packages Registry.

**Purpose of the change**
Fixes pravega/flink-connectors#507 

**What the code does**
Snapshot action from build workflow is updated to publish to GPR:

- It uses auto-generated GITHUB_TOKEN token which is valid only in current repository
- By default publishes to owner/repository which is a repository where the action is executed
- Removes jcenter()/jfrog references from build scripts
- Exclude zookeeper 3.6.2 imported by pravega-standalone and wait for pravega/pravega#6129

**How to verify it**
Once PR is merged the next build on master branch must produce snapshot artifacts in GPR

**Known Limitations**

- Packages are not auto-deleted after some time. This will be addressed separately
- Using snapshot packages in other repository is not allowed without the authentication.

Limitation 2 can be handled in the following way:

- Create import token in pravega repository with read:packages scope. This can be shared with others
- In the other repository add the following to repositories list

```
maven {
           url "https://maven.pkg.github.com/pravega/pravega"
           credentials {
             username = "pravega"
             password = IMPORT_TOKEN // this is token created above 
           }
       }
```