### PR TITLE
[Issue-656] Fix dynamic credential issue for SchemaRegistry access

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/util/SchemaRegistryUtils.java
+++ b/src/main/java/io/pravega/connectors/flink/util/SchemaRegistryUtils.java
@@ -46,7 +46,7 @@ public class SchemaRegistryUtils {
         } else {
             if (isCredentialsLoadDynamic()) {
                 // dynamic credential, e.g. Keycloak
-                builder.authentication(new PravegaCredentialProvider(pravegaConfig.getClientConfig()));
+                builder.authentication(new PravegaCredentialProvider());
             } else {
                 // no credential
             }


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
- Change `PravegaCredentialProvider` constructor for setting up the SchemaRegistry configuration when loading dynamic credentials from something like Keycloak

**Purpose of the change**
Fix #656 

**What the code does**
- Call the `PravegaCredentialProvider` constructor without parameters for setting up the SchemaRegistry configuration for dynamic credential loading

**How to verify it**
`./gradlew clean build` passed
