### PR TITLE
[Issue-649] Upgrade pravega to the latest 0.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,8 +86,22 @@ configurations.all {
 
 configurations {
     testImplementation.extendsFrom(compileOnly)
-    testImplementation.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-    testImplementation.exclude group: 'log4j', module: 'log4j'
+    testImplementation {
+        exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+        exclude group: 'log4j', module: 'log4j'
+        resolutionStrategy {
+            force group: 'io.netty', name: 'netty-common', version: nettyVersion
+            force group: 'io.netty', name: 'netty-transport', version: nettyVersion
+            force group: 'io.netty', name: 'netty-handler', version: nettyVersion
+            force group: 'io.netty', name: 'netty-codec', version: nettyVersion
+            force group: 'io.netty', name: 'netty-codec-http', version: nettyVersion
+            force group: 'io.netty', name: 'netty-codec-http2', version: nettyVersion
+            force group: 'io.netty', name: 'netty-codec-socks', version: nettyVersion
+            force group: 'io.netty', name: 'netty-handler-proxy', version: nettyVersion
+            force group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion
+            force group: 'io.netty', name: 'netty-tcnative-boringssl-static', version: nettyVersion
+        }
+    }
 }
 
 dependencies {
@@ -112,9 +126,8 @@ dependencies {
     testImplementation (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
         exclude group:  'org.slf4j', module: 'slf4j-api'
         exclude group:  'ch.qos.logback', module: 'logback-classic'
-        exclude group:  'org.apache.zookeeper', module: 'zookeeper'
+        exclude group: 'io.netty'
     }
-    testImplementation group: 'org.apache.zookeeper', name: 'zookeeper', version: '3.5.9'
     testImplementation (group: 'io.pravega', name: 'schemaregistry-server', version: schemaRegistryVersion) {
         transitive = false
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,10 +33,12 @@ gradleSshPluginVersion=2.9.0
 gradleMkdocsPluginVersion=2.1.1
 jacocoVersion=0.8.2
 hamcrestVersion=2.2
+nettyVersion=4.1.65.Final
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.11.0-SNAPSHOT
 pravegaVersion=0.11.0-3001.0a80ee3-SNAPSHOT
+# pravegaVersion=0.11.0-3038.fc1f5c3-SNAPSHOT
 schemaRegistryVersion=0.4.0-78.f1b3eef-SNAPSHOT
 apacheCommonsVersion=3.7
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,8 +37,7 @@ nettyVersion=4.1.65.Final
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.11.0-SNAPSHOT
-pravegaVersion=0.11.0-3001.0a80ee3-SNAPSHOT
-# pravegaVersion=0.11.0-3038.fc1f5c3-SNAPSHOT
+pravegaVersion=0.11.0-3038.fc1f5c3-SNAPSHOT
 schemaRegistryVersion=0.4.0-78.f1b3eef-SNAPSHOT
 apacheCommonsVersion=3.7
 


### PR DESCRIPTION
**Change log description**
Upgrade Pravega version to 0.11

**Purpose of the change**
Fix #649 

**What the code does**
Update Pravega version to 0.11 and force `io.netty` to `4.1.65.Final` as `pravega-standalone` states it wants `4.1.68.Final` but it doesn't.

**How to verify it**
`.\gradlew clean build` passes.
