### PR TITLE
[Issue-534] Support format metadata

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -656,7 +656,7 @@ public class FlinkPravegaReader<T>
     }
 
     /**
-     * Create the {@link EventStreamReader} for the current configuration. <p/>
+     * Create the {@link EventStreamReader} for the current configuration. <p>
      *
      * The reader will output raw ByteBuffer rather than the deserialized T.
      * See {@link emitEvent} for the decoding process.

--- a/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSource.java
@@ -25,11 +25,6 @@ import org.apache.flink.table.connector.source.SourceFunctionProvider;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.FieldsDataType;
-import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -42,9 +37,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
-
 public class FlinkPravegaDynamicTableSource implements ScanTableSource, SupportsReadingMetadata {
+
+    private static final String FORMAT_METADATA_PREFIX = "from_format.";
 
     // Source produced data type
     protected DataType producedDataType;
@@ -57,8 +52,6 @@ public class FlinkPravegaDynamicTableSource implements ScanTableSource, Supports
 
     // Scan format for decoding records from Pravega
     private final DecodingFormat<DeserializationSchema<RowData>> decodingFormat;
-
-    private static final String FORMAT_METADATA_PREFIX = "from_format.";
 
     // The reader group name to coordinate the parallel readers. This should be unique for a Flink job.
     @Nullable

--- a/src/test/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableITCase.java
@@ -351,10 +351,9 @@ public class FlinkPravegaDynamicTableITCase extends TestLogger {
         String sourceDDL =
                 String.format(
                         "CREATE TABLE debezium_source ( %n" +
-                                // TODO: Support format metadata
-                                // https://github.com/pravega/flink-connectors/issues/534
-                                // + " origin_ts TIMESTAMP(3) METADATA FROM 'value.ingestion-timestamp' VIRTUAL, %n" // unused
-                                // + " origin_table STRING METADATA FROM 'value.source.table' VIRTUAL, %n"
+                                // test format metadata
+                                "  origin_ts TIMESTAMP(3) METADATA FROM 'from_format.ingestion-timestamp' VIRTUAL, %n" +  // unused
+                                "  origin_table STRING METADATA FROM 'from_format.source.table' VIRTUAL, %n" +
                                 "  id INT NOT NULL, %n" +
                                 "  name STRING, %n" +
                                 "  description STRING, %n" +
@@ -383,6 +382,7 @@ public class FlinkPravegaDynamicTableITCase extends TestLogger {
                         stream);
         String sinkDDL =
                 "CREATE TABLE sink ( \n" +
+                        "  origin_table STRING, \n" +
                         "  name STRING, \n" +
                         "  weightSum DECIMAL(10,3), \n" +
                         "  PRIMARY KEY (name) NOT ENFORCED \n" +
@@ -396,7 +396,7 @@ public class FlinkPravegaDynamicTableITCase extends TestLogger {
         TableResult tableResult =
                 tEnv.executeSql(
                         "INSERT INTO sink "
-                                + "SELECT name, SUM(weight) "
+                                + "SELECT FIRST_VALUE(origin_table), name, SUM(weight) "
                                 + "FROM debezium_source GROUP BY name");
         /*
          * Debezium captures change data on the `products` table:
@@ -447,13 +447,13 @@ public class FlinkPravegaDynamicTableITCase extends TestLogger {
          */
         List<String> expected =
                 Arrays.asList(
-                        "scooter,3.140",
-                        "car battery,8.100",
-                        "12-pack drill bits,0.800",
-                        "hammer,2.625",
-                        "rocks,5.100",
-                        "jacket,0.600",
-                        "spare tire,22.200");
+                        "products,scooter,3.140",
+                        "products,car battery,8.100",
+                        "products,12-pack drill bits,0.800",
+                        "products,hammer,2.625",
+                        "products,rocks,5.100",
+                        "products,jacket,0.600",
+                        "products,spare tire,22.200");
 
         waitingExpectedResults("sink", expected, Duration.ofSeconds(10));
 


### PR DESCRIPTION
Signed-off-by: zhongle.wang <zhongle_wang@dell.com>

**Change log description**
Add format metadata during the deserialization process.

**Purpose of the change**
Fixes #534 

**What the code does**
Preserve the format metadata keys and push down to the nested deserializationSchema.

**How to verify it**
`./gradlew clean build` should pass
