### PR TITLE
[Issue-671] Use Pravega netty in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,18 +89,6 @@ configurations {
     testImplementation {
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
         exclude group: 'log4j', module: 'log4j'
-        resolutionStrategy {
-            force group: 'io.netty', name: 'netty-common', version: nettyVersion
-            force group: 'io.netty', name: 'netty-transport', version: nettyVersion
-            force group: 'io.netty', name: 'netty-handler', version: nettyVersion
-            force group: 'io.netty', name: 'netty-codec', version: nettyVersion
-            force group: 'io.netty', name: 'netty-codec-http', version: nettyVersion
-            force group: 'io.netty', name: 'netty-codec-http2', version: nettyVersion
-            force group: 'io.netty', name: 'netty-codec-socks', version: nettyVersion
-            force group: 'io.netty', name: 'netty-handler-proxy', version: nettyVersion
-            force group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion
-            force group: 'io.netty', name: 'netty-tcnative-boringssl-static', version: nettyVersion
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,6 @@ dependencies {
     testImplementation (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
         exclude group:  'org.slf4j', module: 'slf4j-api'
         exclude group:  'ch.qos.logback', module: 'logback-classic'
-        exclude group: 'io.netty'
     }
     testImplementation (group: 'io.pravega', name: 'schemaregistry-server', version: schemaRegistryVersion) {
         transitive = false


### PR DESCRIPTION
Signed-off-by: thekingofcity <3353040+thekingofcity@users.noreply.github.com>

**Change log description**
The latest Pravega update netty version, so the tests in connectors could remove the force netty version.

**Purpose of the change**
Fix #671 

**What the code does**
Remove force netty.

**How to verify it**
`.\gradlew clean build` passes.
