### PR TITLE
[Issue-675] Keep schema registry up to date

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,8 +37,8 @@ nettyVersion=4.1.65.Final
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.11.0-SNAPSHOT
-pravegaVersion=0.11.0-3038.fc1f5c3-SNAPSHOT
-schemaRegistryVersion=0.4.0-78.f1b3eef-SNAPSHOT
+pravegaVersion=0.11.0
+schemaRegistryVersion=0.4.0-80.1629800-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # These properties are only needed for publishing to maven central

--- a/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
+++ b/src/main/java/io/pravega/connectors/flink/FlinkPravegaReader.java
@@ -27,8 +27,6 @@ import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReaderGroupNotFoundException;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.TruncatedDataException;
-import io.pravega.connectors.flink.serialization.DeserializerFromSchemaRegistry;
-import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
 import io.pravega.connectors.flink.serialization.PravegaDeserializationSchemaWithMetadata;
 import io.pravega.connectors.flink.watermark.AssignerWithTimeWindows;
 import org.apache.flink.api.common.ExecutionConfig;
@@ -717,20 +715,6 @@ public class FlinkPravegaReader<T>
          */
         public Builder<T> withDeserializationSchema(DeserializationSchema<T> deserializationSchema) {
             this.deserializationSchema = deserializationSchema;
-            return builder();
-        }
-
-        /**
-         * Sets the deserialization schema from schema registry. It supports Json, Avro and Protobuf format.
-         *
-         * @param groupId The group id in schema registry
-         * @param tClass  The class describing the deserialized type.
-         * @return Builder instance.
-         */
-        @SuppressWarnings("unchecked")
-        public Builder<T> withDeserializationSchemaFromRegistry(String groupId, Class<T> tClass) {
-            this.deserializationSchema = new PravegaDeserializationSchema<>(tClass,
-                    new DeserializerFromSchemaRegistry<>(getPravegaConfig(), groupId, tClass));
             return builder();
         }
 

--- a/src/main/java/io/pravega/connectors/flink/serialization/PravegaDeserializationSchema.java
+++ b/src/main/java/io/pravega/connectors/flink/serialization/PravegaDeserializationSchema.java
@@ -67,10 +67,10 @@ public class PravegaDeserializationSchema<T>
             this.typeInfo = TypeInformation.of(typeClass);
         } catch (InvalidTypesException e) {
             throw new IllegalArgumentException(
-                    "Due to Java's type erasure, the generic type information cannot be properly inferred. " + 
-                    "Please pass a 'TypeHint' instead of a class to describe the type. " +
-                    "For example, to describe 'Tuple2<String, String>' as a generic type, use " +
-                    "'new PravegaDeserializationSchema<>(new TypeHint<Tuple2<String, String>>(){}, serializer);'"
+                    "Due to Java's type erasure, the generic type information cannot be properly inferred. " +
+                            "Please pass a 'TypeHint' instead of a class to describe the type. " +
+                            "For example, to describe 'Tuple2<String, String>' as a generic type, use " +
+                            "'new PravegaDeserializationSchema<>(new TypeHint<Tuple2<String, String>>(){}, serializer);'"
             );
         }
     }

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderTest.java
@@ -35,6 +35,8 @@ import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.client.stream.impl.EventPointerImpl;
 import io.pravega.client.stream.impl.EventReadImpl;
 import io.pravega.client.stream.impl.StreamCutImpl;
+import io.pravega.connectors.flink.serialization.DeserializerFromSchemaRegistry;
+import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
 import io.pravega.connectors.flink.serialization.PravegaDeserializationSchemaWithMetadata;
 import io.pravega.connectors.flink.utils.IntegerDeserializationSchema;
 import io.pravega.connectors.flink.utils.IntegerSerializer;
@@ -352,7 +354,8 @@ public class FlinkPravegaReaderTest {
             FlinkPravegaReader.<Integer>builder()
                     .withPravegaConfig(pravegaConfig)
                     .forStream("stream")
-                    .withDeserializationSchemaFromRegistry("stream", Integer.class)
+                    .withDeserializationSchema(new PravegaDeserializationSchema<>(Integer.class,
+                            new DeserializerFromSchemaRegistry<>(pravegaConfig, "stream", Integer.class)))
                     .build();
             fail();
         } catch (NullPointerException e) {
@@ -364,7 +367,8 @@ public class FlinkPravegaReaderTest {
             FlinkPravegaReader.<Integer>builder()
                     .withPravegaConfig(pravegaConfig)
                     .forStream("stream")
-                    .withDeserializationSchemaFromRegistry("stream", Integer.class)
+                    .withDeserializationSchema(new PravegaDeserializationSchema<>(Integer.class,
+                            new DeserializerFromSchemaRegistry<>(pravegaConfig, "stream", Integer.class)))
                     .build();
             fail();
         } catch (NullPointerException e) {

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaSchemaRegistryWriterTestITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaSchemaRegistryWriterTestITCase.java
@@ -34,6 +34,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.junit.AfterClass;
@@ -131,7 +132,7 @@ public class FlinkPravegaSchemaRegistryWriterTestITCase {
             @Override
             public void cancel() {
             }
-        }).addSink(writer);
+        }, new GenericRecordAvroTypeInfo(SCHEMA)).addSink(writer);
 
         try {
             env.execute("Schema Registry Read");


### PR DESCRIPTION
Signed-off-by: thekingofcity <3353040+thekingofcity@users.noreply.github.com>

**Change log description**
Schema Registry will upgrade the internal Avro to 1.11 which will break the compatibility of the current implementation.

**Purpose of the change**
Fix #675 

**What the code does**
Remove `withDeserializationSchemaFromRegistry` and use schema-specific `PravegaDeserializationSchema` in `withDeserializationSchema`.

**How to verify it**
`.\gradlew clean build` passes.
