### PR TITLE
[issue-569] Remove mavenLocal() in the Gradle build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ group = "io.pravega"
 version = getProjectVersion()
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url "https://maven.pkg.github.com/pravega/pravega"


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Remove `mavenLocal()` in the Gradle build script

**Purpose of the change**
Fix #569 

**What the code does**
Remove `mavenLocal()` in `build.gradle`

**How to verify it**
`./gradlew clean build` passed
