### PR TITLE
[Issue-664] Migrate from JUnit4 to JUnit5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,8 @@ dependencies {
     testImplementation group: 'org.apache.flink', name: 'flink-avro', version: flinkVersion
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: hamcrestVersion
     testImplementation group: 'org.testcontainers', name: 'testcontainers', version: testcontainersVersion
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junit5Version
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: assertjVersion
 }
 
 javadoc {
@@ -171,4 +173,5 @@ def getProjectVersion() {
 // for e.g., to use standalone Pravega for running the system test "./gradlew clean build -Dpravega.uri=tcp://localhost:9090"
 test {
     systemProperties = System.properties
+    useJUnitPlatform()
 }

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -16,6 +16,7 @@
     <allow pkg="io.pravega"/>
     <allow pkg="org.apache"/>
     <allow pkg="edu.umd.cs.findbugs"/>
+    <allow pkg="org.assertj"/>
 
     <!-- test dependencies -->
     <allow pkg="org.mockito"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@
 #
 
 # 3rd party Versions.
+assertjVersion=3.23.1
 checkstyleToolVersion=7.1
 flinkVersion=1.15.0
 flinkScalaVersion=2.12
@@ -23,6 +24,7 @@ twitterMvnRepoVersion=4.3.4-TWTTR
 shadowGradlePlugin=7.0.0
 slf4jApiVersion=1.7.25
 junitVersion=4.12
+junit5Version=5.8.1
 mockitoVersion=3.3.3
 gradleGitPluginVersion=4.1.0
 spotbugsVersion=4.0.6

--- a/src/test/java/io/pravega/connectors/flink/EventTimeOrderingFunctionTest.java
+++ b/src/test/java/io/pravega/connectors/flink/EventTimeOrderingFunctionTest.java
@@ -23,9 +23,9 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
 import org.apache.flink.streaming.util.TestHarnessUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -40,7 +40,7 @@ public class EventTimeOrderingFunctionTest {
     private EventTimeOrderingFunction<Tuple2<String, Long>> function;
     private KeyedOneInputStreamOperatorTestHarness<String, Tuple2<String, Long>, Tuple2<String, Long>> testHarness;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         function = new EventTimeOrderingFunction<>(TypeInformation.of(new TypeHint<Tuple2<String, Long>>() {
         }));
@@ -48,7 +48,7 @@ public class EventTimeOrderingFunctionTest {
         testHarness.open();
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         testHarness.close();
         function.close();

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatITCase.java
@@ -29,31 +29,28 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.test.util.AbstractTestBase;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Timeout(value = 120)
 public class FlinkPravegaInputFormatITCase extends AbstractTestBase {
 
     private static final PravegaTestEnvironment PRAVEGA = new PravegaTestEnvironment(PravegaRuntime.container());
 
-    @Rule
-    public final Timeout globalTimeout = new Timeout(120, TimeUnit.SECONDS);
-
-    @BeforeClass
+    @BeforeAll
     public static void setupPravega() throws Exception {
         PRAVEGA.startUp();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownPravega() throws Exception {
         PRAVEGA.tearDown();
     }
@@ -124,10 +121,10 @@ public class FlinkPravegaInputFormatITCase extends AbstractTestBase {
             );
 
             // verify that all events were read
-            Assert.assertEquals(numElements1 + numElements2, integers.collect().size());
+            assertThat(integers.collect().size()).isEqualTo(numElements1 + numElements2);
 
             // this verifies that the input format allows multiple passes
-            Assert.assertEquals(numElements1 + numElements2, integers.collect().size());
+            assertThat(integers.collect().size()).isEqualTo(numElements1 + numElements2);
         }
     }
 
@@ -173,8 +170,8 @@ public class FlinkPravegaInputFormatITCase extends AbstractTestBase {
             ).map(new FailOnceMapper(numElements / 2)).collect();
 
             // verify that the job did fail, and all events were still read
-            Assert.assertTrue(FailOnceMapper.hasFailed());
-            Assert.assertEquals(numElements, integers.size());
+            assertThat(FailOnceMapper.hasFailed()).isTrue();
+            assertThat(integers.size()).isEqualTo(numElements);
 
             FailOnceMapper.reset();
         }

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaInputFormatTest.java
@@ -26,12 +26,13 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.apache.flink.api.common.io.DefaultInputSplitAssigner;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.Iterator;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
@@ -78,27 +79,31 @@ public class FlinkPravegaInputFormatTest {
     /**
      * Testing the builder for missing configurations.
      */
-    @Test (expected = IllegalStateException.class)
+    @Test
     public void testBuilderForMissingDeSerializationSchema() {
         doReturn(clientConfig).when(pravegaConfig).getClientConfig();
         doReturn(stream).when(pravegaConfig).resolve(anyString());
-        FlinkPravegaInputFormat.<String>builder()
-                .withPravegaConfig(pravegaConfig)
-                .forStream(stream)
-                .build();
+        assertThatThrownBy(
+                () -> FlinkPravegaInputFormat.<String>builder()
+                        .withPravegaConfig(pravegaConfig)
+                        .forStream(stream)
+                        .build())
+                .isInstanceOf(IllegalStateException.class);
     }
 
     /**
      * Testing the builder for missing configurations.
      */
-    @Test (expected = IllegalStateException.class)
+    @Test
     public void testBuilderForMissingStream() {
         doReturn(clientConfig).when(pravegaConfig).getClientConfig();
         doReturn(stream).when(pravegaConfig).resolve(anyString());
-        FlinkPravegaInputFormat.<String>builder()
-                .withDeserializationSchema(deserializationSchema)
-                .withPravegaConfig(pravegaConfig)
-                .build();
+        assertThatThrownBy(
+                () -> FlinkPravegaInputFormat.<String>builder()
+                        .withDeserializationSchema(deserializationSchema)
+                        .withPravegaConfig(pravegaConfig)
+                        .build())
+                .isInstanceOf(IllegalStateException.class);
     }
 
     /**
@@ -113,7 +118,7 @@ public class FlinkPravegaInputFormatTest {
                     .forStream("stream")
                     .withDeserializationSchemaFromRegistry("stream", Integer.class)
                     .build();
-            fail();
+            fail(null);
         } catch (NullPointerException e) {
             // "missing default scope"
         }
@@ -125,7 +130,7 @@ public class FlinkPravegaInputFormatTest {
                     .forStream("stream")
                     .withDeserializationSchemaFromRegistry("stream", Integer.class)
                     .build();
-            fail();
+            fail(null);
         } catch (NullPointerException e) {
             // "missing Schema Registry URI"
         }

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatITCase.java
@@ -25,30 +25,27 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.test.util.AbstractTestBase;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Timeout(value = 120)
 public class FlinkPravegaOutputFormatITCase extends AbstractTestBase {
 
     private static final PravegaTestEnvironment PRAVEGA = new PravegaTestEnvironment(PravegaRuntime.container());
 
-    @Rule
-    public final Timeout globalTimeout = new Timeout(120, TimeUnit.SECONDS);
-
-    @BeforeClass
+    @BeforeAll
     public static void setupPravega() throws Exception {
         PRAVEGA.startUp();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownPravega() throws Exception {
         PRAVEGA.tearDown();
     }
@@ -92,7 +89,7 @@ public class FlinkPravegaOutputFormatITCase extends AbstractTestBase {
         );
 
         // verify that all events were read
-        Assert.assertEquals(2, integers.collect().size());
+        assertThat(integers.collect().size()).isEqualTo(2);
     }
 
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaOutputFormatTest.java
@@ -23,8 +23,7 @@ import io.pravega.connectors.flink.utils.DirectExecutorService;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -32,9 +31,9 @@ import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
@@ -73,37 +72,41 @@ public class FlinkPravegaOutputFormatTest {
                 .withPravegaConfig(pravegaConfig)
                 .forStream(stream)
                 .build();
-        assertEquals(stream.getScope(), outputFormat.getScope());
-        assertEquals(stream.getStreamName(), outputFormat.getStream());
-        assertEquals(serializationSchema, outputFormat.getSerializationSchema());
-        assertEquals(eventRouter, outputFormat.getEventRouter());
+        assertThat(outputFormat.getScope()).isEqualTo(stream.getScope());
+        assertThat(outputFormat.getStream()).isEqualTo(stream.getStreamName());
+        assertThat(outputFormat.getSerializationSchema()).isEqualTo(serializationSchema);
+        assertThat(outputFormat.getEventRouter()).isEqualTo(eventRouter);
     }
 
     /**
      * Testing the builder for right configurations.
      * Should fail since we don't pass {@link SerializationSchema}
      */
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testBuilderForFailure1() {
         PravegaConfig pravegaConfig = mock(PravegaConfig.class);
-        FlinkPravegaOutputFormat.<String>builder()
-                .withEventRouter(eventRouter)
-                .withPravegaConfig(pravegaConfig)
-                .forStream(stream)
-                .build();
+        assertThatThrownBy(
+                () -> FlinkPravegaOutputFormat.<String>builder()
+                        .withEventRouter(eventRouter)
+                        .withPravegaConfig(pravegaConfig)
+                        .forStream(stream)
+                        .build())
+                .isInstanceOf(NullPointerException.class);
     }
 
     /**
      * Testing the builder for right configurations.
      * Should fail since we don't pass {@link Stream}
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testBuilderForFailure2() {
-        FlinkPravegaOutputFormat.<String>builder()
-                .withEventRouter(eventRouter)
-                .withSerializationSchema(serializationSchema)
-                .withPravegaConfig(pravegaConfig)
-                .build();
+        assertThatThrownBy(
+                () -> FlinkPravegaOutputFormat.<String>builder()
+                        .withEventRouter(eventRouter)
+                        .withSerializationSchema(serializationSchema)
+                        .withPravegaConfig(pravegaConfig)
+                        .build())
+                .isInstanceOf(IllegalStateException.class);
     }
 
     /**
@@ -133,7 +136,7 @@ public class FlinkPravegaOutputFormatTest {
 
         // test writeRecord success
         spyFlinkPravegaOutputFormat.writeRecord("test-1");
-        assertEquals(1, spyFlinkPravegaOutputFormat.getPendingWritesCount().get());
+        assertThat(spyFlinkPravegaOutputFormat.getPendingWritesCount().get()).isEqualTo(1);
         writeFuture.complete(null);
 
         // test writeRecord induce failure
@@ -144,17 +147,17 @@ public class FlinkPravegaOutputFormatTest {
         try {
             spyFlinkPravegaOutputFormat.writeRecord("test-3");
         } catch (Exception e) {
-            Assert.assertTrue(e instanceof IOException);
-            assertTrue(spyFlinkPravegaOutputFormat.isErrorOccurred());
-            assertEquals("test simulated", e.getCause().getMessage());
-            assertEquals(0, spyFlinkPravegaOutputFormat.getPendingWritesCount().get());
+            assertThat(e instanceof IOException).isTrue();
+            assertThat(spyFlinkPravegaOutputFormat.isErrorOccurred()).isTrue();
+            assertThat(e.getCause().getMessage()).isEqualTo("test simulated");
+            assertThat(spyFlinkPravegaOutputFormat.getPendingWritesCount().get()).isEqualTo(0);
         }
 
         // test close error
         try {
             spyFlinkPravegaOutputFormat.close();
         } catch (Exception e) {
-            Assert.assertTrue(e instanceof IOException);
+            assertThat(e instanceof IOException).isTrue();
         }
 
         // test close
@@ -173,7 +176,7 @@ public class FlinkPravegaOutputFormatTest {
                     .forStream("stream")
                     .withSerializationSchemaFromRegistry("stream", Integer.class)
                     .build();
-            fail();
+            fail(null);
         } catch (NullPointerException e) {
             // "missing default scope"
         }
@@ -185,7 +188,7 @@ public class FlinkPravegaOutputFormatTest {
                     .forStream("stream")
                     .withSerializationSchemaFromRegistry("stream", Integer.class)
                     .build();
-            fail();
+            fail(null);
         } catch (NullPointerException e) {
             // "missing Schema Registry URI"
         }

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderITCase.java
@@ -36,18 +36,17 @@ import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.Collector;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import java.util.concurrent.TimeUnit;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Integration tests for {@link FlinkPravegaReader}.
  */
+@Timeout(value = 180)
 public class FlinkPravegaReaderITCase extends AbstractTestBase {
 
     // Number of events to produce into the test stream.
@@ -55,16 +54,12 @@ public class FlinkPravegaReaderITCase extends AbstractTestBase {
 
     private static final PravegaTestEnvironment PRAVEGA = new PravegaTestEnvironment(PravegaRuntime.container());
 
-    //Ensure each test completes within 180 seconds.
-    @Rule
-    public final Timeout globalTimeout = new Timeout(180, TimeUnit.SECONDS);
-
-    @BeforeClass
+    @BeforeAll
     public static void setupPravega() throws Exception {
         PRAVEGA.startUp();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownPravega() throws Exception {
         PRAVEGA.tearDown();
     }
@@ -154,7 +149,7 @@ public class FlinkPravegaReaderITCase extends AbstractTestBase {
                 }
 
                 if (!(ExceptionUtils.getRootCause(e) instanceof SuccessException)) {
-                    Assert.fail("Unexpected error occurred in the test. " + ExceptionUtils.getRootCauseMessage(e));
+                    fail("Unexpected error occurred in the test. " + ExceptionUtils.getRootCauseMessage(e));
                 }
             }
 

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderRGStateITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderRGStateITCase.java
@@ -38,18 +38,17 @@ import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.AbstractTestBase;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Test case that validates the following.
@@ -60,6 +59,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * 6. Flink restart strategy should kick in and the reader hook should reinitialize the state of the readers to beginning position
  * 7. Validate and make sure that we are not missing any events.
  */
+@Timeout(value = 180)
 public class FlinkPravegaReaderRGStateITCase extends AbstractTestBase {
 
     // Number of events to produce into the test stream.
@@ -67,15 +67,12 @@ public class FlinkPravegaReaderRGStateITCase extends AbstractTestBase {
 
     private static final PravegaTestEnvironment PRAVEGA = new PravegaTestEnvironment(PravegaRuntime.container());
 
-    @Rule
-    public final Timeout globalTimeout = new Timeout(180, TimeUnit.SECONDS);
-
-    @BeforeClass
+    @BeforeAll
     public static void setupPravega() throws Exception {
         PRAVEGA.startUp();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownPravega() throws Exception {
         PRAVEGA.tearDown();
     }
@@ -132,7 +129,7 @@ public class FlinkPravegaReaderRGStateITCase extends AbstractTestBase {
             } catch (Exception e) {
                 if (!(ExceptionUtils.getRootCause(e) instanceof SuccessException)) {
                     log.error("testReaderState failed with exception", e);
-                    Assert.fail();
+                    fail(null);
                 }
             }
         }

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaReaderSavepointITCase.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -145,7 +144,7 @@ public class FlinkPravegaReaderSavepointITCase extends TestLogger {
             for (int attempt = 1; savepointPath == null && attempt <= 5; attempt++) {
                 savepointPath = MINI_CLUSTER.triggerSavepoint(
                         program1.getJobID(),
-                        Files.createTempDirectory(tmpFolder.toString()).toString(),
+                        tmpFolder.toFile().getAbsolutePath(),
                         false,
                         SavepointFormatType.CANONICAL).get();
             }
@@ -201,7 +200,7 @@ public class FlinkPravegaReaderSavepointITCase extends TestLogger {
         // checkpoint to files (but aggregate state below 1 MB) and don't to any async checkpoints
         env.getCheckpointConfig().setCheckpointStorage(
                 new FileSystemCheckpointStorage(
-                        Files.createTempDirectory(tmpFolder.toString()).toFile().toURI(), 1024 * 1024));
+                       tmpFolder.toFile().toURI(), 1024 * 1024));
 
         // the Pravega reader
         final FlinkPravegaReader<Integer> pravegaSource = FlinkPravegaReader.<Integer>builder()

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaSchemaRegistryReaderTestITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaSchemaRegistryReaderTestITCase.java
@@ -36,16 +36,16 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Timeout(value = 180)
 public class FlinkPravegaSchemaRegistryReaderTestITCase {
 
     private static class MyTest {
@@ -65,16 +65,12 @@ public class FlinkPravegaSchemaRegistryReaderTestITCase {
     private static final GenericRecord AVRO_EVENT = new GenericRecordBuilder(SCHEMA).set("name", "test").build();
     private static final MyTest JSON_EVENT = new MyTest("test");
 
-    //Ensure each test completes within 180 seconds.
-    @Rule
-    public final Timeout globalTimeout = new Timeout(180, TimeUnit.SECONDS);
-
-    @BeforeClass
+    @BeforeAll
     public static void setupServices() {
         SCHEMA_REGISTRY.startUp();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownServices() {
         SCHEMA_REGISTRY.tearDown();
     }
@@ -200,8 +196,8 @@ public class FlinkPravegaSchemaRegistryReaderTestITCase {
                 .build();
 
         List<GenericRecord> result = env.createInput(reader, new GenericRecordAvroTypeInfo(SCHEMA)).collect();
-        Assert.assertEquals(result.size(), 1);
-        Assert.assertEquals(result.get(0), AVRO_EVENT);
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0)).isEqualTo(AVRO_EVENT);
     }
 
     // ================================================================================

--- a/src/test/java/io/pravega/connectors/flink/FlinkPravegaSchemaRegistryWriterTestITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkPravegaSchemaRegistryWriterTestITCase.java
@@ -38,16 +38,16 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Timeout(value = 180)
 public class FlinkPravegaSchemaRegistryWriterTestITCase {
 
     private static class MyTest {
@@ -90,16 +90,12 @@ public class FlinkPravegaSchemaRegistryWriterTestITCase {
     private static final User AVRO_SPEC_EVENT = User.newBuilder().setName("test").build();
     private static final MyTest JSON_EVENT = new MyTest("test");
 
-    //Ensure each test completes within 180 seconds.
-    @Rule
-    public final Timeout globalTimeout = new Timeout(180, TimeUnit.SECONDS);
-
-    @BeforeClass
+    @BeforeAll
     public static void setupServices() throws Exception {
         SCHEMA_REGISTRY.startUp();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownServices() throws Exception {
         SCHEMA_REGISTRY.tearDown();
     }
@@ -141,7 +137,7 @@ public class FlinkPravegaSchemaRegistryWriterTestITCase {
         final EventRead<GenericRecord> eventRead = reader.readNextEvent(1000);
         final GenericRecord event = eventRead.getEvent();
 
-        Assert.assertEquals(event, AVRO_GEN_EVENT);
+        assertThat(event).isEqualTo(AVRO_GEN_EVENT);
     }
 
     @Test
@@ -181,7 +177,7 @@ public class FlinkPravegaSchemaRegistryWriterTestITCase {
         final EventRead<User> eventRead = reader.readNextEvent(1000);
         final User event = eventRead.getEvent();
 
-        Assert.assertEquals(event, AVRO_SPEC_EVENT);
+        assertThat(event).isEqualTo(AVRO_SPEC_EVENT);
     }
 
     @Test
@@ -221,7 +217,7 @@ public class FlinkPravegaSchemaRegistryWriterTestITCase {
         final EventRead<MyTest> eventRead = reader.readNextEvent(1000);
         final MyTest event = eventRead.getEvent();
 
-        Assert.assertEquals(event, JSON_EVENT);
+        assertThat(event).isEqualTo(JSON_EVENT);
     }
 
     @Test
@@ -251,7 +247,7 @@ public class FlinkPravegaSchemaRegistryWriterTestITCase {
         final EventRead<GenericRecord> eventRead = reader.readNextEvent(1000);
         final GenericRecord event = eventRead.getEvent();
 
-        Assert.assertEquals(event, AVRO_GEN_EVENT);
+        assertThat(event).isEqualTo(AVRO_GEN_EVENT);
     }
 
     // ================================================================================

--- a/src/test/java/io/pravega/connectors/flink/FlinkSerializerWrapperTest.java
+++ b/src/test/java/io/pravega/connectors/flink/FlinkSerializerWrapperTest.java
@@ -17,14 +17,14 @@ package io.pravega.connectors.flink;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Random;
 
 import static io.pravega.connectors.flink.util.FlinkPravegaUtils.byteBufferToArray;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FlinkSerializerWrapperTest {
 
@@ -66,7 +66,7 @@ public class FlinkSerializerWrapperTest {
             buffer.flip();
 
             long deserialized = deserializationSchema.deserialize(byteBufferToArray(buffer));
-            assertEquals(value, deserialized);
+            assertThat(deserialized).isEqualTo(value);
         }
     }
 

--- a/src/test/java/io/pravega/connectors/flink/PravegaInputSplitTest.java
+++ b/src/test/java/io/pravega/connectors/flink/PravegaInputSplitTest.java
@@ -16,13 +16,12 @@
 package io.pravega.connectors.flink;
 
 import io.pravega.client.batch.SegmentRange;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PravegaInputSplitTest {
 
@@ -42,7 +41,7 @@ public class PravegaInputSplitTest {
     PravegaInputSplit mockSplitNullSegmentRange2;
 
 
-    @Before
+    @BeforeEach
     public void setupMocks() throws Exception {
         MockitoAnnotations.initMocks(this);
     }
@@ -53,10 +52,10 @@ public class PravegaInputSplitTest {
         PravegaInputSplit split2 = new PravegaInputSplit(12345, range1);
 
         // compare one to itself
-        assertTrue(split1.equals(split1));
+        assertThat(split1.equals(split1)).isTrue();
 
         // compare one to the other
-        assertTrue(split1.equals(split2));
+        assertThat(split1.equals(split2)).isTrue();
 
     }
 
@@ -66,14 +65,14 @@ public class PravegaInputSplitTest {
 
         PravegaInputSplit split1 = new PravegaInputSplit(12345, range1);
         PravegaInputSplit split2 = new PravegaInputSplit(12345, range2);
-        assertFalse(split1.equals(split2));
+        assertThat(split1.equals(split2)).isFalse();
 
         PravegaInputSplit split3 = new PravegaInputSplit(12345, range1);
         PravegaInputSplit split4 = new PravegaInputSplit(67890, range1);
-        assertFalse(split3.equals(split4));
+        assertThat(split3.equals(split4)).isFalse();
 
         String str = "dummy";
-        assertFalse(split3.equals(str));
+        assertThat(split3).isNotEqualTo(str);
 
     }
 

--- a/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
+++ b/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
@@ -28,18 +28,14 @@ import io.pravega.client.stream.impl.StreamCutImpl;
 import io.pravega.connectors.flink.serialization.CheckpointSerializer;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.util.concurrent.Executors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -58,8 +54,8 @@ public class ReaderCheckpointHookTest {
         ReaderGroupConfig readerGroupConfig = mock(ReaderGroupConfig.class);
         ClientConfig clientConfig = mock(ClientConfig.class);
         TestableReaderCheckpointHook hook = new TestableReaderCheckpointHook(HOOK_UID, READER_GROUP_NAME, SCOPE, Time.minutes(1), clientConfig, readerGroupConfig);
-        assertEquals(HOOK_UID, hook.getIdentifier());
-        assertTrue(hook.createCheckpointDataSerializer() instanceof CheckpointSerializer);
+        assertThat(hook.getIdentifier()).isEqualTo(HOOK_UID);
+        assertThat(hook.createCheckpointDataSerializer() instanceof CheckpointSerializer).isTrue();
     }
 
     @Test
@@ -71,14 +67,14 @@ public class ReaderCheckpointHookTest {
 
         when(hook.readerGroup.initiateCheckpoint(anyString(), any())).thenReturn(checkpointPromise);
         CompletableFuture<Checkpoint> checkpointFuture = hook.triggerCheckpoint(1L, 1L, Executors.directExecutor());
-        assertNotNull(checkpointFuture);
+        assertThat(checkpointFuture).isNotNull();
         verify(hook.readerGroup).initiateCheckpoint(anyString(), any());
 
         // complete the checkpoint promise
         Checkpoint expectedCheckpoint = mock(Checkpoint.class);
         checkpointPromise.complete(expectedCheckpoint);
-        assertTrue(checkpointFuture.isDone());
-        assertSame(expectedCheckpoint, checkpointFuture.get());
+        assertThat(checkpointFuture.isDone()).isTrue();
+        assertThat(checkpointFuture.get()).isSameAs(expectedCheckpoint);
     }
 
     @Test
@@ -91,12 +87,12 @@ public class ReaderCheckpointHookTest {
         when(hook.readerGroup.initiateCheckpoint(anyString(), any())).thenReturn(checkpointPromise);
 
         CompletableFuture<Checkpoint> checkpointFuture = hook.triggerCheckpoint(1L, 1L, Executors.directExecutor());
-        assertNotNull(checkpointFuture);
+        assertThat(checkpointFuture).isNotNull();
         verify(hook.readerGroup).initiateCheckpoint(anyString(), any());
 
         // invoke the timeout callback
         hook.invokeScheduledCallables();
-        assertTrue(checkpointFuture.isCancelled());
+        assertThat(checkpointFuture.isCancelled()).isTrue();
     }
 
     @Test
@@ -116,7 +112,7 @@ public class ReaderCheckpointHookTest {
         hook.close();
         verify(hook.readerGroup).close();
         verify(hook.readerGroupManager).close();
-        assertNull(hook.getScheduledExecutorService());
+        assertThat(hook.getScheduledExecutorService()).isNull();
     }
 
     @Test

--- a/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistryFormatFactoryTest.java
+++ b/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistryFormatFactoryTest.java
@@ -42,14 +42,13 @@ import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContex
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.TestLogger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link PravegaRegistryFormatFactory}. */
 public class PravegaRegistryFormatFactoryTest extends TestLogger {
@@ -97,7 +96,7 @@ public class PravegaRegistryFormatFactoryTest extends TestLogger {
         final Map<String, String> options = getAllOptions();
 
         final DynamicTableSource actualSource = createTableSource(options);
-        assertTrue(actualSource instanceof TestDynamicTableFactory.DynamicTableSourceMock);
+        assertThat(actualSource instanceof TestDynamicTableFactory.DynamicTableSourceMock).isTrue();
         TestDynamicTableFactory.DynamicTableSourceMock sourceMock =
                 (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
 
@@ -105,7 +104,7 @@ public class PravegaRegistryFormatFactoryTest extends TestLogger {
                 sourceMock.valueFormat.createRuntimeDecoder(
                         ScanRuntimeProviderContext.INSTANCE, RESOLVED_SCHEMA.toPhysicalRowDataType());
 
-        assertEquals(expectedDeser, actualDeser);
+        assertThat(actualDeser).isEqualTo(expectedDeser);
 
         final PravegaRegistryRowDataSerializationSchema expectedSer =
                 new PravegaRegistryRowDataSerializationSchema(
@@ -119,14 +118,14 @@ public class PravegaRegistryFormatFactoryTest extends TestLogger {
                         ENCODE_DECIMAL_AS_PLAIN_NUMBER);
 
         final DynamicTableSink actualSink = createTableSink(options);
-        assertTrue(actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock);
+        assertThat(actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock).isTrue();
         TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
                 (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
 
         SerializationSchema<RowData> actualSer =
                 sinkMock.valueFormat.createRuntimeEncoder(null, RESOLVED_SCHEMA.toPhysicalRowDataType());
 
-        assertEquals(expectedSer, actualSer);
+        assertThat(actualSer).isEqualTo(expectedSer);
     }
 
     // ------------------------------------------------------------------------

--- a/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/formats/registry/PravegaRegistrySeDeITCase.java
@@ -46,9 +46,9 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -84,8 +84,7 @@ import static org.apache.flink.table.api.DataTypes.TIME;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Intergration Test for Pravega Registry serialization and deserialization schema. */
 @SuppressWarnings("checkstyle:StaticVariableName")
@@ -118,12 +117,12 @@ public class PravegaRegistrySeDeITCase {
     private static final SchemaRegistryTestEnvironment SCHEMA_REGISTRY =
             new SchemaRegistryTestEnvironment(PravegaRuntime.container(), SchemaRegistryRuntime.container());
 
-    @BeforeClass
+    @BeforeAll
     public static void setupPravega() throws Exception {
         SCHEMA_REGISTRY.startUp();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownPravega() throws Exception {
         SCHEMA_REGISTRY.tearDown();
     }
@@ -222,7 +221,7 @@ public class PravegaRegistrySeDeITCase {
         RowData rowData = deserializationSchema.deserialize(input);
         byte[] output = serializationSchema.serialize(rowData);
 
-        assertArrayEquals(input, output);
+        assertThat(output).isEqualTo(input);
 
         avroCatalog.close();
     }
@@ -347,7 +346,7 @@ public class PravegaRegistrySeDeITCase {
 
         RowData rowData = deserializationSchema.deserialize(serializedJson);
         Row actual = convertToExternal(rowData, jsonDataType);
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
         // test serialization
         PravegaRegistryRowDataSerializationSchema serializationSchema =
@@ -359,7 +358,7 @@ public class PravegaRegistrySeDeITCase {
         serializationSchema.open(null);
 
         byte[] actualBytes = serializationSchema.serialize(rowData);
-        assertEquals(new String(serializedJson), new String(actualBytes));
+        assertThat(new String(actualBytes)).isEqualTo(new String(serializedJson));
 
         jsonCatalog.close();
     }

--- a/src/test/java/io/pravega/connectors/flink/serialization/PravegaSerializationTest.java
+++ b/src/test/java/io/pravega/connectors/flink/serialization/PravegaSerializationTest.java
@@ -19,7 +19,7 @@ import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.connectors.flink.PravegaCollector;
 import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -27,8 +27,7 @@ import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PravegaSerializationTest {
 
@@ -39,7 +38,7 @@ public class PravegaSerializationTest {
 
         String input = "Testing input";
         byte[] serialized = serializer.serialize(input);
-        assertEquals(input, deserializer.deserialize(serialized));
+        assertThat(deserializer.deserialize(serialized)).isEqualTo(input);
     }
 
     @Test
@@ -52,10 +51,10 @@ public class PravegaSerializationTest {
 
         PravegaCollector<String> pravegaCollector = new PravegaCollector<>(deserializer);
         deserializer.deserialize(serialized, pravegaCollector);
-        assertEquals(1, pravegaCollector.getRecords().size());
+        assertThat(pravegaCollector.getRecords().size()).isEqualTo(1);
 
         String deserialized = pravegaCollector.getRecords().poll();
-        assertEquals(input, deserialized);
+        assertThat(deserialized).isEqualTo(input);
     }
 
     @Test
@@ -82,7 +81,7 @@ public class PravegaSerializationTest {
             final long value = rnd.nextLong();
 
             byte[] serialized = flinkSerializer.serialize(value);
-            assertEquals(value, ByteBuffer.wrap(serialized).getLong());
+            assertThat(ByteBuffer.wrap(serialized).getLong()).isEqualTo(value);
         }
     }
 
@@ -97,10 +96,10 @@ public class PravegaSerializationTest {
             final long value = rnd.nextLong();
 
             byte[] serialized = flinkSerializer.serialize(value);
-            assertEquals(value, ByteBuffer.wrap(serialized).getLong());
+            assertThat(ByteBuffer.wrap(serialized).getLong()).isEqualTo(value);
 
             // make sure we avoid copies where possible
-            assertTrue(serialized == pravegaSerializer.array);
+            assertThat(serialized == pravegaSerializer.array).isTrue();
         }
     }
 
@@ -168,7 +167,7 @@ public class PravegaSerializationTest {
         final JsonSerializer<TestEvent> jsonSerializer = new JsonSerializer<>(TestEvent.class);
         TestEvent testEvent = new TestEvent("key1", 1);
         ByteBuffer serializedBytes = jsonSerializer.serialize(testEvent);
-        assertEquals(testEvent, jsonSerializer.deserialize(serializedBytes));
+        assertThat(jsonSerializer.deserialize(serializedBytes)).isEqualTo(testEvent);
     }
 
     // ------------------------------------------------------------------------

--- a/src/test/java/io/pravega/connectors/flink/sink/PravegaTransactionStateSerializerTest.java
+++ b/src/test/java/io/pravega/connectors/flink/sink/PravegaTransactionStateSerializerTest.java
@@ -15,11 +15,11 @@
  */
 package io.pravega.connectors.flink.sink;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PravegaTransactionStateSerializerTest {
 
@@ -30,6 +30,6 @@ public class PravegaTransactionStateSerializerTest {
         final String transactionId = "00000000-0000-0000-0000-000000000001";
         final PravegaTransactionState transactionState = new PravegaTransactionState(transactionId);
         final byte[] serialized = SERIALIZER.serialize(transactionState);
-        assertEquals(transactionState, SERIALIZER.deserialize(1, serialized));
+        assertThat(SERIALIZER.deserialize(1, serialized)).isEqualTo(transactionState);
     }
 }

--- a/src/test/java/io/pravega/connectors/flink/sink/PravegaTransactionStateTest.java
+++ b/src/test/java/io/pravega/connectors/flink/sink/PravegaTransactionStateTest.java
@@ -15,9 +15,9 @@
  */
 package io.pravega.connectors.flink.sink;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +29,7 @@ public class PravegaTransactionStateTest {
     public void testInit() {
         PravegaTransactionWriter<Integer> writer = mockPravegaTransactionWriter();
         PravegaTransactionState transactionState = PravegaTransactionState.of(writer);
-        Assert.assertEquals(transactionState.getTransactionId(), TRANSACTION_ID);
+        assertThat(transactionState.getTransactionId()).isEqualTo(TRANSACTION_ID);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/pravega/connectors/flink/source/FlinkPravegaSourceITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/source/FlinkPravegaSourceITCase.java
@@ -32,14 +32,14 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.TimeUnit;
 
+@Timeout(value = 120, unit = TimeUnit.MINUTES)
 public class FlinkPravegaSourceITCase {
 
     // Number of events to produce into the test stream.
@@ -47,15 +47,12 @@ public class FlinkPravegaSourceITCase {
 
     private static final PravegaTestEnvironment PRAVEGA = new PravegaTestEnvironment(PravegaRuntime.container());
 
-    @Rule
-    public final Timeout globalTimeout = new Timeout(120, TimeUnit.MINUTES);
-
-    @BeforeClass
+    @BeforeAll
     public static void setupPravega() throws Exception {
         PRAVEGA.startUp();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownPravega() throws Exception {
         PRAVEGA.tearDown();
     }

--- a/src/test/java/io/pravega/connectors/flink/source/reader/FlinkPravegaSourceReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/source/reader/FlinkPravegaSourceReaderTest.java
@@ -35,16 +35,17 @@ import org.apache.flink.connector.testutils.source.reader.SourceReaderTestBase;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
 import org.apache.flink.core.io.InputStatus;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for {@link PravegaSourceReader}. */
 public class FlinkPravegaSourceReaderTest extends SourceReaderTestBase<PravegaSplit> {
@@ -57,12 +58,12 @@ public class FlinkPravegaSourceReaderTest extends SourceReaderTestBase<PravegaSp
 
     private String readerGroupName;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupPravega() throws Exception {
         PRAVEGA.startUp();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownPravega() throws Exception {
         PRAVEGA.tearDown();
     }
@@ -90,7 +91,7 @@ public class FlinkPravegaSourceReaderTest extends SourceReaderTestBase<PravegaSp
             ReaderOutput<Integer> output = new TestingReaderOutput<>();
 
             InputStatus status = reader.pollNext(output);
-            Assert.assertEquals(status, InputStatus.NOTHING_AVAILABLE);
+            assertThat(status).isEqualTo(InputStatus.NOTHING_AVAILABLE);
         }
     }
 

--- a/src/test/java/io/pravega/connectors/flink/source/reader/FlinkPravegaSplitReaderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/source/reader/FlinkPravegaSplitReaderTest.java
@@ -33,16 +33,17 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
@@ -54,12 +55,12 @@ public class FlinkPravegaSplitReaderTest {
 
     private static final PravegaTestEnvironment PRAVEGA = new PravegaTestEnvironment(PravegaRuntime.container());
 
-    @BeforeClass
+    @BeforeAll
     public static void setupPravega() throws Exception {
         PRAVEGA.startUp();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownPravega() throws Exception {
         PRAVEGA.tearDown();
     }
@@ -83,9 +84,9 @@ public class FlinkPravegaSplitReaderTest {
                 null,
                 "rg",
                 1);
-        Throwable thrown = Assert.assertThrows("close EventStreamReader failure", RuntimeException.class, reader::close);
-        Assert.assertEquals(thrown.getSuppressed().length, 1);
-        Assert.assertEquals(thrown.getSuppressed()[0].getMessage(), "close EventStreamClientFactory failure");
+        assertThatThrownBy(reader::close).isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("close EventStreamReader failure")
+                .hasSuppressedException(new RuntimeException("close EventStreamClientFactory failure"));
     }
 
     // ------------------
@@ -112,7 +113,7 @@ public class FlinkPravegaSplitReaderTest {
                         }
                     }
                     finishedSplits.add(splitId);
-                    Assert.assertEquals(numEvents, NUM_EVENTS);
+                    assertThat(numEvents).isEqualTo(NUM_EVENTS);
                     splitId = recordsBySplitIds.nextSplit();
                 }
             }

--- a/src/test/java/io/pravega/connectors/flink/util/FlinkPravegaUtilsTest.java
+++ b/src/test/java/io/pravega/connectors/flink/util/FlinkPravegaUtilsTest.java
@@ -15,15 +15,15 @@
  */
 package io.pravega.connectors.flink.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FlinkPravegaUtilsTest {
 
     @Test
     public void testGetReaderName() {
         String testStr = new String(new char[256]).replace('\0', 'a');
-        assertTrue(FlinkPravegaUtils.getReaderName(testStr, 1, 1).length() < 256);
+        assertThat(FlinkPravegaUtils.getReaderName(testStr, 1, 1).length() < 256).isTrue();
     }
 }

--- a/src/test/java/io/pravega/connectors/flink/utils/IntSequenceExactlyOnceValidator.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/IntSequenceExactlyOnceValidator.java
@@ -18,13 +18,14 @@ package io.pravega.connectors.flink.utils;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * A sink function that validates that in a sequence of integers, each integer occurs
@@ -57,11 +58,11 @@ public class IntSequenceExactlyOnceValidator extends RichSinkFunction<Integer>
     public void invoke(Integer value, Context context) throws Exception {
         numElementsSoFar++;
         if (numElementsSoFar > numElementsTotal) {
-            Assert.fail("Received more elements than expected");
+            fail("Received more elements than expected");
         }
 
         if (duplicateChecker.get(value)) {
-            Assert.fail("Received a duplicate: " + value);
+            fail("Received a duplicate: " + value);
         }
         duplicateChecker.set(value);
 
@@ -73,7 +74,7 @@ public class IntSequenceExactlyOnceValidator extends RichSinkFunction<Integer>
     @Override
     public void close() throws Exception {
         if (numElementsSoFar < numElementsTotal) {
-            Assert.fail("Missing elements, only received " + numElementsSoFar);
+            fail("Missing elements, only received " + numElementsSoFar);
         }
     }
 
@@ -91,11 +92,11 @@ public class IntSequenceExactlyOnceValidator extends RichSinkFunction<Integer>
     @Override
     public void restoreState(List<Tuple2<Integer, BitSet>> state) throws Exception {
         if (state.isEmpty()) {
-            Assert.fail("Function was restored without state - no checkpoint completed before.");
+            fail("Function was restored without state - no checkpoint completed before.");
         }
 
         if (state.size() > 1) {
-            Assert.fail("Function was restored with multiple states. unexpected scale-in");
+            fail("Function was restored with multiple states. unexpected scale-in");
         }
 
         Tuple2<Integer, BitSet> s = state.get(0);

--- a/src/test/java/io/pravega/connectors/flink/utils/PravegaTestEnvironment.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/PravegaTestEnvironment.java
@@ -19,16 +19,31 @@ package io.pravega.connectors.flink.utils;
 import io.pravega.connectors.flink.utils.runtime.PravegaRuntime;
 import io.pravega.connectors.flink.utils.runtime.PravegaRuntimeOperator;
 import org.apache.flink.connector.testframe.TestResource;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * A test environment for supporting running a Pravega standalone instance before executing tests.
  */
-public class PravegaTestEnvironment implements TestResource {
+public class PravegaTestEnvironment implements BeforeAllCallback, AfterAllCallback, TestResource {
 
     private final PravegaRuntime runtime;
 
     public PravegaTestEnvironment(PravegaRuntime runtime) {
         this.runtime = runtime;
+    }
+
+    /** JUnit 5 Extension setup method. */
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        runtime.startUp();
+    }
+
+    /** JUnit 5 Extension shutdown method. */
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        runtime.tearDown();
     }
 
     /** Start up the test resource. */

--- a/src/test/java/io/pravega/connectors/flink/utils/SchemaRegistryTestEnvironment.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/SchemaRegistryTestEnvironment.java
@@ -19,6 +19,7 @@ package io.pravega.connectors.flink.utils;
 import io.pravega.connectors.flink.utils.runtime.PravegaRuntime;
 import io.pravega.connectors.flink.utils.runtime.SchemaRegistryRuntime;
 import io.pravega.connectors.flink.utils.runtime.SchemaRegistryRuntimeOperator;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * A test environment for supporting running a Pravega standalone instance
@@ -31,6 +32,18 @@ public class SchemaRegistryTestEnvironment extends PravegaTestEnvironment {
     public SchemaRegistryTestEnvironment(PravegaRuntime pravegaRuntime, SchemaRegistryRuntime schemaRegistryRuntime) {
         super(pravegaRuntime);
         this.schemaRegistryRuntime = schemaRegistryRuntime;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+        schemaRegistryRuntime.startUp(super.operator());
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        super.afterAll(context);
+        schemaRegistryRuntime.tearDown();
     }
 
     /** Start up the test resource. */


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Migrate all unit tests and integration tests to JUnit 5 to align with the Flink community [changes](https://issues.apache.org/jira/browse/FLINK-25325). 

**Purpose of the change**
Fix #664 

**What the code does**
- Introduce JUnit5 dependencies
- Change all JUnit annotations to use JUnit5 package `org.junit.jupiter.api`
- Use AssertJ as the assumption and assertion library
- Remove all JUnit4 `@Rule` annotations

**How to verify it**
`./gradlew clean build` passed.
