### PR TITLE
[Issue-660] Add required sceme for controller URI

### DIFF
--- a/src/test/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableFactoryTest.java
+++ b/src/test/java/io/pravega/connectors/flink/dynamic/table/FlinkPravegaDynamicTableFactoryTest.java
@@ -78,7 +78,7 @@ import static org.junit.Assert.assertTrue;
 
 public class FlinkPravegaDynamicTableFactoryTest extends TestLogger {
     private static final String SCOPE = "scope";
-    private static final String CONTROLLER_URI = "dummy";
+    private static final String CONTROLLER_URI = "tcp://dummy:9090";
     private static final String AUTH_TYPE = "basic";
     private static final String AUTH_TOKEN = "token";
 


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
- Add required scheme in controller URI in unit test to align with changes in Pravega: https://github.com/pravega/pravega/pull/6559.

**Purpose of the change**
- Fix #660 

**What the code does**
- Change `CONTROLLER_URI` in unit test `FlinkPravegaDynamicTableFactoryTest` to `tcp://dummy:9090`

**How to verify it**
`gradlew clean build` should pass