### PR TITLE
[Issue-581] Make `mkdocsBuild` great again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ buildscript {
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${bintrayPluginVersion}"
         classpath group: 'org.hidetake', name: 'gradle-ssh-plugin', version: gradleSshPluginVersion
         classpath "ru.vyarus:gradle-mkdocs-plugin:${gradleMkdocsPluginVersion}"
+        classpath "org.ajoberstar.grgit:grgit-gradle:${gradleGitPluginVersion}"
         classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:${spotbugsPluginVersion}"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,13 +19,13 @@ shadowGradlePlugin=7.0.0
 slf4jApiVersion=1.7.25
 junitVersion=4.12
 mockitoVersion=1.10.19
-gradleGitPluginVersion=1.7.2
+gradleGitPluginVersion=4.1.0
 spotbugsVersion=4.0.6
 spotbugsAnnotationsVersion=4.0.6
 spotbugsPluginVersion=4.4.4
 jcipAnnotationsVersion=1.0
 gradleSshPluginVersion=2.9.0
-gradleMkdocsPluginVersion=1.1.0
+gradleMkdocsPluginVersion=2.1.1
 jacocoVersion=0.8.2
 hamcrestVersion=2.2
 


### PR DESCRIPTION
Signed-off-by: thekingofcity <3353040+thekingofcity@users.noreply.github.com>

**Change log description**
The current `mkdocsBuild` job will fail after #490 upgraded the Gradle to 7.
Update the plugins to make `mkdocsBuild` great again.

**Purpose of the change**
Fixes #581 

**What the code does**
Update `build.gradle` and `gradle.properties`.

**How to verify it**
`.\gradlew clean mkdocsBuild` will generate the desired docs.
