### PR TITLE
[Issue-619] Mismatch in ThrottledIntegerGeneratingSource

### DIFF
--- a/src/test/java/io/pravega/connectors/flink/utils/ThrottledIntegerGeneratingSource.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/ThrottledIntegerGeneratingSource.java
@@ -140,7 +140,7 @@ public class ThrottledIntegerGeneratingSource
         }
 
         synchronized (this.blocker) {
-            while (this.lastCheckpointConfirmed <= lastCheckpoint + 4) {
+            while (this.lastCheckpointConfirmed <= lastCheckpoint + 2) {
                 this.blocker.wait();
             }
         }


### PR DESCRIPTION
Signed-off-by: thekingofcity <3353040+thekingofcity@users.noreply.github.com>

**Change log description**
There is a mismatch in ThrottledIntegerGeneratingSource between code and comment.

**Purpose of the change**
Fix #619 

**What the code does**
Change the code to `while (this.lastCheckpointConfirmed <= lastCheckpoint + 2) {`.

**How to verify it**
`.\gradlew clean build` should pass.
