### PR TITLE
[issue-595] Allow insecure HTTP connection

### DIFF
--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -47,6 +47,7 @@ publishing {
             else {
                 maven {
                     url = publishUrl
+                    allowInsecureProtocol = true
                     // Only configure credentials if they are provided (allows publishing to the filesystem)
                     if (project.hasProperty("publishUsername") && project.hasProperty("publishPassword")) {
                         credentials {


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
-  Allow communication with a repository over an insecure HTTP connection.

**Purpose of the change**
Fix #595 

**What the code does**
- Set `allowInsecureProtocol` to `true` in `maven.gradle`

**How to verify it**
`./gradlew clean build` passed
