### PR TITLE
[Issue-556] Drop support for Scala 2.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,46 +52,8 @@ jobs:
       - name: Build via Gradle
         run: ./gradlew clean build
 
-  build_with_scala_211:
-    name: Build with Scala 2.11
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # see comments above
-          fetch-depth: 0
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: '11' # major or semver Java version will be acceptable, see https://github.com/marketplace/actions/setup-java-jdk#basic
-          java-package: jdk  # (jre, jdk, or jdk+fx) - defaults to jdk
-          architecture: x64  # (x64 or x86) - defaults to x64
-
-        # see comments above
-      - name: Cache gradle modules
-        uses: actions/cache@v2
-        with:
-          path: |
-            .gradle
-            $HOME/.gradle
-            $HOME/.m2
-          key: ${{ runner.os }}-gradle-scala211-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-
-        # see comments above
-      - name: Cache build outputs
-        uses: actions/cache@v2
-        with:
-          path: ./*
-          key: scala211-${{ github.run_id }}
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Build via Gradle with Scala 2.11
-        run: |
-          ./gradlew clean build -PflinkScalaVersion=2.11
-          bash <(curl -s https://codecov.io/bash) -t 9c42ff48-d98f-4444-af05-cf734aa1dbd0
+      - name: Report to Codecov
+        run: bash <(curl -s https://codecov.io/bash) -t 9c42ff48-d98f-4444-af05-cf734aa1dbd0
 
   snapshot:
     name: Publish snapshot to Github Packages
@@ -103,7 +65,7 @@ jobs:
       BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
       BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
     steps:
-        # see comments above
+        # gradle packages that need to be cached
       - name: Cache gradle modules
         uses: actions/cache@v2
         with:
@@ -113,7 +75,7 @@ jobs:
             $HOME/.m2
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
-        # see comments above
+        # publish the artifact from the build cache
       - name: Cache build outputs
         uses: actions/cache@v2
         with:
@@ -122,33 +84,3 @@ jobs:
 
       - name: Publish to Github Packages
         run: ./gradlew publish -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}}
-
-  snapshot_with_scala_211:
-    name: Publish snapshot to Github Packages with Scala 2.11
-    needs: [build_with_scala_211]
-    runs-on: ubuntu-latest
-    # only publish the snapshot when it is a push on the master or the release branch (starts with r0.x or r1.x)
-    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/r0.') || startsWith(github.ref, 'refs/heads/r1.')) }}
-    env:
-      BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-      BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
-    steps:
-        # see comments above
-      - name: Cache gradle modules
-        uses: actions/cache@v2
-        with:
-          path: |
-            .gradle
-            $HOME/.gradle
-            $HOME/.m2
-          key: ${{ runner.os }}-gradle-scala211-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-
-        # see comments above
-      - name: Cache build outputs
-        uses: actions/cache@v2
-        with:
-          path: ./*
-          key: scala211-${{ github.run_id }}
-
-      - name: Publish to Github Packages with Scala 2.11
-        run: ./gradlew publish -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}} -PflinkScalaVersion=2.11

--- a/documentation/src/docs/getting-started.md
+++ b/documentation/src/docs/getting-started.md
@@ -9,7 +9,7 @@ You may obtain a copy of the License at
 -->
 # Pravega Flink Connectors [![Build Status](https://travis-ci.org/pravega/flink-connectors.svg?branch=master)](https://travis-ci.org/pravega/flink-connectors)
 
-This repository implements  connectors to read and write [Pravega](http://pravega.io/) Streams with [Apache Flink](http://flink.apache.org/) stream processing framework.
+This repository implements connectors to read and write [Pravega](http://pravega.io/) Streams with [Apache Flink](http://flink.apache.org/) stream processing framework.
 
 The connectors can be used to build end-to-end stream processing pipelines (see [Samples](https://github.com/pravega/pravega-samples)) that use Pravega as the stream storage and message bus, and Apache Flink for computation over the streams.
 
@@ -55,18 +55,6 @@ To install the artifacts in the local maven repository cache `~/.m2/repository`,
 We can check and change the Flink version that Pravega builds against via the `flinkVersion` variable in the `gradle.properties` file.
 
 **Note**: Only Flink versions that are compatible with the latest connector code can be chosen.
-
-#### Building against another Scala version
-
-This section is only relevant if you use [Scala](https://www.scala-lang.org/) in the stream processing application with Flink and Pravega.
-
-Parts of the Apache Flink use the language or depend on libraries written in Scala. Because Scala is **not** strictly compatible across versions, there exist different versions of Flink compiled for different Scala versions.
-If we use Scala code in the same application where we use the Apache Flink or the Flink connectors, we typically have to make sure we use a version of Flink that uses the same Scala version as our application.
-
-Each version of Flink has a preferred Scala version as determined by the official Flink docker image. We use the preferred version by default.
-To depend on released Flink artifacts for a different Scala version, you need to edit the `build.gradle` file and change all entries for the Flink dependencies to have a different Scala version suffix. For example, `flink-streaming-java_2.11` would be replaced by `flink-streaming-java_2.12` for Scala **2.12**.
-
-In order to build a new version of Flink for a different Scala version, please refer to the [Flink documentation](https://ci.apache.org/projects/flink/flink-docs-stable/start/building.html#scala-versions).
 
 ## Setting up your IDE
 


### PR DESCRIPTION
Signed-off-by: thekingofcity <3353040+thekingofcity@users.noreply.github.com>

**Change log description**
This PR drops support for Scala 2.11.

**Purpose of the change**
Fixes #556

**What the code does**
Remove the 2.11 part in workflows and update the related doc.

**How to verify it**
Github Actions should work only with one artifact.
