### PR TITLE
[Issue-702] Upgrade to Flink 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ supported versions of Flink and Pravega.
 
 | Git Branch                                                                          | Pravega Version | Flink Version | Status            | Artifact Link                                                                        |
 |-------------------------------------------------------------------------------------|-----------------|---------------|-------------------|--------------------------------------------------------------------------------------|
-| [master](https://github.com/pravega/flink-connectors)                               | 0.13            | 1.15          | Under Development | https://github.com/pravega/flink-connectors/packages/1441637                         |
+| [master](https://github.com/pravega/flink-connectors)                               | 0.13            | 1.16          | Under Development | https://github.com/pravega/flink-connectors/packages/1441637                         |
+| [r0.13-flink1.15](https://github.com/pravega/flink-connectors/tree/r0.13-flink1.15) | 0.13            | 1.15          | Under Development | https://github.com/pravega/flink-connectors/packages/1441637                         |
+| [r0.13-flink1.14](https://github.com/pravega/flink-connectors/tree/r0.13-flink1.14) | 0.13            | 1.14          | Under Development | https://github.com/pravega/flink-connectors/packages/1441637                         |
 | [r0.12](https://github.com/pravega/flink-connectors/tree/r0.12)                     | 0.12            | 1.15          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.15_2.12/0.12.0/ |
 | [r0.12-flink1.14](https://github.com/pravega/flink-connectors/tree/r0.12-flink1.14) | 0.12            | 1.14          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.14_2.12/0.12.0/ |
 | [r0.12-flink1.13](https://github.com/pravega/flink-connectors/tree/r0.12-flink1.13) | 0.12            | 1.13          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.13_2.12/0.12.0/ |

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # 3rd party Versions.
 assertjVersion=3.23.1
 checkstyleToolVersion=7.1
-flinkVersion=1.15.0
+flinkVersion=1.16.0
 flinkScalaVersion=2.12
 jacksonVersion=2.8.9
 twitterMvnRepoVersion=4.3.4-TWTTR


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Upgrade Flink version to `1.16.0` on master branch

**Purpose of the change**
Fix #702 

**What the code does**
Upgrade `flinkVersion` to `1.16.0` in `gradle.properties`

**How to verify it**
`./gradlew clean build` should pass