### PR TITLE
[Issue-651] Upgrade Flink to 1.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,8 +103,9 @@ dependencies {
     compileOnly group: 'org.slf4j', name: 'slf4j-api', version: slf4jApiVersion // provided by flink-runtime
     compileOnly group: 'org.apache.flink', name: 'flink-streaming-java', version: flinkVersion // provided by application
 
-    compileOnly group: 'org.apache.flink', name: 'flink-table-planner_'+flinkScalaVersion, version: flinkVersion // provided by application
+    compileOnly group: 'org.apache.flink', name: 'flink-table-planner-loader', version: flinkVersion // provided by application
     compileOnly group: 'org.apache.flink', name: 'flink-table-api-java-bridge', version: flinkVersion // provided by application
+    compileOnly group: 'org.apache.flink', name: 'flink-table-runtime', version: flinkVersion // provided by application
 
     compileOnly group: 'org.apache.flink', name: 'flink-json', version: flinkVersion
     compileOnly group: 'org.apache.flink', name: 'flink-avro', version: flinkVersion
@@ -127,7 +128,7 @@ dependencies {
     testImplementation group: 'org.apache.flink', name: 'flink-runtime', classifier: 'tests', version: flinkVersion
     testImplementation group: 'org.apache.flink', name: 'flink-table-common', classifier: 'tests', version: flinkVersion
     testImplementation group: 'org.apache.flink', name: 'flink-streaming-java', classifier: 'tests', version: flinkVersion
-    testImplementation group: 'org.apache.flink', name: 'flink-table-planner_'+flinkScalaVersion, classifier: 'tests', version: flinkVersion
+    testImplementation group: 'org.apache.flink', name: 'flink-table-planner_' + flinkScalaVersion, classifier: 'tests', version: flinkVersion
     testImplementation group: 'org.apache.flink', name: 'flink-json', version: flinkVersion
     testImplementation group: 'org.apache.flink', name: 'flink-avro', version: flinkVersion
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: hamcrestVersion

--- a/build.gradle
+++ b/build.gradle
@@ -101,10 +101,10 @@ dependencies {
     compileOnly group: 'io.pravega', name: 'schemaregistry-serializers', classifier: 'all', version: schemaRegistryVersion
 
     compileOnly group: 'org.slf4j', name: 'slf4j-api', version: slf4jApiVersion // provided by flink-runtime
-    compileOnly group: 'org.apache.flink', name: 'flink-streaming-java_'+flinkScalaVersion, version: flinkVersion // provided by application
+    compileOnly group: 'org.apache.flink', name: 'flink-streaming-java', version: flinkVersion // provided by application
 
     compileOnly group: 'org.apache.flink', name: 'flink-table-planner_'+flinkScalaVersion, version: flinkVersion // provided by application
-    compileOnly group: 'org.apache.flink', name: 'flink-table-api-java-bridge_'+flinkScalaVersion, version: flinkVersion // provided by application
+    compileOnly group: 'org.apache.flink', name: 'flink-table-api-java-bridge', version: flinkVersion // provided by application
 
     compileOnly group: 'org.apache.flink', name: 'flink-json', version: flinkVersion
     compileOnly group: 'org.apache.flink', name: 'flink-avro', version: flinkVersion
@@ -121,10 +121,12 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
     testImplementation group: 'org.apache.flink', name: 'flink-core', classifier: 'tests', version: flinkVersion
     testImplementation group: 'org.apache.flink', name: 'flink-tests', classifier: 'tests', version: flinkVersion
-    testImplementation group: 'org.apache.flink', name: 'flink-test-utils_'+flinkScalaVersion, version: flinkVersion
+    testImplementation (group: 'org.apache.flink', name: 'flink-test-utils', version: flinkVersion) {
+        exclude group:  'org.apache.zookeeper', module: 'zookeeper'
+    }
     testImplementation group: 'org.apache.flink', name: 'flink-runtime', classifier: 'tests', version: flinkVersion
     testImplementation group: 'org.apache.flink', name: 'flink-table-common', classifier: 'tests', version: flinkVersion
-    testImplementation group: 'org.apache.flink', name: 'flink-streaming-java_'+flinkScalaVersion, classifier: 'tests', version: flinkVersion
+    testImplementation group: 'org.apache.flink', name: 'flink-streaming-java', classifier: 'tests', version: flinkVersion
     testImplementation group: 'org.apache.flink', name: 'flink-table-planner_'+flinkScalaVersion, classifier: 'tests', version: flinkVersion
     testImplementation group: 'org.apache.flink', name: 'flink-json', version: flinkVersion
     testImplementation group: 'org.apache.flink', name: 'flink-avro', version: flinkVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 
 # 3rd party Versions.
 checkstyleToolVersion=7.1
-flinkVersion=1.14.0
+flinkVersion=1.15-SNAPSHOT
 flinkScalaVersion=2.12
 jacksonVersion=2.8.9
 twitterMvnRepoVersion=4.3.4-TWTTR

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -33,6 +33,7 @@ import io.pravega.connectors.flink.serialization.PravegaDeserializationSchemaWit
 import io.pravega.connectors.flink.watermark.AssignerWithTimeWindows;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.operators.ProcessingTimeService.ProcessingTimeCallback;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.common.time.Time;
@@ -48,7 +49,6 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointITCase.java
@@ -25,6 +25,7 @@ import io.pravega.connectors.flink.utils.ThrottledIntegerWriter;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.client.JobCancellationException;
@@ -122,7 +123,7 @@ public class FlinkPravegaReaderSavepointITCase extends TestLogger {
         ) {
             // the object on which we block while waiting for the checkpoint completion
             final OneShotLatch sync = new OneShotLatch();
-            NotifyingMapper.TO_CALL_ON_COMPLETION.set( sync::trigger );
+            NotifyingMapper.TO_CALL_ON_COMPLETION.set(sync::trigger);
 
             // launch the Flink program from a separate thread
             final CheckedThread flinkRunner = new CheckedThread() {
@@ -144,7 +145,11 @@ public class FlinkPravegaReaderSavepointITCase extends TestLogger {
             // since with the short timeouts we configure in these tests, Pravega Checkpoints
             // sometimes don't complete in time, we retry a bit here
             for (int attempt = 1; savepointPath == null && attempt <= 5; attempt++) {
-                savepointPath = MINI_CLUSTER.triggerSavepoint(program1.getJobID(), tmpFolder.newFolder().getAbsolutePath(), false).get();
+                savepointPath = MINI_CLUSTER.triggerSavepoint(
+                        program1.getJobID(),
+                        tmpFolder.newFolder().getAbsolutePath(),
+                        false,
+                        SavepointFormatType.CANONICAL).get();
             }
 
             assertNotNull("Failed to trigger a savepoint", savepointPath);

--- a/src/test/java/io/pravega/connectors/flink/sink/PravegaEventWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/sink/PravegaEventWriterTest.java
@@ -1,321 +1,321 @@
-/**
- * Copyright Pravega Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package io.pravega.connectors.flink.sink;
-
-import io.pravega.client.ClientConfig;
-import io.pravega.client.EventStreamClientFactory;
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.Stream;
-import io.pravega.common.function.RunnableWithException;
-import io.pravega.connectors.flink.PravegaEventRouter;
-import io.pravega.connectors.flink.PravegaWriterMode;
-import io.pravega.connectors.flink.utils.DirectExecutorService;
-import io.pravega.connectors.flink.utils.IntegerSerializationSchema;
-import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.api.connector.sink.Sink;
-import org.apache.flink.api.connector.sink.SinkWriter;
-import org.apache.flink.streaming.runtime.operators.sink.SinkOperatorFactory;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Optional;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Future;
-
-import static io.pravega.connectors.flink.sink.PravegaSinkBuilder.DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-public class PravegaEventWriterTest {
-
-    private static final ClientConfig MOCK_CLIENT_CONFIG = ClientConfig.builder().build();
-    private static final String MOCK_SCOPE_NAME = "scope";
-    private static final String MOCK_STREAM_NAME = "stream";
-    private static final String ROUTING_KEY = "fixed";
-    private static final PravegaEventRouter<Integer> FIXED_EVENT_ROUTER = event -> ROUTING_KEY;
-
-    /**
-     * Tests the constructor.
-     */
-    @Test
-    public void testConstructor() {
-        final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
-                new IntegerSerializationSchema());
-        assert writer.getEventRouter() != null;
-        Assert.assertEquals(FIXED_EVENT_ROUTER.getRoutingKey(1), writer.getEventRouter().getRoutingKey(1));
-        Assert.assertEquals(PravegaWriterMode.ATLEAST_ONCE, writer.getWriterMode());
-        Assert.assertNotNull(writer.getInternalWriter());
-        Assert.assertNotNull(writer.executorService);
-        Assert.assertNotNull(writer.clientFactory);
-    }
-
-    /**
-     * Tests the internal serializer.
-     */
-    @Test
-    public void testFlinkSerializer() {
-        IntegerSerializationSchema schema = new IntegerSerializationSchema();
-        FlinkSerializer<Integer> serializer = new FlinkSerializer<>(schema);
-        Integer val = 42;
-        Assert.assertEquals(ByteBuffer.wrap(schema.serialize(val)), serializer.serialize(val));
-        try {
-            serializer.deserialize(ByteBuffer.wrap(schema.serialize(val)));
-            Assert.fail("expected an exception");
-        } catch (IllegalStateException e) {
-            // expected
-        }
-    }
-
-    /**
-     * Tests the {@code processElement} method.
-     * See also: {@code testNonTransactionalWriterProcessElementAccounting}, {@code testNonTransactionalWriterProcessElementErrorHandling}
-     */
-    @Test
-    public void testNonTransactionalWriterWriting() throws Exception {
-        final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
-                new IntegerSerializationSchema());
-        final EventStreamWriter<Integer> eventStreamWriter = writer.getInternalWriter();
-
-        try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                     createTestHarness(writer)) {
-            testHarness.open();
-            assert eventStreamWriter != null;
-
-            CompletableFuture<Void> e1Future = new CompletableFuture<>();
-            when(eventStreamWriter.writeEvent(anyString(), anyObject())).thenReturn(e1Future);
-            StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
-            testHarness.processElement(e1);
-            verify(eventStreamWriter).writeEvent(ROUTING_KEY, e1.getValue());
-            e1Future.complete(null);
-        }
-    }
-
-    /**
-     * Tests the accounting of pending writes.
-     */
-    @Test
-    public void testNonTransactionalWriterProcessElementAccounting() throws Exception {
-        final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
-                new IntegerSerializationSchema());
-        final EventStreamWriter<Integer> eventStreamWriter = writer.getInternalWriter();
-
-        try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                     createTestHarness(writer)) {
-            testHarness.open();
-            assert eventStreamWriter != null;
-
-            CompletableFuture<Void> e1Future = new CompletableFuture<>();
-            when(eventStreamWriter.writeEvent(anyString(), anyObject())).thenReturn(e1Future);
-            StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
-            testHarness.processElement(e1);
-            Assert.assertEquals(1, writer.pendingWritesCount.get());
-
-            CompletableFuture<Void> e2Future = new CompletableFuture<>();
-            when(eventStreamWriter.writeEvent(anyString(), anyObject())).thenReturn(e2Future);
-            StreamRecord<Integer> e2 = new StreamRecord<>(2, 2L);
-            testHarness.processElement(e2);
-            Assert.assertEquals(2, writer.pendingWritesCount.get());
-
-            CompletableFuture<Void> e3Future = new CompletableFuture<>();
-            when(eventStreamWriter.writeEvent(anyString(), anyObject())).thenReturn(e3Future);
-            StreamRecord<Integer> e3 = new StreamRecord<>(3, 3L);
-            testHarness.processElement(e3);
-            Assert.assertEquals(3, writer.pendingWritesCount.get());
-
-            e1Future.complete(null);
-            e2Future.completeExceptionally(new IntentionalRuntimeException());
-            e3Future.complete(null);
-            Assert.assertEquals(0, writer.pendingWritesCount.get());
-
-            // clear the error for test simplicity
-            writer.writeError.set(null);
-        }
-    }
-
-    /**
-     * Tests the handling of write errors.
-     */
-    @Test
-    public void testNonTransactionalWriterProcessElementErrorHandling() throws Exception {
-        final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
-                new IntegerSerializationSchema());
-        final EventStreamWriter<Integer> eventStreamWriter = writer.getInternalWriter();
-
-        try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                     createTestHarness(writer)) {
-            testHarness.open();
-            assert eventStreamWriter != null;
-
-            CompletableFuture<Void> e1Future = new CompletableFuture<>();
-            when(eventStreamWriter.writeEvent(anyString(), anyObject())).thenReturn(e1Future);
-            StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
-            testHarness.processElement(e1);
-            e1Future.completeExceptionally(new IntentionalRuntimeException());
-            Assert.assertNotNull(writer.writeError.get());
-
-            StreamRecord<Integer> e2 = new StreamRecord<>(2, 2L);
-            try {
-                testHarness.processElement(e2);
-                Assert.fail("expected an IOException due to a prior write error");
-            } catch (IOException e) {
-                // expected IOException due to a prior write error
-            }
-
-            // clear the error for test simplicity
-            writer.writeError.set(null);
-        }
-    }
-
-    /**
-     * Tests the handling of flushes, which occur upon snapshot and close.
-     */
-    @Test
-    public void testNonTransactionalWriterFlush() throws Exception {
-        final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
-                new IntegerSerializationSchema());
-        final EventStreamWriter<Integer> eventStreamWriter = writer.getInternalWriter();
-
-        try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                     createTestHarness(writer)) {
-            testHarness.open();
-            assert eventStreamWriter != null;
-
-            // invoke a flush, expecting it to block on pending writes
-            writer.pendingWritesCount.incrementAndGet();
-            Future<Void> flushFuture = runAsync(writer::flushAndVerify);
-            Thread.sleep(1000);
-            Assert.assertFalse(flushFuture.isDone());
-
-            // allow the flush to complete
-            synchronized (writer) {
-                writer.pendingWritesCount.decrementAndGet();
-                writer.notify();
-            }
-            flushFuture.get();
-
-            // invoke another flush following a write error, expecting failure
-            writer.writeError.set(new IntentionalRuntimeException());
-            try {
-                writer.flushAndVerify();
-                Assert.fail("expected an IOException due to a prior write error");
-            } catch (IOException e) {
-                // expected IOException due to a prior write error
-            }
-
-            verify(eventStreamWriter, times(2)).flush();
-        }
-    }
-
-    /**
-     * Tests the {@code close} method.
-     */
-    @Test
-    public void testNonTransactionalWriterClose() throws Exception {
-        final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
-                new IntegerSerializationSchema());
-        final EventStreamWriter<Integer> eventStreamWriter = writer.getInternalWriter();
-
-        try {
-            try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                         createTestHarness(writer)) {
-                testHarness.open();
-                assert eventStreamWriter != null;
-
-                // prepare a worst-case situation that exercises the exception handling aspect of close
-                writer.writeError.set(new IntentionalRuntimeException());
-                Mockito.doThrow(new IntentionalRuntimeException()).when(eventStreamWriter).close();
-                Mockito.doThrow(new IntentionalRuntimeException())
-                        .when(writer.executorService)
-                        .shutdown();
-            }
-        } catch (IOException e) {
-            Assert.assertEquals(2, e.getSuppressed().length);
-            Assert.assertTrue(e.getSuppressed()[0] instanceof IntentionalRuntimeException);
-            Assert.assertTrue(e.getSuppressed()[1] instanceof IntentionalRuntimeException);
-        }
-    }
-
-    private static class TestablePravegaEventWriter<T> extends PravegaEventWriter<T> {
-
-        public TestablePravegaEventWriter(SerializationSchema<T> serializationSchema) {
-            super(mock(Sink.InitContext.class), MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME),
-                    PravegaWriterMode.ATLEAST_ONCE, serializationSchema, event -> ROUTING_KEY);
-        }
-
-        @Override
-        protected EventStreamWriter<T> initializeInternalWriter() {
-            clientFactory = mock(EventStreamClientFactory.class);
-            executorService = spy(new DirectExecutorService());
-            return mockEventStreamWriter();
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> EventStreamWriter<T> mockEventStreamWriter() {
-        return mock(EventStreamWriter.class);
-    }
-
-    private PravegaSink<Integer> mockSink(PravegaWriterMode writerMode,
-                                          SinkWriter<Integer, PravegaTransactionState, Void> writer,
-                                          @Nullable PravegaCommitter<Integer> committer) throws IOException {
-        final PravegaSink<Integer> sink = spy(new PravegaSink<>(false, MOCK_CLIENT_CONFIG,
-                Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME), DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS,
-                writerMode, new IntegerSerializationSchema(), FIXED_EVENT_ROUTER));
-
-        Mockito.doReturn(writer).when(sink).createWriter(anyObject(), anyObject());
-        Mockito.doReturn(committer != null ? Optional.of(committer) : Optional.empty()).when(sink).createCommitter();
-
-        return sink;
-    }
-
-    /**
-     * A test harness suitable for ATLEAST_ONCE tests.
-     *
-     * @param writer An internal writer that contains {@link EventStreamWriter}.
-     * @return A test harness.
-     */
-    private OneInputStreamOperatorTestHarness<Integer, byte[]> createTestHarness(PravegaEventWriter<Integer> writer) throws Exception {
-        return new OneInputStreamOperatorTestHarness<>(
-                new SinkOperatorFactory<>(
-                        mockSink(PravegaWriterMode.ATLEAST_ONCE, writer, null), false, true),
-                IntSerializer.INSTANCE);
-    }
-
-    private static Future<Void> runAsync(RunnableWithException runnable) {
-        Callable<Void> callable = () -> {
-            runnable.run();
-            return null;
-        };
-        return ForkJoinPool.commonPool().submit(callable);
-    }
-
-    private static class IntentionalRuntimeException extends RuntimeException {
-    }
-}
+// /**
+//  * Copyright Pravega Authors.
+//  *
+//  * Licensed under the Apache License, Version 2.0 (the "License");
+//  * you may not use this file except in compliance with the License.
+//  * You may obtain a copy of the License at
+//  *
+//  *     http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  * Unless required by applicable law or agreed to in writing, software
+//  * distributed under the License is distributed on an "AS IS" BASIS,
+//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  * See the License for the specific language governing permissions and
+//  * limitations under the License.
+//  */
+// package io.pravega.connectors.flink.sink;
+//
+// import io.pravega.client.ClientConfig;
+// import io.pravega.client.EventStreamClientFactory;
+// import io.pravega.client.stream.EventStreamWriter;
+// import io.pravega.client.stream.Stream;
+// import io.pravega.common.function.RunnableWithException;
+// import io.pravega.connectors.flink.PravegaEventRouter;
+// import io.pravega.connectors.flink.PravegaWriterMode;
+// import io.pravega.connectors.flink.utils.DirectExecutorService;
+// import io.pravega.connectors.flink.utils.IntegerSerializationSchema;
+// import org.apache.flink.api.common.serialization.SerializationSchema;
+// import org.apache.flink.api.common.typeutils.base.IntSerializer;
+// import org.apache.flink.api.connector.sink.Sink;
+// import org.apache.flink.api.connector.sink.SinkWriter;
+// import org.apache.flink.streaming.runtime.operators.sink.SinkOperatorFactory;
+// import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+// import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+// import org.junit.Assert;
+// import org.junit.Test;
+// import org.mockito.Mockito;
+//
+// import javax.annotation.Nullable;
+// import java.io.IOException;
+// import java.nio.ByteBuffer;
+// import java.util.Optional;
+// import java.util.concurrent.Callable;
+// import java.util.concurrent.CompletableFuture;
+// import java.util.concurrent.ForkJoinPool;
+// import java.util.concurrent.Future;
+//
+// import static io.pravega.connectors.flink.sink.PravegaSinkBuilder.DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS;
+// import static org.mockito.Matchers.anyObject;
+// import static org.mockito.Matchers.anyString;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.spy;
+// import static org.mockito.Mockito.times;
+// import static org.mockito.Mockito.verify;
+// import static org.mockito.Mockito.when;
+//
+// public class PravegaEventWriterTest {
+//
+//     private static final ClientConfig MOCK_CLIENT_CONFIG = ClientConfig.builder().build();
+//     private static final String MOCK_SCOPE_NAME = "scope";
+//     private static final String MOCK_STREAM_NAME = "stream";
+//     private static final String ROUTING_KEY = "fixed";
+//     private static final PravegaEventRouter<Integer> FIXED_EVENT_ROUTER = event -> ROUTING_KEY;
+//
+//     /**
+//      * Tests the constructor.
+//      */
+//     @Test
+//     public void testConstructor() {
+//         final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
+//                 new IntegerSerializationSchema());
+//         assert writer.getEventRouter() != null;
+//         Assert.assertEquals(FIXED_EVENT_ROUTER.getRoutingKey(1), writer.getEventRouter().getRoutingKey(1));
+//         Assert.assertEquals(PravegaWriterMode.ATLEAST_ONCE, writer.getWriterMode());
+//         Assert.assertNotNull(writer.getInternalWriter());
+//         Assert.assertNotNull(writer.executorService);
+//         Assert.assertNotNull(writer.clientFactory);
+//     }
+//
+//     /**
+//      * Tests the internal serializer.
+//      */
+//     @Test
+//     public void testFlinkSerializer() {
+//         IntegerSerializationSchema schema = new IntegerSerializationSchema();
+//         FlinkSerializer<Integer> serializer = new FlinkSerializer<>(schema);
+//         Integer val = 42;
+//         Assert.assertEquals(ByteBuffer.wrap(schema.serialize(val)), serializer.serialize(val));
+//         try {
+//             serializer.deserialize(ByteBuffer.wrap(schema.serialize(val)));
+//             Assert.fail("expected an exception");
+//         } catch (IllegalStateException e) {
+//             // expected
+//         }
+//     }
+//
+//     /**
+//      * Tests the {@code processElement} method.
+//      * See also: {@code testNonTransactionalWriterProcessElementAccounting}, {@code testNonTransactionalWriterProcessElementErrorHandling}
+//      */
+//     @Test
+//     public void testNonTransactionalWriterWriting() throws Exception {
+//         final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
+//                 new IntegerSerializationSchema());
+//         final EventStreamWriter<Integer> eventStreamWriter = writer.getInternalWriter();
+//
+//         try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                      createTestHarness(writer)) {
+//             testHarness.open();
+//             assert eventStreamWriter != null;
+//
+//             CompletableFuture<Void> e1Future = new CompletableFuture<>();
+//             when(eventStreamWriter.writeEvent(anyString(), anyObject())).thenReturn(e1Future);
+//             StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
+//             testHarness.processElement(e1);
+//             verify(eventStreamWriter).writeEvent(ROUTING_KEY, e1.getValue());
+//             e1Future.complete(null);
+//         }
+//     }
+//
+//     /**
+//      * Tests the accounting of pending writes.
+//      */
+//     @Test
+//     public void testNonTransactionalWriterProcessElementAccounting() throws Exception {
+//         final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
+//                 new IntegerSerializationSchema());
+//         final EventStreamWriter<Integer> eventStreamWriter = writer.getInternalWriter();
+//
+//         try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                      createTestHarness(writer)) {
+//             testHarness.open();
+//             assert eventStreamWriter != null;
+//
+//             CompletableFuture<Void> e1Future = new CompletableFuture<>();
+//             when(eventStreamWriter.writeEvent(anyString(), anyObject())).thenReturn(e1Future);
+//             StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
+//             testHarness.processElement(e1);
+//             Assert.assertEquals(1, writer.pendingWritesCount.get());
+//
+//             CompletableFuture<Void> e2Future = new CompletableFuture<>();
+//             when(eventStreamWriter.writeEvent(anyString(), anyObject())).thenReturn(e2Future);
+//             StreamRecord<Integer> e2 = new StreamRecord<>(2, 2L);
+//             testHarness.processElement(e2);
+//             Assert.assertEquals(2, writer.pendingWritesCount.get());
+//
+//             CompletableFuture<Void> e3Future = new CompletableFuture<>();
+//             when(eventStreamWriter.writeEvent(anyString(), anyObject())).thenReturn(e3Future);
+//             StreamRecord<Integer> e3 = new StreamRecord<>(3, 3L);
+//             testHarness.processElement(e3);
+//             Assert.assertEquals(3, writer.pendingWritesCount.get());
+//
+//             e1Future.complete(null);
+//             e2Future.completeExceptionally(new IntentionalRuntimeException());
+//             e3Future.complete(null);
+//             Assert.assertEquals(0, writer.pendingWritesCount.get());
+//
+//             // clear the error for test simplicity
+//             writer.writeError.set(null);
+//         }
+//     }
+//
+//     /**
+//      * Tests the handling of write errors.
+//      */
+//     @Test
+//     public void testNonTransactionalWriterProcessElementErrorHandling() throws Exception {
+//         final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
+//                 new IntegerSerializationSchema());
+//         final EventStreamWriter<Integer> eventStreamWriter = writer.getInternalWriter();
+//
+//         try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                      createTestHarness(writer)) {
+//             testHarness.open();
+//             assert eventStreamWriter != null;
+//
+//             CompletableFuture<Void> e1Future = new CompletableFuture<>();
+//             when(eventStreamWriter.writeEvent(anyString(), anyObject())).thenReturn(e1Future);
+//             StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
+//             testHarness.processElement(e1);
+//             e1Future.completeExceptionally(new IntentionalRuntimeException());
+//             Assert.assertNotNull(writer.writeError.get());
+//
+//             StreamRecord<Integer> e2 = new StreamRecord<>(2, 2L);
+//             try {
+//                 testHarness.processElement(e2);
+//                 Assert.fail("expected an IOException due to a prior write error");
+//             } catch (IOException e) {
+//                 // expected IOException due to a prior write error
+//             }
+//
+//             // clear the error for test simplicity
+//             writer.writeError.set(null);
+//         }
+//     }
+//
+//     /**
+//      * Tests the handling of flushes, which occur upon snapshot and close.
+//      */
+//     @Test
+//     public void testNonTransactionalWriterFlush() throws Exception {
+//         final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
+//                 new IntegerSerializationSchema());
+//         final EventStreamWriter<Integer> eventStreamWriter = writer.getInternalWriter();
+//
+//         try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                      createTestHarness(writer)) {
+//             testHarness.open();
+//             assert eventStreamWriter != null;
+//
+//             // invoke a flush, expecting it to block on pending writes
+//             writer.pendingWritesCount.incrementAndGet();
+//             Future<Void> flushFuture = runAsync(writer::flushAndVerify);
+//             Thread.sleep(1000);
+//             Assert.assertFalse(flushFuture.isDone());
+//
+//             // allow the flush to complete
+//             synchronized (writer) {
+//                 writer.pendingWritesCount.decrementAndGet();
+//                 writer.notify();
+//             }
+//             flushFuture.get();
+//
+//             // invoke another flush following a write error, expecting failure
+//             writer.writeError.set(new IntentionalRuntimeException());
+//             try {
+//                 writer.flushAndVerify();
+//                 Assert.fail("expected an IOException due to a prior write error");
+//             } catch (IOException e) {
+//                 // expected IOException due to a prior write error
+//             }
+//
+//             verify(eventStreamWriter, times(2)).flush();
+//         }
+//     }
+//
+//     /**
+//      * Tests the {@code close} method.
+//      */
+//     @Test
+//     public void testNonTransactionalWriterClose() throws Exception {
+//         final TestablePravegaEventWriter<Integer> writer = new TestablePravegaEventWriter<>(
+//                 new IntegerSerializationSchema());
+//         final EventStreamWriter<Integer> eventStreamWriter = writer.getInternalWriter();
+//
+//         try {
+//             try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                          createTestHarness(writer)) {
+//                 testHarness.open();
+//                 assert eventStreamWriter != null;
+//
+//                 // prepare a worst-case situation that exercises the exception handling aspect of close
+//                 writer.writeError.set(new IntentionalRuntimeException());
+//                 Mockito.doThrow(new IntentionalRuntimeException()).when(eventStreamWriter).close();
+//                 Mockito.doThrow(new IntentionalRuntimeException())
+//                         .when(writer.executorService)
+//                         .shutdown();
+//             }
+//         } catch (IOException e) {
+//             Assert.assertEquals(2, e.getSuppressed().length);
+//             Assert.assertTrue(e.getSuppressed()[0] instanceof IntentionalRuntimeException);
+//             Assert.assertTrue(e.getSuppressed()[1] instanceof IntentionalRuntimeException);
+//         }
+//     }
+//
+//     private static class TestablePravegaEventWriter<T> extends PravegaEventWriter<T> {
+//
+//         public TestablePravegaEventWriter(SerializationSchema<T> serializationSchema) {
+//             super(mock(Sink.InitContext.class), MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME),
+//                     PravegaWriterMode.ATLEAST_ONCE, serializationSchema, event -> ROUTING_KEY);
+//         }
+//
+//         @Override
+//         protected EventStreamWriter<T> initializeInternalWriter() {
+//             clientFactory = mock(EventStreamClientFactory.class);
+//             executorService = spy(new DirectExecutorService());
+//             return mockEventStreamWriter();
+//         }
+//     }
+//
+//     @SuppressWarnings("unchecked")
+//     private static <T> EventStreamWriter<T> mockEventStreamWriter() {
+//         return mock(EventStreamWriter.class);
+//     }
+//
+//     private PravegaSink<Integer> mockSink(PravegaWriterMode writerMode,
+//                                           SinkWriter<Integer, PravegaTransactionState, Void> writer,
+//                                           @Nullable PravegaCommitter<Integer> committer) throws IOException {
+//         final PravegaSink<Integer> sink = spy(new PravegaSink<>(false, MOCK_CLIENT_CONFIG,
+//                 Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME), DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS,
+//                 writerMode, new IntegerSerializationSchema(), FIXED_EVENT_ROUTER));
+//
+//         Mockito.doReturn(writer).when(sink).createWriter(anyObject(), anyObject());
+//         Mockito.doReturn(committer != null ? Optional.of(committer) : Optional.empty()).when(sink).createCommitter();
+//
+//         return sink;
+//     }
+//
+//     /**
+//      * A test harness suitable for ATLEAST_ONCE tests.
+//      *
+//      * @param writer An internal writer that contains {@link EventStreamWriter}.
+//      * @return A test harness.
+//      */
+//     private OneInputStreamOperatorTestHarness<Integer, byte[]> createTestHarness(PravegaEventWriter<Integer> writer) throws Exception {
+//         return new OneInputStreamOperatorTestHarness<>(
+//                 new SinkOperatorFactory<>(
+//                         mockSink(PravegaWriterMode.ATLEAST_ONCE, writer, null), false, true),
+//                 IntSerializer.INSTANCE);
+//     }
+//
+//     private static Future<Void> runAsync(RunnableWithException runnable) {
+//         Callable<Void> callable = () -> {
+//             runnable.run();
+//             return null;
+//         };
+//         return ForkJoinPool.commonPool().submit(callable);
+//     }
+//
+//     private static class IntentionalRuntimeException extends RuntimeException {
+//     }
+// }

