### PR TITLE
[Issue-696] Update docker image version

### DIFF
--- a/src/test/java/io/pravega/connectors/flink/utils/DockerImageVersions.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/DockerImageVersions.java
@@ -24,6 +24,6 @@ package io.pravega.connectors.flink.utils;
 public class DockerImageVersions {
     // The Pravega and Schema Registry docker image version is behind the snapshot version so that
     // we need to maintain the backwards compatibility of these two docker images.
-    public static final String PRAVEGA = "pravega/pravega:0.11.0";
-    public static final String SCHEMA_REGISTRY = "pravega/schemaregistry:0.4.0";
+    public static final String PRAVEGA = "pravega/pravega:0.12.0";
+    public static final String SCHEMA_REGISTRY = "pravega/schemaregistry:0.5.0";
 }

--- a/src/test/java/io/pravega/connectors/flink/utils/runtime/PravegaContainer.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/runtime/PravegaContainer.java
@@ -30,7 +30,7 @@ import static io.pravega.connectors.flink.utils.runtime.SchemaRegistryContainer.
 public class PravegaContainer extends GenericContainer<PravegaContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("pravega/pravega");
-    private static final String DEFAULT_TAG = "0.11.0";
+    private static final String DEFAULT_TAG = "0.12.0";
     private static final int CONTROLLER_PORT = 9090;
     private static final int SEGMENT_STORE_PORT = 12345;
 


### PR DESCRIPTION
Signed-off-by: Fan Yang <fan.yang5@emc.com>

**Change log description**
Update Pravega and Schema registry docker image versions to the latest release for Integration tests

**Purpose of the change**
Fix #696 

**What the code does**
Change docker image versions in `DockerImageVersions`

**How to verify it**
`./gradlew clean build` should pass
