### PR TITLE
[issue-545] Support new Json option

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/formats/registry/PravegaRegistryFormatFactory.java
+++ b/src/main/java/io/pravega/connectors/flink/formats/registry/PravegaRegistryFormatFactory.java
@@ -96,6 +96,7 @@ public class PravegaRegistryFormatFactory implements DeserializationFormatFactor
         final JsonOptions.MapNullKeyMode mapNullKeyMode =
                 JsonOptions.getMapNullKeyMode(formatOptions);
         final String mapNullKeyLiteral = formatOptions.get(PravegaRegistryOptions.MAP_NULL_KEY_LITERAL);
+        final boolean encodeDecimalAsPlainNumber = formatOptions.get(PravegaRegistryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER);
 
         return new EncodingFormat<SerializationSchema<RowData>>() {
             @Override
@@ -110,7 +111,8 @@ public class PravegaRegistryFormatFactory implements DeserializationFormatFactor
                         serializationFormat,
                         timestampOption,
                         mapNullKeyMode,
-                        mapNullKeyLiteral);
+                        mapNullKeyLiteral,
+                        encodeDecimalAsPlainNumber);
             }
 
             @Override
@@ -143,6 +145,7 @@ public class PravegaRegistryFormatFactory implements DeserializationFormatFactor
         options.add(PravegaRegistryOptions.TIMESTAMP_FORMAT);
         options.add(PravegaRegistryOptions.MAP_NULL_KEY_MODE);
         options.add(PravegaRegistryOptions.MAP_NULL_KEY_LITERAL);
+        options.add(PravegaRegistryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         return options;
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/formats/registry/PravegaRegistryOptions.java
+++ b/src/main/java/io/pravega/connectors/flink/formats/registry/PravegaRegistryOptions.java
@@ -49,4 +49,5 @@ public class PravegaRegistryOptions {
     public static final ConfigOption<String> TIMESTAMP_FORMAT = JsonOptions.TIMESTAMP_FORMAT;
     public static final ConfigOption<String> MAP_NULL_KEY_MODE = JsonOptions.MAP_NULL_KEY_MODE;
     public static final ConfigOption<String> MAP_NULL_KEY_LITERAL = JsonOptions.MAP_NULL_KEY_LITERAL;
+    public static final ConfigOption<Boolean> ENCODE_DECIMAL_AS_PLAIN_NUMBER = JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 }

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/PravegaCatalog.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/PravegaCatalog.java
@@ -80,7 +80,8 @@ public class PravegaCatalog extends AbstractCatalog {
 
     public PravegaCatalog(String catalogName, String defaultDatabase, String controllerUri, String schemaRegistryUri,
                           String serializationFormat, String failOnMissingField, String ignoreParseErrors,
-                          String timestampFormat, String mapNullKeyMode, String mapNullKeyLiteral) {
+                          String timestampFormat, String mapNullKeyMode,
+                          String mapNullKeyLiteral, String encodeDecimalAsPlainNumber) {
 
         super(catalogName, defaultDatabase);
 
@@ -104,7 +105,8 @@ public class PravegaCatalog extends AbstractCatalog {
                 PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FORMAT.key()),
                 this.serializationFormat.name());
 
-        propagateJsonOptions(failOnMissingField, ignoreParseErrors, timestampFormat, mapNullKeyMode, mapNullKeyLiteral);
+        propagateJsonOptions(failOnMissingField, ignoreParseErrors, timestampFormat,
+                mapNullKeyMode, mapNullKeyLiteral, encodeDecimalAsPlainNumber);
 
         log.info("Created Pravega Catalog {}", catalogName);
     }
@@ -481,7 +483,7 @@ public class PravegaCatalog extends AbstractCatalog {
 
     // put Json related options to properties
     private void propagateJsonOptions(String failOnMissingField, String ignoreParseErrors, String timestampFormat,
-                                      String mapNullKeyMode, String mapNullKeyLiteral) {
+                                      String mapNullKeyMode, String mapNullKeyLiteral, String encodeDecimalAsPlainNumber) {
 
         properties.put(String.format("%s.%s",
                 PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FAIL_ON_MISSING_FIELD.key()),
@@ -498,5 +500,8 @@ public class PravegaCatalog extends AbstractCatalog {
         properties.put(String.format("%s.%s",
                 PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.MAP_NULL_KEY_LITERAL.key()),
                 mapNullKeyLiteral);
+        properties.put(String.format("%s.%s",
+                PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.key()),
+                encodeDecimalAsPlainNumber);
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
@@ -54,6 +54,7 @@ public class PravegaCatalogFactory implements CatalogFactory {
         options.add(PravegaCatalogFactoryOptions.JSON_TIMESTAMP_FORMAT);
         options.add(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_MODE);
         options.add(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_LITERAL);
+        options.add(PravegaCatalogFactoryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         return options;
     }
 
@@ -80,6 +81,7 @@ public class PravegaCatalogFactory implements CatalogFactory {
                 delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_IGNORE_PARSE_ERRORS).toString(),
                 delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_TIMESTAMP_FORMAT),
                 delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_MODE),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_LITERAL));
+                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_LITERAL),
+                delegatingConfiguration.get(PravegaCatalogFactoryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER).toString());
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactoryOptions.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactoryOptions.java
@@ -41,6 +41,7 @@ public class PravegaCatalogFactoryOptions {
     public static final ConfigOption<String> JSON_TIMESTAMP_FORMAT = JsonOptions.TIMESTAMP_FORMAT;
     public static final ConfigOption<String> JSON_MAP_NULL_KEY_MODE = JsonOptions.MAP_NULL_KEY_MODE;
     public static final ConfigOption<String> JSON_MAP_NULL_KEY_LITERAL = JsonOptions.MAP_NULL_KEY_LITERAL;
+    public static final ConfigOption<Boolean> ENCODE_DECIMAL_AS_PLAIN_NUMBER = JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 
     private PravegaCatalogFactoryOptions() {}
 }

