### PR TITLE
[issue-543] Generify a common method to deal with Json related options

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/PravegaCatalog.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/PravegaCatalog.java
@@ -105,31 +105,7 @@ public class PravegaCatalog extends AbstractCatalog {
                 PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FORMAT.key()),
                 this.serializationFormat.name());
 
-        if (failOnMissingField != null) {
-            properties.put(String.format("%s.%s",
-                    PravegaRegistryFormatFactory.IDENTIFIER, JsonOptions.FAIL_ON_MISSING_FIELD.key()),
-                    failOnMissingField);
-        }
-        if (ignoreParseErrors != null) {
-            properties.put(String.format("%s.%s",
-                    PravegaRegistryFormatFactory.IDENTIFIER, JsonOptions.IGNORE_PARSE_ERRORS.key()),
-                    ignoreParseErrors);
-        }
-        if (timestampFormat != null) {
-            properties.put(String.format("%s.%s",
-                    PravegaRegistryFormatFactory.IDENTIFIER, JsonOptions.TIMESTAMP_FORMAT.key()),
-                    timestampFormat);
-        }
-        if (mapNullKeyMode != null) {
-            properties.put(String.format("%s.%s",
-                    PravegaRegistryFormatFactory.IDENTIFIER, JsonOptions.MAP_NULL_KEY_MODE.key()),
-                    mapNullKeyMode);
-        }
-        if (mapNullKeyLiteral != null) {
-            properties.put(String.format("%s.%s",
-                    PravegaRegistryFormatFactory.IDENTIFIER, JsonOptions.MAP_NULL_KEY_LITERAL.key()),
-                    mapNullKeyLiteral);
-        }
+        propagateJsonOptions(failOnMissingField, ignoreParseErrors, timestampFormat, mapNullKeyMode, mapNullKeyLiteral);
 
         log.info("Created Pravega Catalog {}", catalogName);
     }
@@ -502,5 +478,35 @@ public class PravegaCatalog extends AbstractCatalog {
             throw new CatalogException("Fail to close connection to Pravega Schema registry", e);
         }
         schemaRegistryClient = SchemaRegistryClientFactory.withNamespace(namespace, config);
+    }
+
+    // put Json related options to properties
+    private void propagateJsonOptions(String failOnMissingField, String ignoreParseErrors,
+                                      String timestampFormat, String mapNullKeyMode, String mapNullKeyLiteral) {
+        if (failOnMissingField != null) {
+            properties.put(String.format("%s.%s",
+                    PravegaRegistryFormatFactory.IDENTIFIER, JsonOptions.FAIL_ON_MISSING_FIELD.key()),
+                    failOnMissingField);
+        }
+        if (ignoreParseErrors != null) {
+            properties.put(String.format("%s.%s",
+                    PravegaRegistryFormatFactory.IDENTIFIER, JsonOptions.IGNORE_PARSE_ERRORS.key()),
+                    ignoreParseErrors);
+        }
+        if (timestampFormat != null) {
+            properties.put(String.format("%s.%s",
+                    PravegaRegistryFormatFactory.IDENTIFIER, JsonOptions.TIMESTAMP_FORMAT.key()),
+                    timestampFormat);
+        }
+        if (mapNullKeyMode != null) {
+            properties.put(String.format("%s.%s",
+                    PravegaRegistryFormatFactory.IDENTIFIER, JsonOptions.MAP_NULL_KEY_MODE.key()),
+                    mapNullKeyMode);
+        }
+        if (mapNullKeyLiteral != null) {
+            properties.put(String.format("%s.%s",
+                    PravegaRegistryFormatFactory.IDENTIFIER, JsonOptions.MAP_NULL_KEY_LITERAL.key()),
+                    mapNullKeyLiteral);
+        }
     }
 }

--- a/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
@@ -214,8 +214,8 @@ public class PravegaRegistrySeDeITCase {
     public void testJsonDeserialize() throws Exception {
         final PravegaCatalog jsonCatalog = new PravegaCatalog(TEST_JSON_CATALOG_NAME, SETUP_UTILS.getScope(),
                 SETUP_UTILS.getControllerUri().toString(), SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString(),
-                "Json", null, null,
-                null, null, null);
+                "Json", "false", "false",
+                "SQL", "FAIL", "null");
         initJson();
         jsonCatalog.open();
 


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Move json related option operations into one function 

**Purpose of the change**
Fix #543 

**What the code does**
Move json related option operations into `propagateJsonOptions` in `PravegaCatalog`

**How to verify it**
`./gradlew clean build` passes
