### PR TITLE
[issue-597] allow insecure http connection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ repositories {
     if (findProperty("repositoryUrl")) {
         maven {
             url findProperty("repositoryUrl")
+            allowInsecureProtocol = true
         }
     }
     else {


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
- Allow communication with a repository over an insecure HTTP connection.

**Purpose of the change**
Fix #597 

**What the code does**
- Set `allowInsecureProtocol` to true in `build.gradle`

**How to verify it**
`./gradlew clean build` passed
