### PR TITLE
[Issue-627] Move `CheckpointSerializer` to serialization package

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -21,6 +21,7 @@ import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReaderGroupNotFoundException;
+import io.pravega.connectors.flink.serialization.CheckpointSerializer;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;

--- a/src/main/java/io/pravega/connectors/flink/serialization/CheckpointSerializer.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/CheckpointSerializer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.pravega.connectors.flink;
+package io.pravega.connectors.flink.serialization;
 
 import io.pravega.client.stream.Checkpoint;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
  * <p>The serializer currently uses {@link java.io.Serializable Java Serialization} to
  * serialize the checkpoint objects.
  */
-class CheckpointSerializer implements SimpleVersionedSerializer<Checkpoint> {
+public class CheckpointSerializer implements SimpleVersionedSerializer<Checkpoint> {
 
     private static final int VERSION = 2;
 

--- a/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
+++ b/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
@@ -25,6 +25,7 @@ import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.CheckpointImpl;
 import io.pravega.client.stream.impl.StreamCutImpl;
+import io.pravega.connectors.flink.serialization.CheckpointSerializer;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.util.concurrent.Executors;
 import org.junit.Test;


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Move `CheckpointSerializer` into package `serialization`.

**Purpose of the change**
Fix #627 

**What the code does**
- Move `CheckpointSerializer` to package `serialization` and change its visibility
- Change all the affected import path

**How to verify it**
`./gradlew clean build` passed
`FlinkPravegaReaderSavepointITCase` test passed