### PR TITLE
[issue-557] Fix Json prefix

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
@@ -27,7 +27,7 @@ import java.util.Set;
 /** Factory for {@link PravegaCatalog}. */
 public class PravegaCatalogFactory implements CatalogFactory {
     // the prefix of checkpoint names json related options
-    private static final String JSON_PREFIX = "json";
+    private static final String JSON_PREFIX = "json.";
 
     private static final Logger LOG = LoggerFactory.getLogger(PravegaCatalogFactory.class);
 


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Add missing `.` in json prefix in `PravegaCatalogFactory`.

**Purpose of the change**
Fix #557 

**What the code does**
Fix `JSON_PREFIX` in `PravegaCatalogFactory`

**How to verify it**
`./gradlew clean build` passed
