### PR TITLE
[Issue-685] Change deprecated usage of `DeleteScope` API

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/PravegaCatalog.java
+++ b/src/main/java/io/pravega/connectors/flink/table/catalog/pravega/PravegaCatalog.java
@@ -228,7 +228,7 @@ public class PravegaCatalog extends AbstractCatalog {
         }
 
         try {
-            streamManager.deleteScope(name, cascade);
+            streamManager.deleteScopeRecursive(name);
         } catch (DeleteScopeFailedException e) {
             throw new CatalogException(String.format("Failed to drop database %s", name));
         }


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Change the usage of deprecated `deleteScope()` API to a new `deleteScopeRecursive()` API as introduced in Pravega 0.11.0(ref: https://github.com/pravega/pravega/pull/6312).

**Purpose of the change**
Fix #685 

**What the code does**
Change `deleteScope()` to `deleteScopeRecursive()` in `PravegaCatalog`

**How to verify it**
`./gradlew clean build` should pass