--- a/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
@@ -288,7 +288,7 @@ public class PravegaCatalogITCase {
         CATALOG = new PravegaCatalog(TEST_CATALOG_NAME, SETUP_UTILS.getScope(),
                 SETUP_UTILS.getControllerUri().toString(), SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString(),
                 "Avro", "false", "false",
-                "SQL", "FAIL", "null");
+                "SQL", "FAIL", "null", "false");
         EventStreamWriter<Object> writer = SCHEMA_REGISTRY_UTILS.getWriter(TEST_STREAM, AvroSchema.of(TEST_SCHEMA), SerializationFormat.Avro);
         writer.writeEvent(EVENT).join();
         writer.close();

--- a/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistryFormatFactoryTest.java
+++ b/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistryFormatFactoryTest.java
@@ -64,6 +64,7 @@ public class PravegaRegistryFormatFactoryTest extends TestLogger {
     private static final JsonOptions.MapNullKeyMode MAP_NULL_KEY_MODE =
             JsonOptions.MapNullKeyMode.FAIL;
     private static final String MAP_NULL_KEY_LITERAL = "null";
+    private static final boolean ENCODE_DECIMAL_AS_PLAIN_NUMBER = false;
 
     @Test
     public void testSeDeSchema() {
@@ -100,7 +101,8 @@ public class PravegaRegistryFormatFactoryTest extends TestLogger {
                         SERIALIZATIONFORMAT,
                         TIMESTAMP_FORMAT,
                         MAP_NULL_KEY_MODE,
-                        MAP_NULL_KEY_LITERAL);
+                        MAP_NULL_KEY_LITERAL,
+                        ENCODE_DECIMAL_AS_PLAIN_NUMBER);
 
         final DynamicTableSink actualSink = createTableSink(options);
         assertTrue(actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock);

--- a/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
@@ -105,6 +105,7 @@ public class PravegaRegistrySeDeITCase {
     private static final JsonOptions.MapNullKeyMode MAP_NULL_KEY_MODE =
             JsonOptions.MapNullKeyMode.FAIL;
     private static final String MAP_NULL_KEY_LITERAL = "null";
+    private static final boolean ENCODE_DECIMAL_AS_PLAIN_NUMBER = false;
 
     /** Setup utility */
     private static final SetupUtils SETUP_UTILS = new SetupUtils();
@@ -128,7 +129,7 @@ public class PravegaRegistrySeDeITCase {
         final PravegaCatalog avroCatalog = new PravegaCatalog(TEST_AVRO_CATALOG_NAME, SETUP_UTILS.getScope(),
                 SETUP_UTILS.getControllerUri().toString(), SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString(),
                 "Avro", "false", "false",
-                "SQL", "FAIL", "null");
+                "SQL", "FAIL", "null", "false");
         initAvro();
         avroCatalog.open();
 
@@ -183,7 +184,7 @@ public class PravegaRegistrySeDeITCase {
         PravegaRegistryRowDataSerializationSchema serializationSchema =
                 new PravegaRegistryRowDataSerializationSchema(avroRowType, SETUP_UTILS.getScope(),
                         AVRO_TEST_STREAM, SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri(), SerializationFormat.Avro,
-                        TIMESTAMP_FORMAT, MAP_NULL_KEY_MODE, MAP_NULL_KEY_LITERAL);
+                        TIMESTAMP_FORMAT, MAP_NULL_KEY_MODE, MAP_NULL_KEY_LITERAL, ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         serializationSchema.open(null);
         PravegaRegistryRowDataDeserializationSchema deserializationSchema =
                 new PravegaRegistryRowDataDeserializationSchema(avroRowType, avroTypeInfo, SETUP_UTILS.getScope(),
@@ -215,7 +216,7 @@ public class PravegaRegistrySeDeITCase {
         final PravegaCatalog jsonCatalog = new PravegaCatalog(TEST_JSON_CATALOG_NAME, SETUP_UTILS.getScope(),
                 SETUP_UTILS.getControllerUri().toString(), SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString(),
                 "Json", "false", "false",
-                "SQL", "FAIL", "null");
+                "SQL", "FAIL", "null", "false");
         initJson();
         jsonCatalog.open();
 
@@ -327,7 +328,7 @@ public class PravegaRegistrySeDeITCase {
         PravegaRegistryRowDataSerializationSchema serializationSchema =
                 new PravegaRegistryRowDataSerializationSchema(
                         jsonRowType, SETUP_UTILS.getScope(), JSON_TEST_STREAM, SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri(),
-                        SerializationFormat.Json, TIMESTAMP_FORMAT, MAP_NULL_KEY_MODE, MAP_NULL_KEY_LITERAL);
+                        SerializationFormat.Json, TIMESTAMP_FORMAT, MAP_NULL_KEY_MODE, MAP_NULL_KEY_LITERAL, ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         serializationSchema.open(null);
 
         byte[] actualBytes = serializationSchema.serialize(rowData);


### PR DESCRIPTION

Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Support a new Json option `ENCODE_DECIMAL_AS_PLAIN_NUMBER` in Pravega Registry format factory

**Purpose of the change**
Fix #545 

**What the code does**
Add new ConfigOption in `PravegaRegistryOptions` and `PravegaCatalogFactory`
Use new `ObjectMapper` configured with `encodeDecimalAsPlainNumber` in serialization schema

**How to verify it**
`./gradlew clean build` passes.