### PR TITLE
[issue-577] Add support for security in PravegaCatalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ group = "io.pravega"
 version = getProjectVersion()
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url "https://maven.pkg.github.com/pravega/pravega"

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/PravegaCatalog.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/PravegaCatalog.java
@@ -75,6 +75,16 @@ public class PravegaCatalog extends AbstractCatalog {
     private Map<String, String> properties;
     private SerializationFormat serializationFormat;
 
+    /**
+     * Creates a new Pravega Catalog instance.
+     *
+     * @param catalogName             The Pravega catalog name.
+     * @param defaultDatabase         The default database for Pravega catalog, which is mapped to Pravega scope here.
+     * @param properties              The options read from configuration.
+     * @param clientConfig            The Pravega client configuration.
+     * @param config                  The Schema Registry client configuration.
+     * @param serializationFormat     The serialization format used for serialization.
+     */
     public PravegaCatalog(String catalogName, String defaultDatabase, Map<String, String> properties,
                           ClientConfig clientConfig, SchemaRegistryClientConfig config,
                           SerializationFormat serializationFormat) {

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
@@ -107,6 +107,7 @@ public class PravegaCatalogFactory implements CatalogFactory {
         });
 
         PravegaConfig pravegaConfig = PravegaOptionsUtil.getPravegaConfig(configOptions)
+                .withDefaultScope(configOptions.get(PravegaCatalogFactoryOptions.DEFAULT_DATABASE))
                 .withSchemaRegistryURI(URI.create(configOptions.get(PravegaCatalogFactoryOptions.SCHEMA_REGISTRY_URI)));
         SchemaRegistryClientConfig schemaRegistryClientConfig = SchemaRegistryUtils.getSchemaRegistryClientConfig(pravegaConfig);
         return new PravegaCatalog(

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
@@ -1,16 +1,24 @@
 /**
  * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.connectors.flink.table.catalog.pravega.factories;
 
+import io.pravega.connectors.flink.PravegaConfig;
+import io.pravega.connectors.flink.dynamic.table.FlinkPravegaDynamicTableFactory;
+import io.pravega.connectors.flink.dynamic.table.PravegaOptions;
+import io.pravega.connectors.flink.dynamic.table.PravegaOptionsUtil;
+import io.pravega.connectors.flink.formats.registry.PravegaRegistryFormatFactory;
+import io.pravega.connectors.flink.formats.registry.PravegaRegistryOptions;
 import io.pravega.connectors.flink.table.catalog.pravega.PravegaCatalog;
+import io.pravega.schemaregistry.client.SchemaRegistryClientConfig;
+import io.pravega.schemaregistry.contract.data.SerializationFormat;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DelegatingConfiguration;
@@ -21,7 +29,10 @@ import org.apache.flink.table.factories.FactoryUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /** Factory for {@link PravegaCatalog}. */
@@ -55,6 +66,10 @@ public class PravegaCatalogFactory implements CatalogFactory {
         options.add(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_MODE);
         options.add(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_LITERAL);
         options.add(PravegaCatalogFactoryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+        options.add(PravegaCatalogFactoryOptions.SECURITY_AUTH_TYPE);
+        options.add(PravegaCatalogFactoryOptions.SECURITY_AUTH_TOKEN);
+        options.add(PravegaCatalogFactoryOptions.SECURITY_VALIDATE_HOSTNAME);
+        options.add(PravegaCatalogFactoryOptions.SECURITY_TRUST_STORE);
         return options;
     }
 
@@ -71,17 +86,48 @@ public class PravegaCatalogFactory implements CatalogFactory {
         // options that separate "json" prefix and the configuration
         ReadableConfig delegatingConfiguration = new DelegatingConfiguration((Configuration) configOptions, JSON_PREFIX);
 
+        Map<String, String> properties = new HashMap<>();
+        properties.put(FactoryUtil.CONNECTOR.key(), FlinkPravegaDynamicTableFactory.IDENTIFIER);
+        properties.put(PravegaOptions.CONTROLLER_URI.key(), configOptions.get(PravegaCatalogFactoryOptions.CONTROLLER_URI));
+        properties.put(FactoryUtil.FORMAT.key(), PravegaRegistryFormatFactory.IDENTIFIER);
+        properties.put(
+                String.format(
+                        "%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.URI.key()),
+                configOptions.get(PravegaCatalogFactoryOptions.SCHEMA_REGISTRY_URI));
+        properties.put(String.format("%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FORMAT.key()),
+                configOptions.get(PravegaCatalogFactoryOptions.SERIALIZATION_FORMAT));
+
+        // put json related options into properties
+        properties.put(String.format("%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FAIL_ON_MISSING_FIELD.key()),
+                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_FAIL_ON_MISSING_FIELD).toString());
+        properties.put(String.format("%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.IGNORE_PARSE_ERRORS.key()),
+                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_IGNORE_PARSE_ERRORS).toString());
+        properties.put(String.format("%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.TIMESTAMP_FORMAT.key()),
+                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_TIMESTAMP_FORMAT));
+        properties.put(String.format("%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.MAP_NULL_KEY_MODE.key()),
+                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_MODE));
+        properties.put(String.format("%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.MAP_NULL_KEY_LITERAL.key()),
+                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_LITERAL));
+        properties.put(String.format("%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.key()),
+                delegatingConfiguration.get(PravegaCatalogFactoryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER).toString());
+
+        PravegaConfig pravegaConfig = PravegaOptionsUtil.getPravegaConfig(configOptions);
+        SchemaRegistryClientConfig schemaRegistryClientConfig = SchemaRegistryClientConfig.builder().
+                schemaRegistryUri(URI.create(configOptions.get(PravegaCatalogFactoryOptions.SCHEMA_REGISTRY_URI))).build();
         return new PravegaCatalog(
                 context.getName(),
                 configOptions.get(PravegaCatalogFactoryOptions.DEFAULT_DATABASE),
-                configOptions.get(PravegaCatalogFactoryOptions.CONTROLLER_URI),
-                configOptions.get(PravegaCatalogFactoryOptions.SCHEMA_REGISTRY_URI),
-                configOptions.get(PravegaCatalogFactoryOptions.SERIALIZATION_FORMAT),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_FAIL_ON_MISSING_FIELD).toString(),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_IGNORE_PARSE_ERRORS).toString(),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_TIMESTAMP_FORMAT),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_MODE),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_LITERAL),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER).toString());
+                properties,
+                pravegaConfig.getClientConfig(),
+                schemaRegistryClientConfig,
+                SerializationFormat.valueOf(configOptions.get(PravegaCatalogFactoryOptions.SERIALIZATION_FORMAT)));
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
@@ -59,17 +59,17 @@ public class PravegaCatalogFactory implements CatalogFactory {
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
         final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(PravegaCatalogFactoryOptions.SECURITY_AUTH_TYPE);
+        options.add(PravegaCatalogFactoryOptions.SECURITY_AUTH_TOKEN);
+        options.add(PravegaCatalogFactoryOptions.SECURITY_VALIDATE_HOSTNAME);
+        options.add(PravegaCatalogFactoryOptions.SECURITY_TRUST_STORE);
         options.add(PravegaCatalogFactoryOptions.SERIALIZATION_FORMAT);
         options.add(PravegaCatalogFactoryOptions.JSON_FAIL_ON_MISSING_FIELD);
         options.add(PravegaCatalogFactoryOptions.JSON_IGNORE_PARSE_ERRORS);
         options.add(PravegaCatalogFactoryOptions.JSON_TIMESTAMP_FORMAT);
         options.add(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_MODE);
         options.add(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_LITERAL);
-        options.add(PravegaCatalogFactoryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER);
-        options.add(PravegaCatalogFactoryOptions.SECURITY_AUTH_TYPE);
-        options.add(PravegaCatalogFactoryOptions.SECURITY_AUTH_TOKEN);
-        options.add(PravegaCatalogFactoryOptions.SECURITY_VALIDATE_HOSTNAME);
-        options.add(PravegaCatalogFactoryOptions.SECURITY_TRUST_STORE);
+        options.add(PravegaCatalogFactoryOptions.JSON_ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         return options;
     }
 
@@ -84,7 +84,7 @@ public class PravegaCatalogFactory implements CatalogFactory {
         // all catalog options
         ReadableConfig configOptions = helper.getOptions();
         // options that separate "json" prefix and the configuration
-        ReadableConfig delegatingConfiguration = new DelegatingConfiguration((Configuration) configOptions, JSON_PREFIX);
+        DelegatingConfiguration delegatingConfiguration = new DelegatingConfiguration((Configuration) configOptions, JSON_PREFIX);
 
         Map<String, String> properties = new HashMap<>();
         properties.put(FactoryUtil.CONNECTOR.key(), FlinkPravegaDynamicTableFactory.IDENTIFIER);
@@ -100,24 +100,10 @@ public class PravegaCatalogFactory implements CatalogFactory {
                 configOptions.get(PravegaCatalogFactoryOptions.SERIALIZATION_FORMAT));
 
         // put json related options into properties
-        properties.put(String.format("%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FAIL_ON_MISSING_FIELD.key()),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_FAIL_ON_MISSING_FIELD).toString());
-        properties.put(String.format("%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.IGNORE_PARSE_ERRORS.key()),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_IGNORE_PARSE_ERRORS).toString());
-        properties.put(String.format("%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.TIMESTAMP_FORMAT.key()),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_TIMESTAMP_FORMAT));
-        properties.put(String.format("%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.MAP_NULL_KEY_MODE.key()),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_MODE));
-        properties.put(String.format("%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.MAP_NULL_KEY_LITERAL.key()),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.JSON_MAP_NULL_KEY_LITERAL));
-        properties.put(String.format("%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.key()),
-                delegatingConfiguration.get(PravegaCatalogFactoryOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER).toString());
+        Map<String, String> jsonProperties = delegatingConfiguration.toMap();
+        jsonProperties.forEach((key, value) -> {
+            properties.put(String.format("%s.%s", PravegaRegistryFormatFactory.IDENTIFIER, key), value);
+        });
 
         PravegaConfig pravegaConfig = PravegaOptionsUtil.getPravegaConfig(configOptions);
         SchemaRegistryClientConfig schemaRegistryClientConfig = SchemaRegistryClientConfig.builder().

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
@@ -17,9 +17,6 @@ import io.pravega.connectors.flink.dynamic.table.PravegaOptionsUtil;
 import io.pravega.connectors.flink.formats.registry.PravegaRegistryFormatFactory;
 import io.pravega.connectors.flink.formats.registry.PravegaRegistryOptions;
 import io.pravega.connectors.flink.table.catalog.pravega.PravegaCatalog;
-import io.pravega.connectors.flink.util.SchemaRegistryUtils;
-import io.pravega.schemaregistry.client.SchemaRegistryClientConfig;
-import io.pravega.schemaregistry.contract.data.SerializationFormat;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DelegatingConfiguration;
@@ -117,9 +114,8 @@ public class PravegaCatalogFactory implements CatalogFactory {
 
         // put json related options into properties
         Map<String, String> jsonProperties = delegatingConfiguration.toMap();
-        jsonProperties.forEach((key, value) -> {
-            properties.put(String.format("%s.%s", PravegaRegistryFormatFactory.IDENTIFIER, key), value);
-        });
+        jsonProperties.forEach((key, value) ->
+                properties.put(String.format("%s.%s", PravegaRegistryFormatFactory.IDENTIFIER, key), value));
         return properties;
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactory.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.connectors.flink.table.catalog.pravega.factories;
@@ -17,6 +17,7 @@ import io.pravega.connectors.flink.dynamic.table.PravegaOptionsUtil;
 import io.pravega.connectors.flink.formats.registry.PravegaRegistryFormatFactory;
 import io.pravega.connectors.flink.formats.registry.PravegaRegistryOptions;
 import io.pravega.connectors.flink.table.catalog.pravega.PravegaCatalog;
+import io.pravega.connectors.flink.util.SchemaRegistryUtils;
 import io.pravega.schemaregistry.client.SchemaRegistryClientConfig;
 import io.pravega.schemaregistry.contract.data.SerializationFormat;
 import org.apache.flink.configuration.ConfigOption;
@@ -105,9 +106,9 @@ public class PravegaCatalogFactory implements CatalogFactory {
             properties.put(String.format("%s.%s", PravegaRegistryFormatFactory.IDENTIFIER, key), value);
         });
 
-        PravegaConfig pravegaConfig = PravegaOptionsUtil.getPravegaConfig(configOptions);
-        SchemaRegistryClientConfig schemaRegistryClientConfig = SchemaRegistryClientConfig.builder().
-                schemaRegistryUri(URI.create(configOptions.get(PravegaCatalogFactoryOptions.SCHEMA_REGISTRY_URI))).build();
+        PravegaConfig pravegaConfig = PravegaOptionsUtil.getPravegaConfig(configOptions)
+                .withSchemaRegistryURI(URI.create(configOptions.get(PravegaCatalogFactoryOptions.SCHEMA_REGISTRY_URI)));
+        SchemaRegistryClientConfig schemaRegistryClientConfig = SchemaRegistryUtils.getSchemaRegistryClientConfig(pravegaConfig);
         return new PravegaCatalog(
                 context.getName(),
                 configOptions.get(PravegaCatalogFactoryOptions.DEFAULT_DATABASE),

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactoryOptions.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactoryOptions.java
@@ -35,19 +35,19 @@ public class PravegaCatalogFactoryOptions {
             ConfigOptions.key("serialization.format").stringType().defaultValue("Avro")
                     .withDescription("Optional serialization format for Pravega catalog. Valid enumerations are ['Avro'(default), 'Json']");
 
+    // Pravega security options
+    public static final ConfigOption<String> SECURITY_AUTH_TYPE = PravegaOptions.SECURITY_AUTH_TYPE;
+    public static final ConfigOption<String> SECURITY_AUTH_TOKEN = PravegaOptions.SECURITY_AUTH_TOKEN;
+    public static final ConfigOption<Boolean> SECURITY_VALIDATE_HOSTNAME = PravegaOptions.SECURITY_VALIDATE_HOSTNAME;
+    public static final ConfigOption<String> SECURITY_TRUST_STORE = PravegaOptions.SECURITY_TRUST_STORE;
+
     // Json related options
     public static final ConfigOption<Boolean> JSON_FAIL_ON_MISSING_FIELD = JsonOptions.FAIL_ON_MISSING_FIELD;
     public static final ConfigOption<Boolean> JSON_IGNORE_PARSE_ERRORS = JsonOptions.IGNORE_PARSE_ERRORS;
     public static final ConfigOption<String> JSON_TIMESTAMP_FORMAT = JsonOptions.TIMESTAMP_FORMAT;
     public static final ConfigOption<String> JSON_MAP_NULL_KEY_MODE = JsonOptions.MAP_NULL_KEY_MODE;
     public static final ConfigOption<String> JSON_MAP_NULL_KEY_LITERAL = JsonOptions.MAP_NULL_KEY_LITERAL;
-    public static final ConfigOption<Boolean> ENCODE_DECIMAL_AS_PLAIN_NUMBER = JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
-
-    // Pravega security options
-    public static final ConfigOption<String> SECURITY_AUTH_TYPE = PravegaOptions.SECURITY_AUTH_TYPE;
-    public static final ConfigOption<String> SECURITY_AUTH_TOKEN = PravegaOptions.SECURITY_AUTH_TOKEN;
-    public static final ConfigOption<Boolean> SECURITY_VALIDATE_HOSTNAME = PravegaOptions.SECURITY_VALIDATE_HOSTNAME;
-    public static final ConfigOption<String> SECURITY_TRUST_STORE = PravegaOptions.SECURITY_TRUST_STORE;
+    public static final ConfigOption<Boolean> JSON_ENCODE_DECIMAL_AS_PLAIN_NUMBER = JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 
     private PravegaCatalogFactoryOptions() {}
 }

--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactoryOptions.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/factories/PravegaCatalogFactoryOptions.java
@@ -43,5 +43,11 @@ public class PravegaCatalogFactoryOptions {
     public static final ConfigOption<String> JSON_MAP_NULL_KEY_LITERAL = JsonOptions.MAP_NULL_KEY_LITERAL;
     public static final ConfigOption<Boolean> ENCODE_DECIMAL_AS_PLAIN_NUMBER = JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 
+    // Pravega security options
+    public static final ConfigOption<String> SECURITY_AUTH_TYPE = PravegaOptions.SECURITY_AUTH_TYPE;
+    public static final ConfigOption<String> SECURITY_AUTH_TOKEN = PravegaOptions.SECURITY_AUTH_TOKEN;
+    public static final ConfigOption<Boolean> SECURITY_VALIDATE_HOSTNAME = PravegaOptions.SECURITY_VALIDATE_HOSTNAME;
+    public static final ConfigOption<String> SECURITY_TRUST_STORE = PravegaOptions.SECURITY_TRUST_STORE;
+
     private PravegaCatalogFactoryOptions() {}
 }

--- a/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
@@ -11,6 +11,10 @@
 package io.pravega.connectors.flink;
 
 import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.connectors.flink.dynamic.table.FlinkPravegaDynamicTableFactory;
+import io.pravega.connectors.flink.dynamic.table.PravegaOptions;
+import io.pravega.connectors.flink.formats.registry.PravegaRegistryFormatFactory;
+import io.pravega.connectors.flink.formats.registry.PravegaRegistryOptions;
 import io.pravega.connectors.flink.table.catalog.pravega.PravegaCatalog;
 import io.pravega.connectors.flink.table.catalog.pravega.factories.PravegaCatalogFactoryOptions;
 import io.pravega.connectors.flink.utils.SchemaRegistryUtils;
@@ -285,10 +289,21 @@ public class PravegaCatalogITCase {
     private static void init() throws Exception {
         SCHEMA_REGISTRY_UTILS.registerSchema(TEST_STREAM, AvroSchema.of(TEST_SCHEMA), SerializationFormat.Avro);
         SETUP_UTILS.createTestStream(TEST_STREAM, 3);
-        CATALOG = new PravegaCatalog(TEST_CATALOG_NAME, SETUP_UTILS.getScope(),
-                SETUP_UTILS.getControllerUri().toString(), SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString(),
-                "Avro", "false", "false",
-                "SQL", "FAIL", "null", "false");
+        Map<String, String> properties = new HashMap<>();
+        properties.put(FactoryUtil.CONNECTOR.key(), FlinkPravegaDynamicTableFactory.IDENTIFIER);
+        properties.put(PravegaOptions.CONTROLLER_URI.key(), SETUP_UTILS.getControllerUri().toString());
+        properties.put(FactoryUtil.FORMAT.key(), PravegaRegistryFormatFactory.IDENTIFIER);
+        properties.put(
+                String.format(
+                        "%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.URI.key()),
+                SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString());
+        properties.put(String.format("%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FORMAT.key()),
+                "Avro");
+        CATALOG = new PravegaCatalog(TEST_CATALOG_NAME, SETUP_UTILS.getScope(), properties, SETUP_UTILS.getClientConfig(),
+                SchemaRegistryClientConfig.builder().schemaRegistryUri(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()).build(),
+                SerializationFormat.Avro);
         EventStreamWriter<Object> writer = SCHEMA_REGISTRY_UTILS.getWriter(TEST_STREAM, AvroSchema.of(TEST_SCHEMA), SerializationFormat.Avro);
         writer.writeEvent(EVENT).join();
         writer.close();

--- a/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
@@ -292,9 +292,11 @@ public class PravegaCatalogITCase {
         properties.put("pravega-registry.uri",
                 SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString());
         properties.put("pravega-registry.format", "Avro");
-        CATALOG = new PravegaCatalog(TEST_CATALOG_NAME, SETUP_UTILS.getScope(), properties, SETUP_UTILS.getClientConfig(),
-                SchemaRegistryClientConfig.builder().schemaRegistryUri(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()).build(),
-                SerializationFormat.Avro);
+        CATALOG = new PravegaCatalog(TEST_CATALOG_NAME, SETUP_UTILS.getScope(), properties,
+                SETUP_UTILS.getPravegaConfig()
+                        .withDefaultScope(SETUP_UTILS.getScope())
+                        .withSchemaRegistryURI(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()),
+                "Avro");
         EventStreamWriter<Object> writer = SCHEMA_REGISTRY_UTILS.getWriter(TEST_STREAM, AvroSchema.of(TEST_SCHEMA), SerializationFormat.Avro);
         writer.writeEvent(EVENT).join();
         writer.close();

--- a/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
@@ -11,10 +11,6 @@
 package io.pravega.connectors.flink;
 
 import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.connectors.flink.dynamic.table.FlinkPravegaDynamicTableFactory;
-import io.pravega.connectors.flink.dynamic.table.PravegaOptions;
-import io.pravega.connectors.flink.formats.registry.PravegaRegistryFormatFactory;
-import io.pravega.connectors.flink.formats.registry.PravegaRegistryOptions;
 import io.pravega.connectors.flink.table.catalog.pravega.PravegaCatalog;
 import io.pravega.connectors.flink.table.catalog.pravega.factories.PravegaCatalogFactoryOptions;
 import io.pravega.connectors.flink.utils.SchemaRegistryUtils;
@@ -290,17 +286,12 @@ public class PravegaCatalogITCase {
         SCHEMA_REGISTRY_UTILS.registerSchema(TEST_STREAM, AvroSchema.of(TEST_SCHEMA), SerializationFormat.Avro);
         SETUP_UTILS.createTestStream(TEST_STREAM, 3);
         Map<String, String> properties = new HashMap<>();
-        properties.put(FactoryUtil.CONNECTOR.key(), FlinkPravegaDynamicTableFactory.IDENTIFIER);
-        properties.put(PravegaOptions.CONTROLLER_URI.key(), SETUP_UTILS.getControllerUri().toString());
-        properties.put(FactoryUtil.FORMAT.key(), PravegaRegistryFormatFactory.IDENTIFIER);
-        properties.put(
-                String.format(
-                        "%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.URI.key()),
+        properties.put("connector", "pravega");
+        properties.put("controller-uri", SETUP_UTILS.getControllerUri().toString());
+        properties.put("format", "pravega-registry");
+        properties.put("pravega-registry.uri",
                 SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString());
-        properties.put(String.format("%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FORMAT.key()),
-                "Avro");
+        properties.put("pravega-registry.format", "Avro");
         CATALOG = new PravegaCatalog(TEST_CATALOG_NAME, SETUP_UTILS.getScope(), properties, SETUP_UTILS.getClientConfig(),
                 SchemaRegistryClientConfig.builder().schemaRegistryUri(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()).build(),
                 SerializationFormat.Avro);

--- a/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
@@ -133,9 +133,11 @@ public class PravegaRegistrySeDeITCase {
         properties.put("pravega-registry.uri",
                 SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString());
         properties.put("pravega-registry.format", "Avro");
-        final PravegaCatalog avroCatalog = new PravegaCatalog(TEST_AVRO_CATALOG_NAME, SETUP_UTILS.getScope(), properties, SETUP_UTILS.getClientConfig(),
-                SchemaRegistryClientConfig.builder().schemaRegistryUri(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()).build(),
-                SerializationFormat.Avro);
+        final PravegaCatalog avroCatalog = new PravegaCatalog(TEST_AVRO_CATALOG_NAME, SETUP_UTILS.getScope(), properties,
+                SETUP_UTILS.getPravegaConfig()
+                        .withDefaultScope(SETUP_UTILS.getScope())
+                        .withSchemaRegistryURI(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()),
+                "Avro");
         initAvro();
         avroCatalog.open();
 
@@ -226,9 +228,11 @@ public class PravegaRegistrySeDeITCase {
         properties.put("pravega-registry.uri",
                 SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString());
         properties.put("pravega-registry.format", "Json");
-        final PravegaCatalog jsonCatalog = new PravegaCatalog(TEST_JSON_CATALOG_NAME, SETUP_UTILS.getScope(), properties, SETUP_UTILS.getClientConfig(),
-                SchemaRegistryClientConfig.builder().schemaRegistryUri(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()).build(),
-                SerializationFormat.Json);
+        final PravegaCatalog jsonCatalog = new PravegaCatalog(TEST_JSON_CATALOG_NAME, SETUP_UTILS.getScope(), properties,
+                SETUP_UTILS.getPravegaConfig()
+                        .withDefaultScope(SETUP_UTILS.getScope())
+                        .withSchemaRegistryURI(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()),
+                "Json");
         initJson();
         jsonCatalog.open();
 

--- a/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
@@ -11,6 +11,8 @@
 package io.pravega.connectors.flink.formats.registry;
 
 import io.pravega.client.stream.Serializer;
+import io.pravega.connectors.flink.dynamic.table.FlinkPravegaDynamicTableFactory;
+import io.pravega.connectors.flink.dynamic.table.PravegaOptions;
 import io.pravega.connectors.flink.table.catalog.pravega.PravegaCatalog;
 import io.pravega.connectors.flink.table.catalog.pravega.util.PravegaSchemaUtils;
 import io.pravega.connectors.flink.utils.SchemaRegistryUtils;
@@ -35,6 +37,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Arra
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
@@ -126,10 +129,21 @@ public class PravegaRegistrySeDeITCase {
 
     @Test
     public void testAvroSerializeDeserialize() throws Exception {
-        final PravegaCatalog avroCatalog = new PravegaCatalog(TEST_AVRO_CATALOG_NAME, SETUP_UTILS.getScope(),
-                SETUP_UTILS.getControllerUri().toString(), SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString(),
-                "Avro", "false", "false",
-                "SQL", "FAIL", "null", "false");
+        Map<String, String> properties = new HashMap<>();
+        properties.put(FactoryUtil.CONNECTOR.key(), FlinkPravegaDynamicTableFactory.IDENTIFIER);
+        properties.put(PravegaOptions.CONTROLLER_URI.key(), SETUP_UTILS.getControllerUri().toString());
+        properties.put(FactoryUtil.FORMAT.key(), PravegaRegistryFormatFactory.IDENTIFIER);
+        properties.put(
+                String.format(
+                        "%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.URI.key()),
+                SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString());
+        properties.put(String.format("%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FORMAT.key()),
+                "Avro");
+        final PravegaCatalog avroCatalog = new PravegaCatalog(TEST_AVRO_CATALOG_NAME, SETUP_UTILS.getScope(), properties, SETUP_UTILS.getClientConfig(),
+                SchemaRegistryClientConfig.builder().schemaRegistryUri(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()).build(),
+                SerializationFormat.Avro);
         initAvro();
         avroCatalog.open();
 
@@ -213,10 +227,21 @@ public class PravegaRegistrySeDeITCase {
 
     @Test
     public void testJsonDeserialize() throws Exception {
-        final PravegaCatalog jsonCatalog = new PravegaCatalog(TEST_JSON_CATALOG_NAME, SETUP_UTILS.getScope(),
-                SETUP_UTILS.getControllerUri().toString(), SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString(),
-                "Json", "false", "false",
-                "SQL", "FAIL", "null", "false");
+        Map<String, String> properties = new HashMap<>();
+        properties.put(FactoryUtil.CONNECTOR.key(), FlinkPravegaDynamicTableFactory.IDENTIFIER);
+        properties.put(PravegaOptions.CONTROLLER_URI.key(), SETUP_UTILS.getControllerUri().toString());
+        properties.put(FactoryUtil.FORMAT.key(), PravegaRegistryFormatFactory.IDENTIFIER);
+        properties.put(
+                String.format(
+                        "%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.URI.key()),
+                SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString());
+        properties.put(String.format("%s.%s",
+                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FORMAT.key()),
+                "Json");
+        final PravegaCatalog jsonCatalog = new PravegaCatalog(TEST_JSON_CATALOG_NAME, SETUP_UTILS.getScope(), properties, SETUP_UTILS.getClientConfig(),
+                SchemaRegistryClientConfig.builder().schemaRegistryUri(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()).build(),
+                SerializationFormat.Json);
         initJson();
         jsonCatalog.open();
 

--- a/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
@@ -11,8 +11,6 @@
 package io.pravega.connectors.flink.formats.registry;
 
 import io.pravega.client.stream.Serializer;
-import io.pravega.connectors.flink.dynamic.table.FlinkPravegaDynamicTableFactory;
-import io.pravega.connectors.flink.dynamic.table.PravegaOptions;
 import io.pravega.connectors.flink.table.catalog.pravega.PravegaCatalog;
 import io.pravega.connectors.flink.table.catalog.pravega.util.PravegaSchemaUtils;
 import io.pravega.connectors.flink.utils.SchemaRegistryUtils;
@@ -37,7 +35,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Arra
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
-import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
@@ -130,17 +127,12 @@ public class PravegaRegistrySeDeITCase {
     @Test
     public void testAvroSerializeDeserialize() throws Exception {
         Map<String, String> properties = new HashMap<>();
-        properties.put(FactoryUtil.CONNECTOR.key(), FlinkPravegaDynamicTableFactory.IDENTIFIER);
-        properties.put(PravegaOptions.CONTROLLER_URI.key(), SETUP_UTILS.getControllerUri().toString());
-        properties.put(FactoryUtil.FORMAT.key(), PravegaRegistryFormatFactory.IDENTIFIER);
-        properties.put(
-                String.format(
-                        "%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.URI.key()),
+        properties.put("connector", "pravega");
+        properties.put("controller-uri", SETUP_UTILS.getControllerUri().toString());
+        properties.put("format", "pravega-registry");
+        properties.put("pravega-registry.uri",
                 SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString());
-        properties.put(String.format("%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FORMAT.key()),
-                "Avro");
+        properties.put("pravega-registry.format", "Avro");
         final PravegaCatalog avroCatalog = new PravegaCatalog(TEST_AVRO_CATALOG_NAME, SETUP_UTILS.getScope(), properties, SETUP_UTILS.getClientConfig(),
                 SchemaRegistryClientConfig.builder().schemaRegistryUri(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()).build(),
                 SerializationFormat.Avro);
@@ -228,17 +220,12 @@ public class PravegaRegistrySeDeITCase {
     @Test
     public void testJsonDeserialize() throws Exception {
         Map<String, String> properties = new HashMap<>();
-        properties.put(FactoryUtil.CONNECTOR.key(), FlinkPravegaDynamicTableFactory.IDENTIFIER);
-        properties.put(PravegaOptions.CONTROLLER_URI.key(), SETUP_UTILS.getControllerUri().toString());
-        properties.put(FactoryUtil.FORMAT.key(), PravegaRegistryFormatFactory.IDENTIFIER);
-        properties.put(
-                String.format(
-                        "%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.URI.key()),
+        properties.put("connector", "pravega");
+        properties.put("controller-uri", SETUP_UTILS.getControllerUri().toString());
+        properties.put("format", "pravega-registry");
+        properties.put("pravega-registry.uri",
                 SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri().toString());
-        properties.put(String.format("%s.%s",
-                        PravegaRegistryFormatFactory.IDENTIFIER, PravegaRegistryOptions.FORMAT.key()),
-                "Json");
+        properties.put("pravega-registry.format", "Json");
         final PravegaCatalog jsonCatalog = new PravegaCatalog(TEST_JSON_CATALOG_NAME, SETUP_UTILS.getScope(), properties, SETUP_UTILS.getClientConfig(),
                 SchemaRegistryClientConfig.builder().schemaRegistryUri(SCHEMA_REGISTRY_UTILS.getSchemaRegistryUri()).build(),
                 SerializationFormat.Json);

--- a/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
@@ -71,7 +71,7 @@ public final class SetupUtils {
 
     // Set to true to enable TLS
     @Setter
-    private boolean enableTls = false;
+    private boolean enableTls = true;
 
     @Getter
     @Setter


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
- use `ClientConfig` to create `StreamManager` instead of `ControllerURI` when creating `PravegaCatalog` in order to set security configs which can be read from `ClientConfig`
- enable `enableTls`

**Purpose of the change**
Fix #577 

**What the code does**
Add Pravega security options in Catalog factory options so that we can create `StreamManager` upon `ClientConfig` that contains security configs.
Set `enableTls` to true for integration tests.

**How to verify it**
`./gradlew clean build` passed
