### PR TITLE
[issue-635] Fix null pointer when closing pravega batch client factory

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaInputFormat.java
@@ -106,7 +106,9 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
     @Override
     public void closeInputFormat() throws IOException {
         // closing the client factory also closes the batch client connection
-        this.batchClientFactory.close();
+        if (this.batchClientFactory != null) {
+            this.batchClientFactory.close();
+        }
     }
 
     @Override
@@ -176,7 +178,9 @@ public class FlinkPravegaInputFormat<T> extends RichInputFormat<T, PravegaInputS
 
     @Override
     public void close() throws IOException {
-        this.segmentIterator.close();
+        if (this.segmentIterator != null) {
+            this.segmentIterator.close();
+        }
     }
 
     /**


### PR DESCRIPTION
Change log description
Fix npe when close pravega batch client factory in batch mode
#635 

Purpose of the change
When the batch task is executed, avoid the null pointer exception

What the code does
Add the null condition to avoid calling methods with null values

How to verify it
In the scenario of batch reading Pravega, when the task ends, an NPE exception will be reported