### PR TITLE
[Issue-571] Add Python datastream API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ log/
 .metadata/
 .recommenders/
 *.log
+*.pyc
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ supported versions of Flink and Pravega.
 | [r0.9-flink1.10](https://github.com/pravega/flink-connectors/tree/r0.9-flink1.10)   | 0.9  | Java 11 | Java 8 or 11 | 1.10 | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.10_2.12/0.9.1/    |
 | [r0.9-flink1.9](https://github.com/pravega/flink-connectors/tree/r0.9-flink1.9)     | 0.9  | Java 11 | Java 8 or 11 | 1.9  | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.9_2.12/0.9.1/     |
 
-Looking for python as an alternative? Check [here](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/python.md) for python implementation reference.
-
 ## How to build
 
 Building the connectors from the source is only necessary when we want to use or contribute to the latest (unreleased) version of the Pravega Flink connectors.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ supported versions of Flink and Pravega.
 | [r0.9-flink1.10](https://github.com/pravega/flink-connectors/tree/r0.9-flink1.10)   | 0.9  | Java 11 | Java 8 or 11 | 1.10 | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.10_2.12/0.9.1/    |
 | [r0.9-flink1.9](https://github.com/pravega/flink-connectors/tree/r0.9-flink1.9)     | 0.9  | Java 11 | Java 8 or 11 | 1.9  | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.9_2.12/0.9.1/     |
 
-Looking for python as an alternative? Check [here](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/python.md) for python implementation reference on `python 3.8` and `apache-flink 1.13.2`.
+Looking for python as an alternative? Check [here](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/python.md) for python implementation reference.
 
 ## How to build
 Building the connectors from the source is only necessary when we want to use or contribute to the latest (unreleased) version of the Pravega Flink connectors.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ supported versions of Flink and Pravega.
 | [r0.9-flink1.10](https://github.com/pravega/flink-connectors/tree/r0.9-flink1.10)   | 0.9  | Java 11 | Java 8 or 11 | 1.10 | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.10_2.12/0.9.1/    |
 | [r0.9-flink1.9](https://github.com/pravega/flink-connectors/tree/r0.9-flink1.9)     | 0.9  | Java 11 | Java 8 or 11 | 1.9  | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.9_2.12/0.9.1/     |
 
+Looking for python as an alternative? Check [here](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/python.md) for python implementation reference on `python 3.8` and `apache-flink 1.13.2`.
+
 ## How to build
 Building the connectors from the source is only necessary when we want to use or contribute to the latest (unreleased) version of the Pravega Flink connectors.
 

--- a/documentation/src/docs/index.md
+++ b/documentation/src/docs/index.md
@@ -7,20 +7,22 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-## Apache Flink Connectors for Pravega
+
+# Apache Flink Connectors for Pravega
 
 This documentation describes the connectors API and it's usage to read and write [Pravega](http://pravega.io/) streams with [Apache Flink](http://flink.apache.org/) stream processing framework.
 
-Build end-to-end stream processing pipelines that use Pravega as the stream storage and message bus, and Apache Flink for computation over the streams.   See the [Pravega Concepts](http://pravega.io/docs/pravega-concepts/) page for more information.
+Build end-to-end stream processing pipelines that use Pravega as the stream storage and message bus, and Apache Flink for computation over the streams. See the [Pravega Concepts](http://pravega.io/docs/pravega-concepts/) page for more information.
 
 ## Table of Contents
 
 - [Getting Started](getting-started.md)
 - [Quick Start](quickstart.md)
 - Features
-	- [Streaming](streaming.md)
-	- [Batch](batch.md)
-	- [Table API/SQL](table-api.md)
+  - [Streaming](streaming.md)
+  - [Batch](batch.md)
+  - [Table API/SQL](table-api.md)
 - [Metrics](metrics.md)
 - [Configurations](configurations.md)
 - [Serialization](serialization.md)
+- [Python datastream API](python.md)

--- a/documentation/src/docs/index.md
+++ b/documentation/src/docs/index.md
@@ -22,7 +22,7 @@ Build end-to-end stream processing pipelines that use Pravega as the stream stor
   - [Streaming](streaming.md)
   - [Batch](batch.md)
   - [Table API/SQL](table-api.md)
+  - [Python Datastream API](python.md)
 - [Metrics](metrics.md)
 - [Configurations](configurations.md)
 - [Serialization](serialization.md)
-- [Python datastream API](python.md)

--- a/documentation/src/docs/python.md
+++ b/documentation/src/docs/python.md
@@ -1,6 +1,6 @@
 # Pravega Python DataStream connector
 
-This Pravega connector of Python API provides a data source and data sink for Flink streaming jobs.
+This Pravega Python DataStream connector provides a data source and data sink for Flink streaming jobs.
 
 Your Flink streaming jobs could use Pravega as their storage with these [Python API Wrappers](https://github.com/pravega/flink-connectors/tree/master/src/main/python). This page only describes the API usage and for parameter concepts please refer to [Configurations](configurations.md) and [Streaming](streaming.md)
 

--- a/documentation/src/docs/python.md
+++ b/documentation/src/docs/python.md
@@ -6,7 +6,13 @@ Your Flink streaming jobs could use Pravega as their storage with these [Python 
 
 **DISCLAIMER: This python wrapper is an IMPLEMENTATION REFERENCE and is not officially published.**
 
-[TOC]
+* [How to use](#How-to-use)
+* [PravegaConfig](#PravegaConfig)
+* [StreamCut](#StreamCut)
+* [FlinkPravegaReader](#FlinkPravegaReader)
+* [FlinkPravegaWriter](#FlinkPravegaWriter)
+* [Metrics](#Metrics)
+* [Serialization](#Serialization)
 
 ## How to use
 

--- a/documentation/src/docs/python.md
+++ b/documentation/src/docs/python.md
@@ -178,6 +178,23 @@ if __name__ == '__main__':
 
 ```
 
+The pravega should have events like:
+
+```bash
+$ bin/helloWorldReader -scope "scope" -name "stream"
+Reading all the events from scope/stream
+Read event '{"f0":3,"f1":1}'
+Read event '{"f0":0,"f1":1}'
+Read event '{"f0":0,"f1":1}'
+...
+Read event '{"f0":0,"f1":1}'
+Read event '{"f0":3,"f1":1}'
+Read event '{"f0":3,"f1":1}'
+No more events from scope/stream
+```
+
+from [gettingstarted example](https://github.com/pravega/pravega-samples/tree/master/pravega-client-examples#gettingstarted) of [pravega-samples](https://github.com/pravega/pravega-samples).
+
 ### Create a StreamExecutionEnvironment
 
 The StreamExecutionEnvironment is a central concept of the DataStream API program. The following code example shows how to create a StreamExecutionEnvironment:

--- a/documentation/src/docs/python.md
+++ b/documentation/src/docs/python.md
@@ -1,19 +1,19 @@
-# Python API for the connector
+# Pravega Python DataStream connector
 
 This Pravega connector of Python API provides a data source and data sink for Flink streaming jobs.
 
-Your Flink streaming jobs could use Pravega as their storage with these [Python API Wrappers](https://github.com/pravega/flink-connectors/tree/master/src/main/python).
+Your Flink streaming jobs could use Pravega as their storage with these [Python API Wrappers](https://github.com/pravega/flink-connectors/tree/master/src/main/python). This page only describes the API usage and for parameter concepts please refer to [Configurations](configurations.md) and [Streaming](streaming.md)
 
-**DISCLAIMER: This python wrapper is an IMPLEMENTATION REFERENCE and is not meant for out-of-box usage.**
+**DISCLAIMER: This python wrapper is an IMPLEMENTATION REFERENCE and is not officially published.**
 
 [TOC]
 
 ## How to use
 
-Together with python wrapper files, you could submit your job with main compute code like this:
+Together with the connector jar and python wrapper files, you could submit your job with main compute code like this:
 
 ```bash
-flink run --python ./application.py --pyFiles ./pravega_config.py --pyFiles ./pravega_writer.py --pyFiles ./pravega_reader.py --jarfile /path/to/pravega-connectors-flink.jar
+flink run --python ./application.py --pyFiles <connector-repo>/src/main/python/ --jarfile /path/to/pravega-connectors-flink.jar
 ```
 
 ## PravegaConfig
@@ -23,30 +23,23 @@ A top-level config object, `PravegaConfig`, is provided to establish a Pravega c
 ```python
 from pravega_config import PravegaConfig
 
-pravega_config = PravegaConfig(CONTROLLER_URI, SCOPE)
+pravega_config = PravegaConfig(uri=uri, scope=scope)
 ```
 
 |parameter|type|required|default value|description|
 |-|-|-|-|-|
 |uri|str|Yes|N/A|The Pravega controller RPC URI.|
 |scope|str|Yes|N/A|The self-defined Pravega scope.|
-|schema_registry_uri|str|No|None|The Pravega schema registry URI.|
 |trust_store|str|No|None|The truststore value.|
 |default_scope|str|No|None|The default Pravega scope, to resolve unqualified stream names and to support reader groups.|
 |credentials|DefaultCredentials|No|None|The Pravega credentials to use.|
 |validate_hostname|bool|No|True|TLS hostname validation.|
 
-For more details about *Default Scope*? See [the java doc](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/configurations.md#understanding-the-default-scope).
-
 ## StreamCut
-
-A `StreamCut` represents a specific position in a Pravega Stream, which may be obtained from various API interactions with the Pravega client. The `FlinkPravegaReader` accepts a `StreamCut` as the start and/or end position of a given stream. For further reading on `StreamCuts`, please refer to documentation on [StreamCut](http://pravega.io/docs/latest/streamcuts/) and [sample code(java only)](https://github.com/pravega/pravega-samples/tree/master/pravega-client-examples/src/main/java/io/pravega/example/streamcuts).
 
 A `StreamCut` object could be constructed from the `from_base64` class method where a base64 str is passed as the only parameter.
 
 By default, the `FlinkPravegaReader` will pass the `UNBOUNDED` `StreamCut` which let the reader read from the HEAD to the TAIL.
-
-For more details about *Historical Stream Processing*? See [the java doc](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/streaming.md#historical-stream-processing).
 
 ## FlinkPravegaReader
 
@@ -86,8 +79,6 @@ ds = env.add_source(pravega_reader)
 |event_read_timeout|timedelta|No|None(1 second on java side)|Sets the timeout for the call to read events from Pravega. After the timeout expires (without an event being returned), another call will be made.|
 |max_outstanding_checkpoint_request|int|No|None(3 on java side)|Configures the maximum outstanding checkpoint requests to Pravega.|
 
-For more details about concepts like *Reader Parallelism* and *Checkpointing*? See [the java doc](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/streaming.md#input-streams).
-
 ## FlinkPravegaWriter
 
 Use `FlinkPravegaWriter` as a datastream sink. Could be added by `env.add_sink`.
@@ -119,11 +110,9 @@ ds = env.add_sink(pravega_reader)
 |enable_watermark|bool|No|False|Emit Flink watermark in event-time semantics to Pravega streams.|
 |txn_lease_renewal_period|timedelta|No|None(30 seconds on java side)|Report Pravega metrics.|
 
-For more details about concepts like *Watermark* and *Writer Modes*? See [the java doc](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/streaming.md#writer-parallelism).
-
 ## Metrics
 
-Metrics are reported by default unless it is explicitly disabled using enable_metrics(False) option. See [Metrics](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/metrics.md) page for more details on type of metrics that are reported.
+Metrics are reported by default unless it is explicitly disabled using enable_metrics(False) option. See [Metrics](metrics.md) page for more details on type of metrics that are reported.
 
 ## Serialization
 

--- a/documentation/src/docs/python.md
+++ b/documentation/src/docs/python.md
@@ -2,9 +2,19 @@
 
 This Pravega connector of Python API provides a data source and data sink for Flink streaming jobs.
 
+Your Flink streaming jobs could use Pravega as their storage with these [Python API Wrappers](https://github.com/pravega/flink-connectors/tree/master/src/main/python).
+
 **DISCLAIMER: This python wrapper is an IMPLEMENTATION REFERENCE and is not meant for out-of-box usage.**
 
 [TOC]
+
+## How to use
+
+Together with python wrapper files, you could submit your job with main compute code like this:
+
+```bash
+flink run --python ./application.py --pyFiles ./pravega_config.py --pyFiles ./pravega_writer.py --pyFiles ./pravega_reader.py --jarfile /path/to/pravega-connectors-flink.jar
+```
 
 ## PravegaConfig
 
@@ -51,9 +61,9 @@ from pravega_reader import FlinkPravegaReader
 
 env = StreamExecutionEnvironment.get_execution_environment()
 
-pravega_config = PravegaConfig(CONTROLLER_URI, SCOPE)
+pravega_config = PravegaConfig(uri=uri, scope=scope)
 pravega_reader = FlinkPravegaReader(
-    stream=STREAM,
+    stream=stream,
     pravega_config=pravega_config,
     deserialization_schema=SimpleStringSchema())
 
@@ -91,8 +101,8 @@ from pravega_writer import FlinkPravegaWriter
 
 env = StreamExecutionEnvironment.get_execution_environment()
 
-pravega_config = PravegaConfig(CONTROLLER_URI, SCOPE)
-pravega_writer = FlinkPravegaWriter(stream=STREAM,
+pravega_config = PravegaConfig(uri=uri, scope=scope)
+pravega_writer = FlinkPravegaWriter(stream=stream,
                                     pravega_config=pravega_config,
                                     serialization_schema=SimpleStringSchema())
 
@@ -115,10 +125,6 @@ For more details about concepts like *Watermark* and *Writer Modes*? See [the ja
 
 Metrics are reported by default unless it is explicitly disabled using enable_metrics(False) option. See [Metrics](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/metrics.md) page for more details on type of metrics that are reported.
 
-Metrics is also gatherable by Python code. See [Metrics](https://ci.apache.org/projects/flink/flink-docs-stable/docs/dev/python/table/metrics/) page of PyFlink for more information.
-
 ## Serialization
-
-See the [serialization](https://github.com/pravega/flink-connectors/blob/master/documentation/src/docs/serialization.md) page for more information on how to use the java serializer and deserializer.
 
 See the [Data Types](https://ci.apache.org/projects/flink/flink-docs-stable/docs/dev/python/datastream/data_types/) page of PyFlink for more information.

--- a/documentation/src/docs/python.md
+++ b/documentation/src/docs/python.md
@@ -1,0 +1,316 @@
+<!--
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Pravega Flink Connectors for Python
+
+[![Build Status](https://img.shields.io/github/workflow/status/pravega/flink-connectors/build)](https://github.com/pravega/flink-connectors/actions/workflows/build.yml?query=branch%3Amaster) [![Issue Tracking](https://img.shields.io/github/issues/pravega/flink-connectors)](https://github.com/pravega/flink-connectors/issues) [![License](https://img.shields.io/github/license/pravega/flink-connectors)](https://github.com/pravega/flink-connectors/blob/master/LICENSE) [![Downloads](https://img.shields.io/github/downloads/pravega/flink-connectors/total)](https://github.com/pravega/flink-connectors/releases) [![docs](https://img.shields.io/static/v1?label=docs&message=see-latest&color=blue)](https://github.com/pravega/flink-connectors/tree/master/documentation/src/docs)
+
+👏🎉 Welcome to the Python world of Pravega Flink Connectors!
+
+🧾 This page is all about how to use the connectors in `PyFlink`.
+
+🚨 **DISCLAIMER: This python wrapper is an IMPLEMENTATION REFERENCE and is not meant for out-of-box usage.** See below [Technical Details](#Technical-Details) for more information.
+
+---
+
+We assume you know some basic ideas about `Pravega`, `Python`, `PyFlink` and is eager to use Pravega as the streaming storage for batch and/or streaming workloads of Flink.
+If not, see the below [Overview](#Overview) section or learn more about [Pravega](https://pravega.io/), [Flink](https://flink.apache.org/), and [Pravega Flink Connectors](https://github.com/pravega/flink-connectors) for their usage and appropriate scenarios.
+
+## Overview
+
+* Pravega
+  > Pravega is an open-source distributed storage service implementing Streams. It offers Stream as the main primitive for the foundation of reliable storage systems: a high-performance, durable, elastic, and unlimited append-only byte stream with strict ordering and consistency.
+* PyFlink
+  > PyFlink is a Python API for Apache Flink that allows you to build scalable batch and streaming workloads, such as real-time data processing pipelines, large-scale exploratory data analysis, Machine Learning (ML) pipelines, and ETL processes.
+* Pravega Flink Connectors
+  > The connectors can be used to build end-to-end stream processing pipelines that use Pravega as the stream storage and message bus, and Apache Flink for computation over the streams.
+
+**TL;DR** With the help of the connectors, your streaming workload can safely rely on Pravega as the streaming storage which provides **end-to-end exactly-once processing pipelines** and **seamless integration with Flink's checkpoints and savepoints mechanism** with the help of connectors.
+
+This Python API of connectors provides both **`PyFlink Table API`** and **`PyFlink DataStream API`**. We will cover them respectively at [Table API](#Table-API) and [DataStream API](#DataStream-API).
+
+## Pre-requisites
+
+To get everything ready, all the following conditions should meet.
+
+1. Pravega running. See [here](http://pravega.io/docs/latest/getting-started/) for instructions.
+2. Python and its packages installed. See [PyFlink setup](https://ci.apache.org/projects/flink/flink-docs-stable/docs/dev/python/installation/).
+3. Latest Pravega Flink connectors at [the release page](https://github.com/pravega/flink-connectors/releases).
+4. Apache Flink running.
+
+> If you wish to use Anaconda instead, replace `pip` with `conda` in the steps above.
+
+## Technical Details
+
+We postpone the actual tutorials here is because understanding the underlying `PyFlink` mechanism is crucial for using connectors' Python API.
+
+🚨 **Python wrapper** is the key for this section and keeps it in mind all the time.
+
+Everything you see in the Python API is a wrapper that points to an actual Java object in the JVM. So basically, the Python API does nothing but simply calls the corresponding Java API for you.
+
+If you wish to have other unimplemented things such as a particular stream cut or event router, you could refer to `DefaultCredentials` implementation in the Python API. (For `interface` implementation, see [Implementing Java interfaces from Python (callback)](https://www.py4j.org/advanced_topics.html#implementing-java-interfaces-from-python-callback))
+
+Consider a simple Java class (`DefaultCredentials`):
+
+```java
+package io.pravega.shared.security.auth;
+
+// omit imports
+
+public class DefaultCredentials implements Credentials {
+    private final String token;
+
+    public DefaultCredentials(@NonNull String password, @NonNull String userName) {
+        String decoded = userName + ":" + password;
+        this.token = Base64.getEncoder().encodeToString(decoded.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // omit other members and methods
+}
+```
+
+To use this in Python, simply do the following:
+
+```python
+from py4j.java_gateway import JavaObject
+from pyflink.java_gateway import get_gateway
+
+username, password = 'admin', '1111_aaaa'
+
+# create the java object
+j_default_credentials: JavaObject = get_gateway() \
+    .jvm.io.pravega.shared.security.auth \
+    .DefaultCredentials(username, password)
+
+# and when you want to use this
+j_pravega_config: JavaObject = get_gateway() \
+            .jvm.io.pravega.connectors.flink \
+            .PravegaConfig.fromDefaults() \
+            .withCredentials(j_default_credentials)
+```
+
+🚨 The magic here is that you could call any java method with matching parameters. If the parameter is a primitive type like `Integer` and `String`, you could simply pass the corresponding Python type like `int` and `str`. For derived types like `DefaultCredentials`, calling the constructor and pass the corresponding `JavaObject` is sufficient.
+
+## Table API
+
+✈ Table API is suitable for pure SQL use. See [Flink Pravega Table API samples for Python](https://github.com/pravega/pravega-samples/blob/dev/scenarios/pravega-flink-connector-sql-samples/python.md) for more details.
+
+## DataStream API
+
+DataStream programs in Flink are regular programs that implement transformations on data streams (e.g., filtering, updating state, defining windows, aggregating). The data streams are initially created from various sources (e.g., message queues, socket streams, files). Results are returned via sinks, which may for example write the data to files, or to standard output (for example the command line terminal).
+
+We follow the official [Intro to the Python DataStream API](https://ci.apache.org/projects/flink/flink-docs-master/docs/dev/python/datastream/intro_to_datastream_api/) documentation. For topics we do not cover below such as the Table & SQL conversion-related things, feel free to visit in need.
+
+### Common Structure of Python DataStream API Programs with Pravega Flink Connectors
+
+```python
+from pyflink.common import WatermarkStrategy, Row
+from pyflink.common.serialization import SimpleStringSchema
+from pyflink.common.typeinfo import Types
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.datastream.connectors import NumberSequenceSource
+from pyflink.datastream.functions import RuntimeContext, MapFunction
+from pyflink.datastream.state import ValueStateDescriptor
+
+from pravega_config import PravegaConfig
+from pravega_writer import FlinkPravegaWriter
+
+CONTROLLER_URI = 'tcp://localhost:9090'
+SCOPE = 'scope'
+STREAM = 'stream'
+
+
+class MyMapFunction(MapFunction):
+    def open(self, runtime_context: RuntimeContext):
+        state_desc = ValueStateDescriptor('cnt', Types.PICKLED_BYTE_ARRAY())
+        self.cnt_state = runtime_context.get_state(state_desc)
+
+    def map(self, value):
+        cnt = self.cnt_state.value()
+        if cnt is None or cnt < 2:
+            self.cnt_state.update(1 if cnt is None else cnt + 1)
+            return value[0], value[1] + 1
+        else:
+            return value[0], value[1]
+
+
+def state_access_demo():
+    # 1. create a StreamExecutionEnvironment
+    env = StreamExecutionEnvironment.get_execution_environment()
+
+    # 2. create source DataStream
+    seq_num_source = NumberSequenceSource(1, 10000)
+    ds = env.from_source(
+        source=seq_num_source,
+        watermark_strategy=WatermarkStrategy.for_monotonous_timestamps(),
+        source_name='seq_num_source',
+        type_info=Types.LONG())
+
+    # 3. define the execution logic
+    ds = ds.map(lambda a: Row(a % 4, 1), output_type=Types.ROW([Types.LONG(), Types.LONG()])) \
+           .key_by(lambda a: a[0]) \
+           .map(MyMapFunction(), output_type=Types.ROW([Types.LONG(), Types.LONG()]))
+
+    # 4. create sink and emit result to sink
+    pravega_config = PravegaConfig(uri=CONTROLLER_URI, scope=SCOPE)
+    pravega_writer = FlinkPravegaWriter(
+        stream=STREAM,
+        pravega_config=pravega_config,
+        serialization_schema=SimpleStringSchema())
+    ds.add_sink(pravega_writer)
+
+    # 5. execute the job
+    env.execute('state_access_demo')
+
+
+if __name__ == '__main__':
+    state_access_demo()
+
+```
+
+### Create a StreamExecutionEnvironment
+
+The StreamExecutionEnvironment is a central concept of the DataStream API program. The following code example shows how to create a StreamExecutionEnvironment:
+
+```python
+from pyflink.datastream import StreamExecutionEnvironment
+
+env = StreamExecutionEnvironment.get_execution_environment()
+
+# for EXACTLY_ONCE writer mode, checkpoint is required
+env.enable_checkpointing(1000, CheckpointingMode.EXACTLY_ONCE)
+
+# add connectors jar if the job is not submitted with --jarfile options
+env.add_jars("file:///path/to/pravega-connectors-flink.jar")
+```
+
+### Create a DataStream
+
+The DataStream API gets its name from the special DataStream class that is used to represent a collection of data in a Flink program. You can think of them as immutable collections of data that can contain duplicates. This data can either be finite or unbounded, the API that you use to work on them is the same.
+
+A `DataStream` is similar to a regular Python `Collection` in terms of usage but is quite different in some key ways. They are immutable, meaning that once they are created you cannot add or remove elements. You can also not simply inspect the elements inside but only work on them using the `DataStream` API operations, which are also called transformations.
+
+You can create an initial `DataStream` by adding a source in a Flink program. Then you can derive new streams from this and combine them by using API methods such as `map`, `filter`, and so on.
+
+#### Create using Pravega Flink Connectors
+
+`Datastream` can be created from a list object like [this official example](https://ci.apache.org/projects/flink/flink-docs-stable/docs/dev/python/datastream/intro_to_datastream_api/#create-from-a-list-object). But here we will focus on how to read from external source such as Pravega. This is achieved by using DataStream connectors with method `add_source` as following:
+
+```python
+from pyflink.common.serialization import SimpleStringSchema
+from pyflink.datastream import StreamExecutionEnvironment
+
+from pravega_config import PravegaConfig
+from pravega_reader import FlinkPravegaReader
+
+CONTROLLER_URI = 'tcp://localhost:9090'
+SCOPE = 'scope'
+STREAM = 'stream'
+
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_parallelism(1)
+env.add_jars("file:///path/to/pravega-connectors-flink.jar")
+
+pravega_config = PravegaConfig('tcp://localhost:9090', SCOPE)
+pravega_reader = FlinkPravegaReader(
+    stream=STREAM,
+    pravega_config=pravega_config,
+    deserialization_schema=SimpleStringSchema(),
+    enable_metrics=False)
+
+ds = env.add_source(pravega_reader)
+ds.print()
+
+env.execute("reader_example")
+```
+
+*Unified Source through `from_source` is not supported yet.*
+
+### DataStream Transformations
+
+Operators transform one or more `DataStream` into a new `DataStream`. Programs can combine multiple transformations into sophisticated dataflow topologies.
+
+The following example shows a simple example about how to convert a `DataStream` into another `DataStream` using map transformation:
+
+```python
+ds = ds.map(lambda a: a + 1)
+```
+
+See [operators](https://ci.apache.org/projects/flink/flink-docs-stable/docs/dev/python/datastream/operators/overview/) for an overview of the available `DataStream` transformations.
+
+### Emit Results
+
+#### Print
+
+You can call the `print` method to print the data of a `DataStream` to the standard output:
+
+```python
+ds.print()
+```
+
+#### Collect results to client
+
+You can call the `execute_and_collect` method to collect the data of a `DataStream` to client:
+
+```python
+with ds.execute_and_collect() as results:
+    for result in results:
+        print(result)
+```
+
+#### Emit results to Pravega via Pravega Flink Connectors
+
+You can call the `add_sink` method to emit the data of a `DataStream` to a DataStream sink connector:
+
+```python
+from pyflink.common.serialization import SimpleStringSchema
+from pyflink.common.typeinfo import Types
+from pyflink.datastream import StreamExecutionEnvironment, CheckpointingMode
+
+from pravega_config import PravegaConfig
+from pravega_writer import FlinkPravegaWriter, PravegaWriterMode
+
+CONTROLLER_URI = 'tcp://localhost:9090'
+SCOPE = 'scope'
+STREAM = 'stream'
+
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_parallelism(1)
+env.enable_checkpointing(1000, CheckpointingMode.EXACTLY_ONCE)
+env.add_jars("file:///path/to/pravega-connectors-flink.jar")
+
+pravega_config = PravegaConfig(uri=CONTROLLER_URI, scope=SCOPE)
+pravega_writer = FlinkPravegaWriter(stream=STREAM,
+                                    pravega_config=pravega_config,
+                                    writer_mode=PravegaWriterMode.ATLEAST_ONCE,
+                                    serialization_schema=SimpleStringSchema())
+
+ds = env.from_collection(collection=['a', 'bb', 'ccc'],
+                         type_info=Types.STRING())
+ds.add_sink(pravega_writer)
+
+env.execute("writer_example")
+```
+
+*Unified Sink through `sink_to` is not supported yet.*
+
+### Submit Job
+
+Finally, you should call the `StreamExecutionEnvironment.execute` method to submit the DataStream API job for execution:
+
+```python
+env.execute()
+```
+
+Or submit via `flink` command line interface:
+
+```bash
+flink run --python ./pravega_examples.py --pyFiles ./pravega_config.py --pyFiles ./pravega_writer.py --jarfile /path/to/pravega-connectors-flink.jar
+```

--- a/documentation/src/mkdocs.yml
+++ b/documentation/src/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - 'Streaming': 'streaming.md'
       - 'Batch': 'batch.md'
       - 'Table API': 'table-api.md'
+      - 'Python Datastream API': 'python.md'
   - Metrics: 'metrics.md'
   - Configurations: 'configurations.md'
   - Serialization: 'serialization.md'

--- a/src/main/python/pravega_config.py
+++ b/src/main/python/pravega_config.py
@@ -1,11 +1,17 @@
 """
-Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright Pravega Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 """
 
 from typing import Optional

--- a/src/main/python/pravega_config.py
+++ b/src/main/python/pravega_config.py
@@ -1,0 +1,101 @@
+"""
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+"""
+
+from typing import Optional
+
+from py4j.java_gateway import JavaObject
+from pyflink.java_gateway import get_gateway
+
+
+class Stream():
+    """A stream can be thought of as an unbounded sequence of events."""
+
+    _j_stream: JavaObject
+
+    def __init__(self, scope: str, stream: str) -> None:
+        """Helper utility to create a Stream object.
+
+        Args:
+            scope (str): Scope of the stream.
+            stream (str): Name of the stream.
+        """
+        self._j_stream = get_gateway().jvm.io.pravega.client.stream.Stream.of(
+            scope, stream)
+
+
+class DefaultCredentials():
+    """Pravega authentication credential"""
+
+    _j_default_credentials: JavaObject
+
+    def __init__(self, username: str, password: str) -> None:
+        """Creates a new object containing a token that is valid for
+        Basic authentication scheme. The object encapsulates a token
+        value comprising of a Base64 encoded value of "<username>:<password>".
+
+        Args:
+            username (str): The username.
+            password (str): The password.
+        """
+        self._j_default_credentials = get_gateway(
+        ).jvm.io.pravega.shared.security.auth.DefaultCredentials(
+            username, password)
+
+
+class PravegaConfig():
+    """The Pravega client configuration."""
+
+    _j_pravega_config: JavaObject
+
+    def __init__(self,
+                 uri: str,
+                 scope: str,
+                 schema_registry_uri: Optional[str] = None,
+                 trust_store: Optional[str] = None,
+                 default_scope: Optional[str] = None,
+                 credentials: Optional[DefaultCredentials] = None,
+                 validate_hostname: bool = True) -> None:
+        """Create a pravega client configuration.
+
+        Args:
+            uri (str):
+                The Pravega controller RPC URI.
+            scope (str):
+                The self-defined Pravega scope.
+            schema_registry_uri (Optional[str], optional):
+                The Pravega schema registry URI. Defaults to None.
+            trust_store (Optional[str], optional):
+                The truststore value. Defaults to None.
+            default_scope (Optional[str], optional):
+                The default Pravega scope, to resolve unqualified stream names
+                and to support reader groups. Defaults to None.
+            credentials (Optional[DefaultCredentials], optional):
+                The Pravega credentials to use. Defaults to None.
+            validate_hostname (bool, optional):
+                TLS hostname validation. Defaults to True.
+        """
+        j_uri = get_gateway().jvm.java.net.URI.create(uri)
+        self._j_pravega_config = get_gateway().jvm \
+            .io.pravega.connectors.flink \
+            .PravegaConfig.fromDefaults() \
+            .withControllerURI(j_uri) \
+            .withDefaultScope(scope) \
+            .withHostnameValidation(validate_hostname)
+
+        if schema_registry_uri:
+            j_schema_registry_uri = get_gateway().jvm.java.net.URI.create(
+                schema_registry_uri)
+            self._j_pravega_config.withSchemaRegistryURI(j_schema_registry_uri)
+        if trust_store: self._j_pravega_config.withTrustStore(trust_store)
+        if default_scope:
+            self._j_pravega_config.withDefaultScope(default_scope)
+        if credentials:
+            self._j_pravega_config.withCredentials(
+                credentials._j_default_credentials)

--- a/src/main/python/pravega_reader.py
+++ b/src/main/python/pravega_reader.py
@@ -1,11 +1,17 @@
 """
-Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright Pravega Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 """
 
 from datetime import timedelta

--- a/src/main/python/pravega_reader.py
+++ b/src/main/python/pravega_reader.py
@@ -1,0 +1,165 @@
+"""
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+"""
+
+from datetime import timedelta
+from typing import Optional, Union
+
+from py4j.java_gateway import JavaObject
+from pyflink.common.serialization import DeserializationSchema
+from pyflink.datastream.functions import SourceFunction
+from pyflink.java_gateway import get_gateway
+
+from pravega_config import PravegaConfig, Stream
+
+
+class StreamCut():
+    """
+    A set of segment/offset pairs for a single stream that represent
+    a consistent position in the stream.
+
+    NOTE: Only UNBOUNDED stream cut is supported, users who wish to use
+    a particular stream cut need to wrap the `StreamCutImpl` manually.
+    """
+
+    _j_stream_cut: JavaObject
+
+    UNBOUNDED: 'StreamCut'
+
+    def __init__(self, _j_stream_cut: JavaObject) -> None:
+        """Add stream cut implementation to the internal java object.
+
+        Args:
+            _j_stream_cut (JavaObject): Unbounded stream cut implementation
+                for now, but also could be `StreamCutImpl` if added manually.
+        """
+        self._j_stream_cut = _j_stream_cut
+
+
+StreamCut.UNBOUNDED = StreamCut(
+    get_gateway().jvm.io.pravega.client.stream.StreamCut.UNBOUNDED)
+
+
+class FlinkPravegaReader(SourceFunction):
+    """Flink source implementation for reading from Pravega storage."""
+    def __init__(self,
+                 stream: Union[str, Stream],
+                 pravega_config: PravegaConfig,
+                 deserialization_schema: DeserializationSchema,
+                 start_stream_cut: StreamCut = StreamCut.UNBOUNDED,
+                 end_stream_cut: StreamCut = StreamCut.UNBOUNDED,
+                 enable_metrics: bool = True,
+                 uid: Optional[str] = None,
+                 reader_group_scope: Optional[str] = None,
+                 reader_group_name: Optional[str] = None,
+                 reader_group_refresh_time: timedelta = timedelta(seconds=3),
+                 checkpoint_initiate_timeout: timedelta = timedelta(seconds=5),
+                 event_read_timeout: timedelta = timedelta(seconds=1),
+                 max_outstanding_checkpoint_request: int = 3) -> None:
+        """Build the `FlinkPravegaReader` with options.
+
+        NOTE: `withDeserializationSchemaFromRegistry` and
+        `withTimestampAssigner` are not supported yet.
+
+        Args:
+            stream (Union[str, Stream]):
+                Add a stream to be read by the source,
+                from the earliest available position in the stream.
+
+            pravega_config (PravegaConfig):
+                Set the Pravega client configuration, which includes
+                connection info, security info, and a default scope.
+
+            deserialization_schema (DeserializationSchema):
+                Sets the deserialization schema.
+
+            start_stream_cut (StreamCut, optional):
+                Read from the given start position in the stream.
+                Defaults to StreamCut.UNBOUNDED.
+
+            end_stream_cut (StreamCut, optional):
+                Read from the given start position in the stream
+                to the given end position. Defaults to StreamCut.UNBOUNDED.
+
+            enable_metrics (bool, optional):
+                Pravega reader metrics. Defaults to True.
+
+            uid (Optional[str], optional):
+                Configures the source uid to identify the checkpoint state
+                of this source. Defaults to generated random uid on java side.
+
+            reader_group_scope (Optional[str], optional):
+                Configures the reader group scope for synchronization
+                purposes. Defaults to `pravega_config.default_scope`.
+
+            reader_group_name (Optional[str], optional):
+                Configures the reader group name.
+                Defaults to auto-generated name on java side.
+
+            reader_group_refresh_time (timedelta, optional):
+                Sets the group refresh time.
+                Defaults to 3 seconds on java side.
+
+            checkpoint_initiate_timeout (timedelta, optional):
+                Sets the timeout for initiating a checkpoint in Pravega.
+                Defaults to 5 seconds on java side.
+
+            event_read_timeout (timedelta, optional):
+                Sets the timeout for the call to read events from Pravega.
+                After the timeout expires (without an event being returned),
+                another call will be made. Defaults to 1 second on java side.
+
+            max_outstanding_checkpoint_request (int, optional):
+                Configures the maximum outstanding checkpoint requests to
+                Pravega. Defaults to 3 on java side.
+
+                Upon requesting more checkpoints than the specified maximum,
+                (say a checkpoint request times out on the
+                ReaderCheckpointHook but Pravega is still working on it),
+                this configurations allows Pravega to limit any further
+                checkpoint request being made to the ReaderGroup.
+
+                This configuration is particularly relevant when multiple
+                checkpoint requests need to be honored (e.g., frequent
+                savepoint requests being triggered concurrently).
+        """
+        j_builder: JavaObject = get_gateway().jvm \
+            .io.pravega.connectors.flink.FlinkPravegaReader.builder()
+
+        # AbstractReaderBuilder
+        j_builder.forStream(
+            stream if type(stream) == str else stream._j_stream,
+            start_stream_cut._j_stream_cut, end_stream_cut._j_stream_cut)
+        j_builder.withPravegaConfig(pravega_config._j_pravega_config)
+        j_builder.enableMetrics(enable_metrics)
+
+        # FlinkPravegaReader.Builder
+        j_builder.withDeserializationSchema(
+            deserialization_schema._j_deserialization_schema)
+
+        # AbstractStreamingReaderBuilder
+        if uid: j_builder.uid(uid)
+        if reader_group_scope:
+            j_builder.withReaderGroupScope(reader_group_scope)
+        if reader_group_name:
+            j_builder.withReaderGroupName(reader_group_name)
+        JFlinkTimeCls = get_gateway().jvm.org.apache.flink.api.common.time.Time
+        j_builder.withReaderGroupRefreshTime(
+            JFlinkTimeCls.seconds(reader_group_refresh_time.seconds))
+        j_builder.withCheckpointInitiateTimeout(
+            JFlinkTimeCls.seconds(checkpoint_initiate_timeout.seconds))
+        j_builder.withEventReadTimeout(
+            JFlinkTimeCls.seconds(event_read_timeout.seconds))
+        j_builder.withMaxOutstandingCheckpointRequest(
+            max_outstanding_checkpoint_request)
+
+        j_flink_pravega_reader: JavaObject = j_builder.build()
+
+        super(FlinkPravegaReader,
+              self).__init__(source_func=j_flink_pravega_reader)

--- a/src/main/python/pravega_reader.py
+++ b/src/main/python/pravega_reader.py
@@ -15,6 +15,7 @@ from py4j.java_gateway import JavaObject
 from pyflink.common.serialization import DeserializationSchema
 from pyflink.datastream.functions import SourceFunction
 from pyflink.java_gateway import get_gateway
+from pyflink.util.java_utils import to_j_flink_time
 
 from pravega_config import PravegaConfig, Stream
 
@@ -179,13 +180,11 @@ class FlinkPravegaReader(SourceFunction):
             j_builder.withReaderGroupScope(reader_group_scope)
         if reader_group_name:
             j_builder.withReaderGroupName(reader_group_name)
-        JFlinkTimeCls = get_gateway().jvm.org.apache.flink.api.common.time.Time
         j_builder.withReaderGroupRefreshTime(
-            JFlinkTimeCls.seconds(reader_group_refresh_time.seconds))
+            to_j_flink_time(reader_group_refresh_time))
         j_builder.withCheckpointInitiateTimeout(
-            JFlinkTimeCls.seconds(checkpoint_initiate_timeout.seconds))
-        j_builder.withEventReadTimeout(
-            JFlinkTimeCls.seconds(event_read_timeout.seconds))
+            to_j_flink_time(checkpoint_initiate_timeout))
+        j_builder.withEventReadTimeout(to_j_flink_time(event_read_timeout))
         j_builder.withMaxOutstandingCheckpointRequest(
             max_outstanding_checkpoint_request)
 

--- a/src/main/python/pravega_reader.py
+++ b/src/main/python/pravega_reader.py
@@ -100,8 +100,7 @@ class FlinkPravegaReader(SourceFunction):
 
         Args:
             stream (Union[str, Stream]):
-                Add a stream to be read by the source,
-                from the earliest available position in the stream.
+                The stream to be read from.
 
             pravega_config (PravegaConfig):
                 Set the Pravega client configuration, which includes
@@ -115,15 +114,15 @@ class FlinkPravegaReader(SourceFunction):
                 Defaults to StreamCut.UNBOUNDED.
 
             end_stream_cut (StreamCut, optional):
-                Read from the given start position in the stream
-                to the given end position. Defaults to StreamCut.UNBOUNDED.
+                Read to the given end position in the stream.
+                Defaults to StreamCut.UNBOUNDED.
 
             enable_metrics (bool, optional):
                 Pravega reader metrics. Defaults to True.
 
             uid (Optional[str], optional):
                 Configures the source uid to identify the checkpoint state
-                of this source. Defaults to generated random uid on java side.
+                of this source. Defaults to random generated uid on java side.
 
             reader_group_scope (Optional[str], optional):
                 Configures the reader group scope for synchronization

--- a/src/main/python/pravega_writer.py
+++ b/src/main/python/pravega_writer.py
@@ -1,0 +1,120 @@
+"""
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+"""
+
+from enum import Enum
+from datetime import timedelta
+from typing import Union
+
+from py4j.java_gateway import JavaObject
+from pyflink.common.serialization import SerializationSchema
+from pyflink.datastream.functions import SinkFunction
+from pyflink.java_gateway import get_gateway
+
+from pravega_config import PravegaConfig, Stream
+
+
+class PravegaWriterMode(Enum):
+    """
+    The supported modes of operation for flink's pravega writer.
+
+    :data:`BEST_EFFORT`:
+    Any write failures will be ignored hence there could be data loss.
+
+    :data:`ATLEAST_ONCE`:
+    The writer will guarantee that all events are persisted in pravega.
+    There could be duplicate events written though.
+
+    :data:`EXACTLY_ONCE`:
+    The writer will guarantee that all events are persisted in pravega exactly once.
+
+    """
+    BEST_EFFORT = 0
+    ATLEAST_ONCE = 1
+    EXACTLY_ONCE = 2
+
+    def _to_j_pravega_writer_mode(self) -> JavaObject:
+        j_pravega_writer_mode = get_gateway().jvm \
+            .io.pravega.connectors.flink.PravegaWriterMode
+        return getattr(j_pravega_writer_mode, self.name)
+
+
+class FlinkPravegaWriter(SinkFunction):
+    """Flink sink implementation for writing into pravega storage."""
+
+    def __init__(
+        self,
+        stream: Union[str, Stream],
+        pravega_config: PravegaConfig,
+        serialization_schema: SerializationSchema,
+        enable_metrics: bool = True,
+        writer_mode: PravegaWriterMode = PravegaWriterMode.ATLEAST_ONCE,
+        enable_watermark: bool = False,
+        txn_leader_renewal_period: timedelta = timedelta(seconds=30)
+    ) -> None:
+        """Build the `FlinkPravegaWriter` with options.
+
+        NOTE: `withEventRouter` is not supported yet.
+
+        Args:
+            stream (Union[str, Stream]):
+                Add a stream to be written to by the writer.
+
+            pravega_config (PravegaConfig):
+                Set the Pravega client configuration, which includes
+                connection info, security info, and a default scope.
+
+            serialization_schema (SerializationSchema):
+                Sets the serialization schema.
+
+            enable_metrics (bool, optional):
+                Pravega reader metrics. Defaults to True.
+
+            writer_mode (PravegaWriterMode, optional):
+                Sets the writer mode to provide at-least-once or exactly-once
+                guarantees. Defaults to PravegaWriterMode.ATLEAST_ONCE.
+
+            enable_watermark (bool, optional):
+                Enable watermark. Defaults to False.
+
+            txn_leader_renewal_period (timedelta, optional):
+                Sets the transaction lease renewal period.
+                Defaults to 30 seconds on java side.
+
+                When the writer mode is set to EXACTLY_ONCE, transactions are
+                used to persist events to the Pravega stream. The transaction
+                interval corresponds to the Flink checkpoint interval.
+                Throughout that interval, the transaction is kept alive with a
+                lease that is periodically renewed. This configuration setting
+                sets the lease renewal period.
+        """
+        j_builder: JavaObject = get_gateway().jvm \
+            .io.pravega.connectors.flink.FlinkPravegaWriter.builder()
+
+        # AbstractWriterBuilder
+        j_builder.forStream(
+            stream if type(stream) == str else stream._j_stream)
+        j_builder.withPravegaConfig(pravega_config._j_pravega_config)
+        j_builder.enableMetrics(enable_metrics)
+
+        # AbstractStreamingWriterBuilder
+        j_builder.withWriterMode(writer_mode._to_j_pravega_writer_mode())
+        j_builder.enableWatermark(enable_watermark)
+        JFlinkTimeCls = get_gateway().jvm.org.apache.flink.api.common.time.Time
+        j_builder.withTxnLeaseRenewalPeriod(
+            JFlinkTimeCls.seconds(txn_leader_renewal_period.seconds))
+
+        # FlinkPravegaWriter.Builder
+        j_builder.withSerializationSchema(
+            serialization_schema._j_serialization_schema)
+
+        j_flink_pravega_writer: JavaObject = j_builder.build()
+
+        super(FlinkPravegaWriter,
+              self).__init__(sink_func=j_flink_pravega_writer)

--- a/src/main/python/pravega_writer.py
+++ b/src/main/python/pravega_writer.py
@@ -1,11 +1,17 @@
 """
-Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright Pravega Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 """
 
 from enum import Enum

--- a/src/main/python/pravega_writer.py
+++ b/src/main/python/pravega_writer.py
@@ -56,7 +56,7 @@ class FlinkPravegaWriter(SinkFunction):
         enable_metrics: bool = True,
         writer_mode: PravegaWriterMode = PravegaWriterMode.ATLEAST_ONCE,
         enable_watermark: bool = False,
-        txn_leader_renewal_period: timedelta = timedelta(seconds=30)
+        txn_lease_renewal_period: timedelta = timedelta(seconds=30)
     ) -> None:
         """Build the `FlinkPravegaWriter` with options.
 
@@ -74,7 +74,7 @@ class FlinkPravegaWriter(SinkFunction):
                 Sets the serialization schema.
 
             enable_metrics (bool, optional):
-                Pravega reader metrics. Defaults to True.
+                Pravega writer metrics. Defaults to True.
 
             writer_mode (PravegaWriterMode, optional):
                 Sets the writer mode to provide at-least-once or exactly-once
@@ -83,7 +83,7 @@ class FlinkPravegaWriter(SinkFunction):
             enable_watermark (bool, optional):
                 Enable watermark. Defaults to False.
 
-            txn_leader_renewal_period (timedelta, optional):
+            txn_lease_renewal_period (timedelta, optional):
                 Sets the transaction lease renewal period.
                 Defaults to 30 seconds on java side.
 
@@ -107,7 +107,7 @@ class FlinkPravegaWriter(SinkFunction):
         j_builder.withWriterMode(writer_mode._to_j_pravega_writer_mode())
         j_builder.enableWatermark(enable_watermark)
         j_builder.withTxnLeaseRenewalPeriod(
-            to_j_flink_time(txn_leader_renewal_period))
+            to_j_flink_time(txn_lease_renewal_period))
 
         # FlinkPravegaWriter.Builder
         j_builder.withSerializationSchema(


### PR DESCRIPTION
Signed-off-by: thekingofcity <3353040+thekingofcity@users.noreply.github.com>

**Change log description**
Python is a popular developing language and we can already use the Python Table API to perform Pravega read and write. However, sometimes SQL is not enough, many users still want to use the Python datastream API.
In order to support multiple Flink version, we plan to have a suggested implementation for a python wrapper and users can include in the python project.

**Purpose of the change**
Fixes #571 

**What the code does**
Add Python API and related docs for the connectors.

**How to verify it**
*Common Structure of Python DataStream API Programs with Pravega Flink Connectors* mentioned in the doc should work.