### PR TITLE
fix npe when close pravega batch client factory in batch mode

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
@@ -105,7 +105,9 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
     @Override
     public void closeInputFormat() throws IOException {
         // closing the client factory also closes the batch client connection
-        this.batchClientFactory.close();
+        if (this.batchClientFactory != null) {
+            this.batchClientFactory.close();
+        }
     }
 
     @Override
@@ -175,7 +177,9 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
 
     @Override
     public void close() throws IOException {
-        this.segmentIterator.close();
+        if (this.segmentIterator != null) {
+            this.segmentIterator.close();
+        }
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: chenlei677 <chenlei677@jd.com>

**Change log description**
Fix npe when close pravega batch client factory in batch mode
#635 

**Purpose of the change**
When the batch task is executed, avoid the null pointer exception

**What the code does**
Add the null condition to avoid calling methods with null values


**How to verify it**
In the scenario of batch reading Pravega, when the task ends, an NPE exception will be reported
