### PR TITLE
[Issue-690] Update connector version to 0.13.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ The connectors can be used to build end-to-end stream processing pipelines (see 
 The [master](https://github.com/pravega/flink-connectors) branch will always have the most recent
 supported versions of Flink and Pravega.
 
-| Git Branch | Pravega Version | Flink Version | Status | Artifact Link |
-|-------------------------------------------------------------------------------------|------|------|-------------------|----------------------------------------------------------------------------------------|
-| [master](https://github.com/pravega/flink-connectors)                               | 0.11 | 1.14 | Under Development | https://github.com/pravega/flink-connectors/packages/1076644|
-| [r0.11-flink1.13](https://github.com/pravega/flink-connectors/tree/r0.11-flink1.13) | 0.11 | 1.13 | Under Development | https://github.com/pravega/flink-connectors/packages/910737 |
-| [r0.11-flink1.12](https://github.com/pravega/flink-connectors/tree/r0.11-flink1.12) | 0.11 | 1.12 | Under Development | https://github.com/pravega/flink-connectors/packages/887087 |
-| [r0.10](https://github.com/pravega/flink-connectors/tree/r0.10)                     | 0.10 | 1.13 | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.13_2.12/0.10.1/  |
-| [r0.10-flink1.12](https://github.com/pravega/flink-connectors/tree/r0.10-flink1.12) | 0.10 | 1.12 | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.12_2.12/0.10.1/    |
-| [r0.10-flink1.11](https://github.com/pravega/flink-connectors/tree/r0.10-flink1.11) | 0.10 | 1.11 | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.11_2.12/0.10.1/    |
+| Git Branch                                                                          | Pravega Version | Flink Version | Status            | Artifact Link                                                                        |
+|-------------------------------------------------------------------------------------|-----------------|---------------|-------------------|--------------------------------------------------------------------------------------|
+| [master](https://github.com/pravega/flink-connectors)                               | 0.13            | 1.15          | Under Development | https://github.com/pravega/flink-connectors/packages/1441637                         |
+| [r0.12](https://github.com/pravega/flink-connectors/tree/r0.12)                     | 0.12            | 1.15          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.15_2.12/0.12.0/ |
+| [r0.12-flink1.14](https://github.com/pravega/flink-connectors/tree/r0.12-flink1.14) | 0.12            | 1.14          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.14_2.12/0.12.0/ |
+| [r0.12-flink1.13](https://github.com/pravega/flink-connectors/tree/r0.12-flink1.13) | 0.12            | 1.13          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.13_2.12/0.12.0/ |
+| [r0.11](https://github.com/pravega/flink-connectors/tree/r0.11)                     | 0.11            | 1.14          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.14_2.12/0.11.0/ |
+| [r0.11-flink1.13](https://github.com/pravega/flink-connectors/tree/r0.11-flink1.13) | 0.11            | 1.13          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.13_2.12/0.11.0/ |
+| [r0.11-flink1.12](https://github.com/pravega/flink-connectors/tree/r0.11-flink1.12) | 0.11            | 1.12          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.12_2.12/0.11.0/ |
 
 ## How to build
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,9 +39,9 @@ nettyVersion=4.1.65.Final
 testcontainersVersion=1.15.3
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.12.0-SNAPSHOT
-pravegaVersion=0.12.0-3099.d57bc8b-SNAPSHOT
-schemaRegistryVersion=0.5.0-82.0072abf-SNAPSHOT
+connectorVersion=0.13.0-SNAPSHOT
+pravegaVersion=0.13.0-3151.28c485f-SNAPSHOT
+schemaRegistryVersion=0.6.0-88.65039cd-SNAPSHOT
 apacheCommonsVersion=3.7
 
 # These properties are only needed for publishing to maven central


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Update connector and Pravega version to `0.13.0-SNAPSHOT`, schema registry to `0.6.0-SNAPSHOT`

**Purpose of the change**
Fix #690 

**What the code does**
Update `connectorVersion` `pravegaVersion` and `schemaRegistryVersion` in `gradle.properties`
Update compatibility matrix in `README.md`

**How to verify it**
`./gradlew clean build` passed
