### PR TITLE
[issue-694] Fix javadoc warning

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/source/enumerator/PravegaSplitEnumerator.java
+++ b/src/main/java/io/pravega/connectors/flink/source/enumerator/PravegaSplitEnumerator.java
@@ -240,6 +240,8 @@ public class PravegaSplitEnumerator implements SplitEnumerator<PravegaSplit, Che
 
     /**
      * Create the {@link ReaderGroup} for the current configuration.
+     *
+     * @return An instance of {@link ReaderGroup}
      */
     protected ReaderGroup createReaderGroup() {
         LOG.info("Creating reader group {} with reader group config: {}", readerGroupName, readerGroupConfig);


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Fix a javadoc warning in `PravegaSplitEnumerator`

**Purpose of the change**
Fix #694 

**What the code does**
Add `@return` in the javadoc in `PravegaSplitEnumerator`

**How to verify it**
`gradlew clean build` passed
