### PR TITLE
[Issue-698] Add `HOST_IP` environment variable

### DIFF
--- a/src/test/java/io/pravega/connectors/flink/utils/runtime/PravegaContainer.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/runtime/PravegaContainer.java
@@ -42,10 +42,10 @@ public class PravegaContainer extends GenericContainer<PravegaContainer> {
         super(dockerImageName);
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
-        addEnv("HOST_IP", getHost());
         addFixedExposedPort(CONTROLLER_PORT, CONTROLLER_PORT);
         addFixedExposedPort(SEGMENT_STORE_PORT, SEGMENT_STORE_PORT);
         withStartupTimeout(Duration.ofSeconds(90));
+        withEnv("HOST_IP", getHost());
         withCommand("standalone");
         waitingFor(Wait.forLogMessage(".* Pravega Sandbox is running locally now.*", 1));
 

--- a/src/test/java/io/pravega/connectors/flink/utils/runtime/PravegaContainer.java
+++ b/src/test/java/io/pravega/connectors/flink/utils/runtime/PravegaContainer.java
@@ -42,6 +42,7 @@ public class PravegaContainer extends GenericContainer<PravegaContainer> {
         super(dockerImageName);
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        addEnv("HOST_IP", getHost());
         addFixedExposedPort(CONTROLLER_PORT, CONTROLLER_PORT);
         addFixedExposedPort(SEGMENT_STORE_PORT, SEGMENT_STORE_PORT);
         withStartupTimeout(Duration.ofSeconds(90));


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Add `HOST_IP` environment variable in `PravegaContainer` for client to be able to connect to the segment store

**Purpose of the change**
Fix #698 

**What the code does**
Add `HOST_IP` environment variable in `PravegaContainer`

**How to verify it**
`./gradlew clean build` should pass
