### PR TITLE
fix npe when close pravega batch client factory in batch mode

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
@@ -105,7 +105,9 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
     @Override
     public void closeInputFormat() throws IOException {
         // closing the client factory also closes the batch client connection
-        this.batchClientFactory.close();
+        if (this.batchClientFactory != null) {
+            this.batchClientFactory.close();
+        }
     }
 
     @Override
@@ -175,7 +177,9 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
 
     @Override
     public void close() throws IOException {
-        this.segmentIterator.close();
+        if (this.segmentIterator != null) {
+            this.segmentIterator.close();
+        }
     }
 
     /**


### PR DESCRIPTION
**Purpose of the change**
Fix npe when close pravega batch client factory in batch mode

**What the code does**
Add the null condition to avoid calling methods with null values

**How to verify it**
In the scenario of batch reading Pravega, when the task ends, an NPE exception will be reported