### PR TITLE
[issue-680] Update connector version to 0.11.1-SNAPSHOT on r0.11 branch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -36,8 +36,8 @@ hamcrestVersion=2.2
 nettyVersion=4.1.65.Final
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.11.0-SNAPSHOT
-pravegaVersion=0.11.0
+connectorVersion=0.11.1-SNAPSHOT
+pravegaVersion=0.11.1-3057.de5dccf-SNAPSHOT
 schemaRegistryVersion=0.4.0-80.1629800-SNAPSHOT
 apacheCommonsVersion=3.7
 


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Update connector and Pravega version to `0.11.1-SNAPSHOT`

**Purpose of the change**
Fix #680 

**What the code does**
Update `connectorVersion` and `pravegaVersion` in `gradle.properties`

**How to verify it**
`./gradlew clean build` should pass
