### PR TITLE
[Issue-539] NullPointerPxception when there is no credentials in pravega client config

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -341,7 +341,7 @@ public class FlinkPravegaReader<T>
         while ((event = pravegaCollector.getRecords().poll()) != null) {
             synchronized (ctx.getCheckpointLock()) {
                 if (isEventTimeMode()) {
-                    assert assigner != null;  // assigner won't be null in event time mode
+                    assert assigner != null;  // assigner won't be null in the event time mode
                     long currentTimestamp = assigner.extractTimestamp(event, previousTimestamp);
                     ctx.collectWithTimestamp(event, currentTimestamp);
                     previousTimestamp = currentTimestamp;
@@ -659,7 +659,7 @@ public class FlinkPravegaReader<T>
      * Create the {@link EventStreamReader} for the current configuration. <p>
      *
      * The reader will output raw ByteBuffer rather than the deserialized T.
-     * See {@link emitEvent} for the decoding process.
+     * See {@link #emitEvent} for the decoding process.
      * To customize the process, overwrite {@link PravegaDeserializationSchemaWithMetadata}.
      *
      * @param readerId the readerID to use.

--- a/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSource.java
+++ b/src/main/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableSource.java
@@ -202,9 +202,10 @@ public class FlinkPravegaDynamicTableSource implements ScanTableSource, Supports
 
             return SourceFunctionProvider.of(readerBuilder.build(), isBounded);
         } else {
-            FlinkPravegaInputFormat.Builder<RowData> inputFormatBuilder = FlinkPravegaInputFormat.<RowData>builder()
-                    .withPravegaConfig(pravegaConfig)
-                    .withDeserializationSchema(deserializationSchema);
+            FlinkPravegaInputFormat.Builder<RowData> inputFormatBuilder =
+                    FlinkPravegaInputFormat.<RowData>builder()
+                            .withPravegaConfig(pravegaConfig)
+                            .withDeserializationSchema(deserializationSchema);
 
             for (StreamWithBoundaries stream : streams) {
                 inputFormatBuilder.forStream(stream.getStream(), stream.getFrom(), stream.getTo());

--- a/src/main/java/io/pravega/connectors/flink/formats/registry/PravegaRegistryRowDataDeserializationSchema.java
+++ b/src/main/java/io/pravega/connectors/flink/formats/registry/PravegaRegistryRowDataDeserializationSchema.java
@@ -216,7 +216,9 @@ public class PravegaRegistryRowDataDeserializationSchema implements Deserializat
         }
 
         @Override
-        public final JsonNode deserialize(InputStream inputStream, SchemaInfo writerSchemaInfo, SchemaInfo readerSchemaInfo) throws IOException {
+        public final JsonNode deserialize(InputStream inputStream,
+                                          SchemaInfo writerSchemaInfo,
+                                          SchemaInfo readerSchemaInfo) throws IOException {
             return objectMapper.readTree(inputStream);
         }
     }

--- a/src/main/java/io/pravega/connectors/flink/serialization/JsonSerializer.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/JsonSerializer.java
@@ -21,7 +21,7 @@ public class JsonSerializer<T> implements Serializer<T>, Serializable {
 
     /** Object mapper for parsing the JSON. */
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private Class<T> valueType;
+    private final Class<T> valueType;
 
     public JsonSerializer(Class<T> valueType) {
         this.valueType = valueType;

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/PravegaCatalog.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/PravegaCatalog.java
@@ -98,7 +98,7 @@ public class PravegaCatalog extends AbstractCatalog {
                 String.format(
                         "%s.%s",
                         PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.URI.key()),
-        schemaRegistryUri);
+                schemaRegistryUri);
 
         properties.put(String.format("%s.%s",
                 PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FORMAT.key()),
@@ -174,7 +174,6 @@ public class PravegaCatalog extends AbstractCatalog {
                 .filter(s -> !s.startsWith("_"))
                 .collect(Collectors.toList());
 
-        log.info("aaa: {}", databaseList);
         return databaseList;
     }
 
@@ -250,9 +249,9 @@ public class PravegaCatalog extends AbstractCatalog {
 
         return StreamSupport
                 .stream(iterable.spliterator(), false)
-                .map(s -> s.getStreamName())
+                .map(Stream::getStreamName)
                 .filter(s -> !s.startsWith("_"))
-                .filter(s -> groupSet.contains(s))
+                .filter(groupSet::contains)
                 .collect(Collectors.toList());
     }
 
@@ -348,7 +347,8 @@ public class PravegaCatalog extends AbstractCatalog {
                 Compatibility.allowAny(),
                 true));
 
-        SchemaInfo schemaInfo = PravegaSchemaUtils.tableSchemaToSchemaInfo(table.getSchema(), serializationFormat);
+        SchemaInfo schemaInfo = PravegaSchemaUtils.tableSchemaToSchemaInfo(
+                table.getSchema(), serializationFormat);
         schemaRegistryClient.addSchema(stream, schemaInfo);
     }
 

--- a/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/FlinkPravegaUtils.java
@@ -135,7 +135,8 @@ public class FlinkPravegaUtils {
         @SneakyThrows
         public T deserialize(ByteBuffer buffer) {
             byte[] array;
-            if (buffer.hasArray() && buffer.arrayOffset() == 0 && buffer.position() == 0 && buffer.limit() == buffer.capacity()) {
+            if (buffer.hasArray() && buffer.arrayOffset() == 0 &&
+                    buffer.position() == 0 && buffer.limit() == buffer.capacity()) {
                 array = buffer.array();
             } else {
                 array = new byte[buffer.remaining()];

--- a/src/main/java/io/pravega/connectors/flink/util/SchemaRegistryUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/SchemaRegistryUtils.java
@@ -14,6 +14,8 @@ import io.pravega.schemaregistry.client.SchemaRegistryClientConfig;
 import io.pravega.schemaregistry.serializer.shared.credentials.PravegaCredentialProvider;
 import org.apache.flink.util.Preconditions;
 
+import static io.pravega.connectors.flink.util.FlinkPravegaUtils.isCredentialsLoadDynamic;
+
 public class SchemaRegistryUtils {
 
     /**
@@ -30,9 +32,18 @@ public class SchemaRegistryUtils {
                 .schemaRegistryUri(pravegaConfig.getSchemaRegistryUri());
 
         if (pravegaConfig.getCredentials() != null) {
-            builder.authentication(pravegaConfig.getCredentials().getAuthenticationType(), pravegaConfig.getCredentials().getAuthenticationToken());
+            // basic credential
+            builder.authentication(
+                    pravegaConfig.getCredentials().getAuthenticationType(),
+                    pravegaConfig.getCredentials().getAuthenticationToken()
+            );
         } else {
-            builder.authentication(new PravegaCredentialProvider(pravegaConfig.getClientConfig()));
+            if (isCredentialsLoadDynamic()) {
+                // dynamic credential, e.g. Keycloak
+                builder.authentication(new PravegaCredentialProvider(pravegaConfig.getClientConfig()));
+            } else {
+                // no credential
+            }
         }
 
         return builder.build();


### PR DESCRIPTION
**Change log description**

Prevent the `NullPointerException` if there is no credential after `getSchemaRegistryClientConfig` is called.

**Purpose of the change**

Fixes #539 

**What the code does**

Remove the authentication process if the pravegaConfig contains no credential.

**How to verify it**

Tests using SchemaRegistry should pass when the pravega is in the standalone mode and is configured without credentials.

> `FlinkPravegaSchemaRegistryReaderTestITCase.testReaderWithJsonRegistryDeserializer`.
