### PR TITLE
[Issue-620] Multiple use of the nested FlinkSerializer

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaOutputFormat.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaOutputFormat.java
@@ -22,6 +22,7 @@ import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
+import io.pravega.connectors.flink.serialization.FlinkSerializer;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.io.RichOutputFormat;
@@ -108,7 +109,7 @@ public class FlinkPravegaOutputFormat<T> extends RichOutputFormat<T> {
 
     @Override
     public void open(int taskNumber, int numTasks) throws IOException {
-        Serializer<T> eventSerializer = new FlinkPravegaWriter.FlinkSerializer<>(serializationSchema);
+        Serializer<T> eventSerializer = new FlinkSerializer<>(serializationSchema);
         EventWriterConfig writerConfig = EventWriterConfig.builder().build();
         clientFactory = createClientFactory(scope, clientConfig);
         pravegaWriter = clientFactory.createEventWriter(stream, eventSerializer, writerConfig);

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaWriter.java
@@ -27,6 +27,7 @@ import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.TransactionalEventStreamWriter;
 import io.pravega.client.stream.TxnFailedException;
+import io.pravega.connectors.flink.serialization.FlinkSerializer;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
@@ -48,7 +49,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -524,26 +524,6 @@ public class FlinkPravegaWriter<T>
     // ------------------------------------------------------------------------
     //  serializer
     // ------------------------------------------------------------------------
-
-    @VisibleForTesting
-    static final class FlinkSerializer<T> implements Serializer<T> {
-
-        private final SerializationSchema<T> serializationSchema;
-
-        FlinkSerializer(SerializationSchema<T> serializationSchema) {
-            this.serializationSchema = serializationSchema;
-        }
-
-        @Override
-        public ByteBuffer serialize(T value) {
-            return ByteBuffer.wrap(serializationSchema.serialize(value));
-        }
-
-        @Override
-        public T deserialize(ByteBuffer serializedValue) {
-            throw new IllegalStateException("deserialize() called within a serializer");
-        }
-    }
 
     // ------------------------------------------------------------------------
     //  State and context classes and serializers

--- a/src/main/java/io/pravega/connectors/flink/serialization/FlinkSerializer.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/FlinkSerializer.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.connectors.flink.serialization;
+
+import io.pravega.client.stream.Serializer;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+
+import java.nio.ByteBuffer;
+
+@VisibleForTesting
+public final class FlinkSerializer<T> implements Serializer<T> {
+
+    private final SerializationSchema<T> serializationSchema;
+
+    public FlinkSerializer(SerializationSchema<T> serializationSchema) {
+        this.serializationSchema = serializationSchema;
+    }
+
+    @Override
+    public ByteBuffer serialize(T value) {
+        return ByteBuffer.wrap(serializationSchema.serialize(value));
+    }
+
+    @Override
+    public T deserialize(ByteBuffer serializedValue) {
+        throw new IllegalStateException("deserialize() called within a serializer");
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaWriterTest.java
@@ -25,6 +25,7 @@ import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.TransactionalEventStreamWriter;
 import io.pravega.client.stream.TxnFailedException;
 import io.pravega.common.function.RunnableWithException;
+import io.pravega.connectors.flink.serialization.FlinkSerializer;
 import io.pravega.connectors.flink.utils.DirectExecutorService;
 import io.pravega.connectors.flink.utils.IntegerSerializationSchema;
 import io.pravega.connectors.flink.utils.StreamSinkOperatorTestHarness;
@@ -145,7 +146,7 @@ public class FlinkPravegaWriterTest {
     @Test
     public void testFlinkSerializer() {
         IntegerSerializationSchema schema = new IntegerSerializationSchema();
-        FlinkPravegaWriter.FlinkSerializer<Integer> serializer = new FlinkPravegaWriter.FlinkSerializer<>(schema);
+        FlinkSerializer<Integer> serializer = new FlinkSerializer<>(schema);
         Integer val = 42;
         Assert.assertEquals(ByteBuffer.wrap(schema.serialize(val)), serializer.serialize(val));
         try {


### PR DESCRIPTION
Signed-off-by: thekingofcity <3353040+thekingofcity@users.noreply.github.com>

**Change log description**
The `FlinkSerializer` from `FlinkPravegaWriter` is also needed in the new unified sink API #460.

**Purpose of the change**
Fix #620

**What the code does**
Instead of nesting it in the `FlinkPravegaWriter`, move it to the `serialization` package.

**How to verify it**
`.\gradlew clean build` should pass.