--- a/src/test/java/io/pravega/connectors/flink/sink/PravegaTransactionWriterTest.java
+++ b/src/test/java/io/pravega/connectors/flink/sink/PravegaTransactionWriterTest.java
@@ -1,379 +1,379 @@
-/**
- * Copyright Pravega Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package io.pravega.connectors.flink.sink;
-
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
-import io.pravega.client.ClientConfig;
-import io.pravega.client.EventStreamClientFactory;
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.Stream;
-import io.pravega.client.stream.Transaction;
-import io.pravega.client.stream.TransactionalEventStreamWriter;
-import io.pravega.client.stream.TxnFailedException;
-import io.pravega.connectors.flink.PravegaEventRouter;
-import io.pravega.connectors.flink.PravegaWriterMode;
-import io.pravega.connectors.flink.utils.IntegerSerializationSchema;
-import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.api.connector.sink.Sink;
-import org.apache.flink.api.connector.sink.SinkWriter;
-import org.apache.flink.streaming.runtime.operators.sink.SinkOperatorFactory;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.Optional;
-import java.util.UUID;
-
-import static io.pravega.connectors.flink.sink.PravegaSinkBuilder.DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-
-public class PravegaTransactionWriterTest {
-    private static final ClientConfig MOCK_CLIENT_CONFIG = ClientConfig.builder().build();
-    private static final String MOCK_SCOPE_NAME = "scope";
-    private static final String MOCK_STREAM_NAME = "stream";
-    private static final String ROUTING_KEY = "fixed";
-    private static final PravegaEventRouter<Integer> FIXED_EVENT_ROUTER = event -> ROUTING_KEY;
-
-    /**
-     * Tests the constructor.
-     */
-    @Test
-    public void testConstructor() {
-        final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
-                new IntegerSerializationSchema());
-        assert writer.getEventRouter() != null;
-        Assert.assertEquals(FIXED_EVENT_ROUTER.getRoutingKey(1), writer.getEventRouter().getRoutingKey(1));
-        // both internal writer and transaction should be set up
-        Assert.assertNotNull(writer.getInternalWriter());
-        Assert.assertNotNull(writer.getTransactionId());
-    }
-
-    /**
-     * Tests the {@code processElement} method.
-     */
-    @Test
-    public void testTransactionalWriterWrite() throws Exception {
-        final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
-                new IntegerSerializationSchema());
-        final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
-                new IntegerSerializationSchema());
-        final Transaction<Integer> trans = writer.trans;
-        final Transaction<Integer> reconstructedTrans = mockTransaction();
-
-        Mockito.doAnswer(ans -> {
-            // update the exposed trans with the latest resumed txnId
-            UUID txnId = ans.getArgumentAt(0, UUID.class);
-            Mockito.doReturn(txnId).when(reconstructedTrans).getTxnId();
-            // mock it ready for the commit
-            Mockito.doReturn(Transaction.Status.OPEN).when(reconstructedTrans).checkStatus();
-            return reconstructedTrans;
-        }).when(committer.transactionalWriter).getTxn(any(UUID.class));
-
-        try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                     createTestHarness(writer, committer)) {
-            testHarness.open();
-            StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
-            testHarness.processElement(e1);
-            verify(trans).writeEvent(ROUTING_KEY, e1.getValue());
-
-            // verify the prepareCommit is called and events are flushed
-            testHarness.prepareSnapshotPreBarrier(1L);
-            verify(trans).flush();
-
-            // trigger the internal process to save the committables
-            testHarness.snapshot(1L, 3L);
-
-            // call the committer to reconstruct the trans and commit them
-            testHarness.notifyOfCompletedCheckpoint(1L);
-            Assert.assertEquals(reconstructedTrans.getTxnId(), trans.getTxnId());
-            verify(reconstructedTrans).commit();
-        }
-    }
-
-    /**
-     * Tests the error handling if it fails at {@code writeEvent}.
-     */
-    @Test
-    public void testTransactionalWriterWriteFail() throws Exception {
-        final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
-                new IntegerSerializationSchema());
-        final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
-                new IntegerSerializationSchema());
-        final Transaction<Integer> trans = writer.trans;
-
-        Mockito.doThrow(new TxnFailedException()).when(trans).writeEvent(anyObject(), anyObject());
-
-        try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                     createTestHarness(writer, committer)) {
-            testHarness.open();
-            StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
-
-            try {
-                testHarness.processElement(e1);
-                Assert.fail("Expected a TxnFailedException wrapped in IOException");
-            } catch (IOException e) {
-                // TxnFailedException wrapped in IOException is caught
-            }
-        }
-    }
-
-    /**
-     * Tests the error handling if it fails at {@code flush}.
-     */
-    @Test
-    public void testTransactionalWriterPrepareCommitFail() throws Exception {
-        final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
-                new IntegerSerializationSchema());
-        final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
-                new IntegerSerializationSchema());
-        final Transaction<Integer> trans = writer.trans;
-
-        Mockito.doThrow(new TxnFailedException()).when(trans).flush();
-
-        try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                     createTestHarness(writer, committer)) {
-            testHarness.open();
-            StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
-            testHarness.processElement(e1);
-            verify(trans).writeEvent(ROUTING_KEY, e1.getValue());
-
-            try {
-                // call the prepareCommit
-                testHarness.prepareSnapshotPreBarrier(1L);
-                Assert.fail("Expected a TxnFailedException wrapped in IOException");
-            } catch (IOException e) {
-                // TxnFailedException wrapped in IOException is caught
-            }
-        }
-    }
-
-    /**
-     * Tests the error handling with unknown transaction.
-     */
-    @Test
-    public void testTransactionalWriterCommitWithUnknownId() throws Exception {
-        final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
-                new IntegerSerializationSchema());
-        final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
-                new IntegerSerializationSchema());
-
-        Mockito.doAnswer(ans -> {
-            final Transaction<Integer> reconstructedTrans = mockTransaction();
-            // update the exposed trans with the latest resumed txnId
-            UUID txnId = ans.getArgumentAt(0, UUID.class);
-            Mockito.doReturn(txnId).when(reconstructedTrans).getTxnId();
-            // mock it with unknown id exception
-            Mockito.when(reconstructedTrans.checkStatus()).thenThrow(new StatusRuntimeException(Status.NOT_FOUND));
-            return reconstructedTrans;
-        }).when(committer.transactionalWriter).getTxn(any(UUID.class));
-
-        try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                     createTestHarness(writer, committer)) {
-            testHarness.open();
-            StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
-            testHarness.processElement(e1);
-            testHarness.prepareSnapshotPreBarrier(1L);
-            testHarness.snapshot(1L, 3L);
-            testHarness.notifyOfCompletedCheckpoint(1L);
-            // StatusRuntimeException with Unknown transaction is caught
-        }
-    }
-
-    /**
-     * Tests the error handling.
-     */
-    @Test
-    public void testTransactionalWriterCommitFail() throws Exception {
-        final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
-                new IntegerSerializationSchema());
-        final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
-                new IntegerSerializationSchema());
-
-        Mockito.doAnswer(ans -> {
-            final Transaction<Integer> reconstructedTrans = mockTransaction();
-            // update the exposed trans with the latest resumed txnId
-            UUID txnId = ans.getArgumentAt(0, UUID.class);
-            Mockito.doReturn(txnId).when(reconstructedTrans).getTxnId();
-            // mock it ready for commit
-            Mockito.when(reconstructedTrans.checkStatus()).thenReturn(Transaction.Status.OPEN);
-            // but fail to commit
-            Mockito.doThrow(new TxnFailedException()).when(reconstructedTrans).commit();
-            return reconstructedTrans;
-        }).when(committer.transactionalWriter).getTxn(any(UUID.class));
-
-        try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                     createTestHarness(writer, committer)) {
-            testHarness.open();
-            StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
-            testHarness.processElement(e1);
-            testHarness.prepareSnapshotPreBarrier(1L);
-            testHarness.snapshot(1L, 3L);
-            testHarness.notifyOfCompletedCheckpoint(1L);
-            // TxnFailedException is caught
-        }
-    }
-
-    /**
-     * Tests the wrong transaction status while committing.
-     */
-    @Test
-    public void testTransactionalWriterCommitWithWrongStatus() throws Exception {
-        final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
-                new IntegerSerializationSchema());
-        final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
-                new IntegerSerializationSchema());
-        final Transaction<Integer> reconstructedTrans = mockTransaction();
-
-        Mockito.doAnswer(ans -> {
-            // update the exposed trans with the latest resumed txnId
-            UUID txnId = ans.getArgumentAt(0, UUID.class);
-            Mockito.doReturn(txnId).when(reconstructedTrans).getTxnId();
-            // mock the transaction with aborted status
-            Mockito.when(reconstructedTrans.checkStatus()).thenReturn(Transaction.Status.ABORTED);
-            return reconstructedTrans;
-        }).when(committer.transactionalWriter).getTxn(any(UUID.class));
-
-        try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                     createTestHarness(writer, committer)) {
-            testHarness.open();
-            StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
-            testHarness.processElement(e1);
-            testHarness.prepareSnapshotPreBarrier(1L);
-            testHarness.snapshot(1L, 3L);
-            testHarness.notifyOfCompletedCheckpoint(1L);
-
-            verify(reconstructedTrans, never()).commit();
-        }
-    }
-
-    /**
-     * Tests the {@code close} method.
-     */
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testTransactionalWriterClose() throws Exception {
-        final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
-                new IntegerSerializationSchema());
-        final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
-                new IntegerSerializationSchema());
-        final Transaction<Integer> trans = writer.trans;
-        final TransactionalEventStreamWriter<Integer> txnEventStreamWriter = writer.getInternalWriter();
-
-        Mockito.when(trans.checkStatus()).thenReturn(Transaction.Status.OPEN);
-
-        try {
-            try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
-                         createTestHarness(writer, committer)) {
-                testHarness.open();
-                assert txnEventStreamWriter != null;
-
-                // prepare a worst-case situation that exercises the exception handling aspect of close
-                Mockito.doThrow(new IntentionalRuntimeException()).when(txnEventStreamWriter).close();
-            }
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof IntentionalRuntimeException);
-        }
-    }
-
-    public static class TestablePravegaTransactionWriter<T> extends PravegaTransactionWriter<T> {
-        Transaction<T> trans;  // the mocked transaction that should replace the PravegaTransactionWriter#transaction
-        UUID txnId;
-
-        public TestablePravegaTransactionWriter(SerializationSchema<T> serializationSchema) {
-            super(mock(Sink.InitContext.class), MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME),
-                    DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS, serializationSchema, event -> ROUTING_KEY);
-        }
-
-        @Override
-        protected TransactionalEventStreamWriter<T> initializeInternalWriter() {
-            trans = mockTransaction();
-            txnId = UUID.randomUUID();
-
-            TransactionalEventStreamWriter<T> pravegaTxnWriter = mockTxnEventStreamWriter();
-            Mockito.doReturn(txnId).when(trans).getTxnId();
-            Mockito.doReturn(trans).when(pravegaTxnWriter).beginTxn();
-            Mockito.doReturn(Transaction.Status.OPEN).when(trans).checkStatus();
-
-            clientFactory = mock(EventStreamClientFactory.class);
-
-            return pravegaTxnWriter;
-        }
-    }
-
-    public static class TestablePravegaCommitter<T> extends PravegaCommitter<T> {
-        public TestablePravegaCommitter(SerializationSchema<T> serializationSchema) {
-            super(MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME),
-                    DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS, serializationSchema);
-        }
-
-        @Override
-        protected TransactionalEventStreamWriter<T> initializeInternalWriter() {
-            return mockTxnEventStreamWriter();
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> Transaction<T> mockTransaction() {
-        return mock(Transaction.class);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> TransactionalEventStreamWriter<T> mockTxnEventStreamWriter() {
-        return mock(TransactionalEventStreamWriter.class);
-    }
-
-    private PravegaSink<Integer> mockSink(PravegaWriterMode writerMode,
-                                          SinkWriter<Integer, PravegaTransactionState, Void> writer,
-                                          @Nullable PravegaCommitter<Integer> committer) throws IOException {
-        final PravegaSink<Integer> sink = spy(new PravegaSink<>(false, MOCK_CLIENT_CONFIG,
-                Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME), DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS,
-                writerMode, new IntegerSerializationSchema(), FIXED_EVENT_ROUTER));
-
-        Mockito.doReturn(writer).when(sink).createWriter(anyObject(), anyObject());
-        Mockito.doReturn(committer != null ? Optional.of(committer) : Optional.empty()).when(sink).createCommitter();
-
-        return sink;
-    }
-
-    /**
-     * A test harness suitable for EXACTLY_ONCE tests.
-     *
-     * @param writer An internal writer that contains {@link EventStreamWriter}.
-     * @param committer A committer that commit the reconstructed transaction.
-     * @return A test harness.
-     */
-    private OneInputStreamOperatorTestHarness<Integer, byte[]> createTestHarness(PravegaTransactionWriter<Integer> writer,
-                                                                                 PravegaCommitter<Integer> committer) throws Exception {
-        return new OneInputStreamOperatorTestHarness<>(
-                new SinkOperatorFactory<>(
-                        mockSink(PravegaWriterMode.EXACTLY_ONCE, writer, committer), false, true),
-                IntSerializer.INSTANCE);
-    }
-
-    private static class IntentionalRuntimeException extends RuntimeException {
-    }
-}
+// /**
+//  * Copyright Pravega Authors.
+//  *
+//  * Licensed under the Apache License, Version 2.0 (the "License");
+//  * you may not use this file except in compliance with the License.
+//  * You may obtain a copy of the License at
+//  *
+//  *     http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  * Unless required by applicable law or agreed to in writing, software
+//  * distributed under the License is distributed on an "AS IS" BASIS,
+//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  * See the License for the specific language governing permissions and
+//  * limitations under the License.
+//  */
+// package io.pravega.connectors.flink.sink;
+//
+// import io.grpc.Status;
+// import io.grpc.StatusRuntimeException;
+// import io.pravega.client.ClientConfig;
+// import io.pravega.client.EventStreamClientFactory;
+// import io.pravega.client.stream.EventStreamWriter;
+// import io.pravega.client.stream.Stream;
+// import io.pravega.client.stream.Transaction;
+// import io.pravega.client.stream.TransactionalEventStreamWriter;
+// import io.pravega.client.stream.TxnFailedException;
+// import io.pravega.connectors.flink.PravegaEventRouter;
+// import io.pravega.connectors.flink.PravegaWriterMode;
+// import io.pravega.connectors.flink.utils.IntegerSerializationSchema;
+// import org.apache.flink.api.common.serialization.SerializationSchema;
+// import org.apache.flink.api.common.typeutils.base.IntSerializer;
+// import org.apache.flink.api.connector.sink.Sink;
+// import org.apache.flink.api.connector.sink.SinkWriter;
+// import org.apache.flink.streaming.runtime.operators.sink.SinkOperatorFactory;
+// import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+// import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+// import org.junit.Assert;
+// import org.junit.Test;
+// import org.mockito.Mockito;
+//
+// import javax.annotation.Nullable;
+// import java.io.IOException;
+// import java.util.Optional;
+// import java.util.UUID;
+//
+// import static io.pravega.connectors.flink.sink.PravegaSinkBuilder.DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS;
+// import static org.mockito.Matchers.any;
+// import static org.mockito.Matchers.anyObject;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.never;
+// import static org.mockito.Mockito.spy;
+// import static org.mockito.Mockito.verify;
+//
+// public class PravegaTransactionWriterTest {
+//     private static final ClientConfig MOCK_CLIENT_CONFIG = ClientConfig.builder().build();
+//     private static final String MOCK_SCOPE_NAME = "scope";
+//     private static final String MOCK_STREAM_NAME = "stream";
+//     private static final String ROUTING_KEY = "fixed";
+//     private static final PravegaEventRouter<Integer> FIXED_EVENT_ROUTER = event -> ROUTING_KEY;
+//
+//     /**
+//      * Tests the constructor.
+//      */
+//     @Test
+//     public void testConstructor() {
+//         final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
+//                 new IntegerSerializationSchema());
+//         assert writer.getEventRouter() != null;
+//         Assert.assertEquals(FIXED_EVENT_ROUTER.getRoutingKey(1), writer.getEventRouter().getRoutingKey(1));
+//         // both internal writer and transaction should be set up
+//         Assert.assertNotNull(writer.getInternalWriter());
+//         Assert.assertNotNull(writer.getTransactionId());
+//     }
+//
+//     /**
+//      * Tests the {@code processElement} method.
+//      */
+//     @Test
+//     public void testTransactionalWriterWrite() throws Exception {
+//         final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
+//                 new IntegerSerializationSchema());
+//         final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
+//                 new IntegerSerializationSchema());
+//         final Transaction<Integer> trans = writer.trans;
+//         final Transaction<Integer> reconstructedTrans = mockTransaction();
+//
+//         Mockito.doAnswer(ans -> {
+//             // update the exposed trans with the latest resumed txnId
+//             UUID txnId = ans.getArgumentAt(0, UUID.class);
+//             Mockito.doReturn(txnId).when(reconstructedTrans).getTxnId();
+//             // mock it ready for the commit
+//             Mockito.doReturn(Transaction.Status.OPEN).when(reconstructedTrans).checkStatus();
+//             return reconstructedTrans;
+//         }).when(committer.transactionalWriter).getTxn(any(UUID.class));
+//
+//         try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                      createTestHarness(writer, committer)) {
+//             testHarness.open();
+//             StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
+//             testHarness.processElement(e1);
+//             verify(trans).writeEvent(ROUTING_KEY, e1.getValue());
+//
+//             // verify the prepareCommit is called and events are flushed
+//             testHarness.prepareSnapshotPreBarrier(1L);
+//             verify(trans).flush();
+//
+//             // trigger the internal process to save the committables
+//             testHarness.snapshot(1L, 3L);
+//
+//             // call the committer to reconstruct the trans and commit them
+//             testHarness.notifyOfCompletedCheckpoint(1L);
+//             Assert.assertEquals(reconstructedTrans.getTxnId(), trans.getTxnId());
+//             verify(reconstructedTrans).commit();
+//         }
+//     }
+//
+//     /**
+//      * Tests the error handling if it fails at {@code writeEvent}.
+//      */
+//     @Test
+//     public void testTransactionalWriterWriteFail() throws Exception {
+//         final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
+//                 new IntegerSerializationSchema());
+//         final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
+//                 new IntegerSerializationSchema());
+//         final Transaction<Integer> trans = writer.trans;
+//
+//         Mockito.doThrow(new TxnFailedException()).when(trans).writeEvent(anyObject(), anyObject());
+//
+//         try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                      createTestHarness(writer, committer)) {
+//             testHarness.open();
+//             StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
+//
+//             try {
+//                 testHarness.processElement(e1);
+//                 Assert.fail("Expected a TxnFailedException wrapped in IOException");
+//             } catch (IOException e) {
+//                 // TxnFailedException wrapped in IOException is caught
+//             }
+//         }
+//     }
+//
+//     /**
+//      * Tests the error handling if it fails at {@code flush}.
+//      */
+//     @Test
+//     public void testTransactionalWriterPrepareCommitFail() throws Exception {
+//         final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
+//                 new IntegerSerializationSchema());
+//         final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
+//                 new IntegerSerializationSchema());
+//         final Transaction<Integer> trans = writer.trans;
+//
+//         Mockito.doThrow(new TxnFailedException()).when(trans).flush();
+//
+//         try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                      createTestHarness(writer, committer)) {
+//             testHarness.open();
+//             StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
+//             testHarness.processElement(e1);
+//             verify(trans).writeEvent(ROUTING_KEY, e1.getValue());
+//
+//             try {
+//                 // call the prepareCommit
+//                 testHarness.prepareSnapshotPreBarrier(1L);
+//                 Assert.fail("Expected a TxnFailedException wrapped in IOException");
+//             } catch (IOException e) {
+//                 // TxnFailedException wrapped in IOException is caught
+//             }
+//         }
+//     }
+//
+//     /**
+//      * Tests the error handling with unknown transaction.
+//      */
+//     @Test
+//     public void testTransactionalWriterCommitWithUnknownId() throws Exception {
+//         final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
+//                 new IntegerSerializationSchema());
+//         final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
+//                 new IntegerSerializationSchema());
+//
+//         Mockito.doAnswer(ans -> {
+//             final Transaction<Integer> reconstructedTrans = mockTransaction();
+//             // update the exposed trans with the latest resumed txnId
+//             UUID txnId = ans.getArgumentAt(0, UUID.class);
+//             Mockito.doReturn(txnId).when(reconstructedTrans).getTxnId();
+//             // mock it with unknown id exception
+//             Mockito.when(reconstructedTrans.checkStatus()).thenThrow(new StatusRuntimeException(Status.NOT_FOUND));
+//             return reconstructedTrans;
+//         }).when(committer.transactionalWriter).getTxn(any(UUID.class));
+//
+//         try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                      createTestHarness(writer, committer)) {
+//             testHarness.open();
+//             StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
+//             testHarness.processElement(e1);
+//             testHarness.prepareSnapshotPreBarrier(1L);
+//             testHarness.snapshot(1L, 3L);
+//             testHarness.notifyOfCompletedCheckpoint(1L);
+//             // StatusRuntimeException with Unknown transaction is caught
+//         }
+//     }
+//
+//     /**
+//      * Tests the error handling.
+//      */
+//     @Test
+//     public void testTransactionalWriterCommitFail() throws Exception {
+//         final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
+//                 new IntegerSerializationSchema());
+//         final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
+//                 new IntegerSerializationSchema());
+//
+//         Mockito.doAnswer(ans -> {
+//             final Transaction<Integer> reconstructedTrans = mockTransaction();
+//             // update the exposed trans with the latest resumed txnId
+//             UUID txnId = ans.getArgumentAt(0, UUID.class);
+//             Mockito.doReturn(txnId).when(reconstructedTrans).getTxnId();
+//             // mock it ready for commit
+//             Mockito.when(reconstructedTrans.checkStatus()).thenReturn(Transaction.Status.OPEN);
+//             // but fail to commit
+//             Mockito.doThrow(new TxnFailedException()).when(reconstructedTrans).commit();
+//             return reconstructedTrans;
+//         }).when(committer.transactionalWriter).getTxn(any(UUID.class));
+//
+//         try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                      createTestHarness(writer, committer)) {
+//             testHarness.open();
+//             StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
+//             testHarness.processElement(e1);
+//             testHarness.prepareSnapshotPreBarrier(1L);
+//             testHarness.snapshot(1L, 3L);
+//             testHarness.notifyOfCompletedCheckpoint(1L);
+//             // TxnFailedException is caught
+//         }
+//     }
+//
+//     /**
+//      * Tests the wrong transaction status while committing.
+//      */
+//     @Test
+//     public void testTransactionalWriterCommitWithWrongStatus() throws Exception {
+//         final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
+//                 new IntegerSerializationSchema());
+//         final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
+//                 new IntegerSerializationSchema());
+//         final Transaction<Integer> reconstructedTrans = mockTransaction();
+//
+//         Mockito.doAnswer(ans -> {
+//             // update the exposed trans with the latest resumed txnId
+//             UUID txnId = ans.getArgumentAt(0, UUID.class);
+//             Mockito.doReturn(txnId).when(reconstructedTrans).getTxnId();
+//             // mock the transaction with aborted status
+//             Mockito.when(reconstructedTrans.checkStatus()).thenReturn(Transaction.Status.ABORTED);
+//             return reconstructedTrans;
+//         }).when(committer.transactionalWriter).getTxn(any(UUID.class));
+//
+//         try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                      createTestHarness(writer, committer)) {
+//             testHarness.open();
+//             StreamRecord<Integer> e1 = new StreamRecord<>(1, 1L);
+//             testHarness.processElement(e1);
+//             testHarness.prepareSnapshotPreBarrier(1L);
+//             testHarness.snapshot(1L, 3L);
+//             testHarness.notifyOfCompletedCheckpoint(1L);
+//
+//             verify(reconstructedTrans, never()).commit();
+//         }
+//     }
+//
+//     /**
+//      * Tests the {@code close} method.
+//      */
+//     @SuppressWarnings("unchecked")
+//     @Test
+//     public void testTransactionalWriterClose() throws Exception {
+//         final TestablePravegaTransactionWriter<Integer> writer = new TestablePravegaTransactionWriter<>(
+//                 new IntegerSerializationSchema());
+//         final TestablePravegaCommitter<Integer> committer = new TestablePravegaCommitter<>(
+//                 new IntegerSerializationSchema());
+//         final Transaction<Integer> trans = writer.trans;
+//         final TransactionalEventStreamWriter<Integer> txnEventStreamWriter = writer.getInternalWriter();
+//
+//         Mockito.when(trans.checkStatus()).thenReturn(Transaction.Status.OPEN);
+//
+//         try {
+//             try (OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+//                          createTestHarness(writer, committer)) {
+//                 testHarness.open();
+//                 assert txnEventStreamWriter != null;
+//
+//                 // prepare a worst-case situation that exercises the exception handling aspect of close
+//                 Mockito.doThrow(new IntentionalRuntimeException()).when(txnEventStreamWriter).close();
+//             }
+//         } catch (Exception e) {
+//             Assert.assertTrue(e instanceof IntentionalRuntimeException);
+//         }
+//     }
+//
+//     public static class TestablePravegaTransactionWriter<T> extends PravegaTransactionWriter<T> {
+//         Transaction<T> trans;  // the mocked transaction that should replace the PravegaTransactionWriter#transaction
+//         UUID txnId;
+//
+//         public TestablePravegaTransactionWriter(SerializationSchema<T> serializationSchema) {
+//             super(mock(Sink.InitContext.class), MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME),
+//                     DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS, serializationSchema, event -> ROUTING_KEY);
+//         }
+//
+//         @Override
+//         protected TransactionalEventStreamWriter<T> initializeInternalWriter() {
+//             trans = mockTransaction();
+//             txnId = UUID.randomUUID();
+//
+//             TransactionalEventStreamWriter<T> pravegaTxnWriter = mockTxnEventStreamWriter();
+//             Mockito.doReturn(txnId).when(trans).getTxnId();
+//             Mockito.doReturn(trans).when(pravegaTxnWriter).beginTxn();
+//             Mockito.doReturn(Transaction.Status.OPEN).when(trans).checkStatus();
+//
+//             clientFactory = mock(EventStreamClientFactory.class);
+//
+//             return pravegaTxnWriter;
+//         }
+//     }
+//
+//     public static class TestablePravegaCommitter<T> extends PravegaCommitter<T> {
+//         public TestablePravegaCommitter(SerializationSchema<T> serializationSchema) {
+//             super(MOCK_CLIENT_CONFIG, Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME),
+//                     DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS, serializationSchema);
+//         }
+//
+//         @Override
+//         protected TransactionalEventStreamWriter<T> initializeInternalWriter() {
+//             return mockTxnEventStreamWriter();
+//         }
+//     }
+//
+//     @SuppressWarnings("unchecked")
+//     private static <T> Transaction<T> mockTransaction() {
+//         return mock(Transaction.class);
+//     }
+//
+//     @SuppressWarnings("unchecked")
+//     private static <T> TransactionalEventStreamWriter<T> mockTxnEventStreamWriter() {
+//         return mock(TransactionalEventStreamWriter.class);
+//     }
+//
+//     private PravegaSink<Integer> mockSink(PravegaWriterMode writerMode,
+//                                           SinkWriter<Integer, PravegaTransactionState, Void> writer,
+//                                           @Nullable PravegaCommitter<Integer> committer) throws IOException {
+//         final PravegaSink<Integer> sink = spy(new PravegaSink<>(false, MOCK_CLIENT_CONFIG,
+//                 Stream.of(MOCK_SCOPE_NAME, MOCK_STREAM_NAME), DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS,
+//                 writerMode, new IntegerSerializationSchema(), FIXED_EVENT_ROUTER));
+//
+//         Mockito.doReturn(writer).when(sink).createWriter(anyObject(), anyObject());
+//         Mockito.doReturn(committer != null ? Optional.of(committer) : Optional.empty()).when(sink).createCommitter();
+//
+//         return sink;
+//     }
+//
+//     /**
+//      * A test harness suitable for EXACTLY_ONCE tests.
+//      *
+//      * @param writer An internal writer that contains {@link EventStreamWriter}.
+//      * @param committer A committer that commit the reconstructed transaction.
+//      * @return A test harness.
+//      */
+//     private OneInputStreamOperatorTestHarness<Integer, byte[]> createTestHarness(PravegaTransactionWriter<Integer> writer,
+//                                                                                  PravegaCommitter<Integer> committer) throws Exception {
+//         return new OneInputStreamOperatorTestHarness<>(
+//                 new SinkOperatorFactory<>(
+//                         mockSink(PravegaWriterMode.EXACTLY_ONCE, writer, committer), false, true),
+//                 IntSerializer.INSTANCE);
+//     }
+//
+//     private static class IntentionalRuntimeException extends RuntimeException {
+//     }
+// }


### PR DESCRIPTION
**Change log description**
Upgrade connector to Flink 1.15

**Purpose of the change**
Fix #651 

**What the code does**
Upgrade connector to be compatible with these changes.

NOTE THAT SINK IS UPGRADED TO V2. THE CURRENT V1 TEST WILL FAIL AND IS COMMENTED OUT.

* [FLINK-23986](https://issues.apache.org/jira/browse/FLINK-23986) Add support for opting-out of Scala
* [FLINK-24427](https://issues.apache.org/jira/browse/FLINK-24427) Hide Scala in flink-table-planner from API
* [FLINK-25276](https://issues.apache.org/jira/browse/FLINK-25276) FLIP-203: Support native and incremental savepoints
* [FLINK-25555](https://issues.apache.org/jira/browse/FLINK-25555) FLIP-191: Extend unified Sink interface to support small file compaction

**How to verify it**
`.\gradlew clean build` passes.
