### PR TITLE
[Issue-709] Leverage `DeliveryGuarantee` in new sink API

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/PravegaWriterMode.java
+++ b/src/main/java/io/pravega/connectors/flink/PravegaWriterMode.java
@@ -20,6 +20,9 @@ import java.io.Serializable;
 /**
  * The supported modes of operation for flink's pravega writer.
  * The different modes correspond to different guarantees for the write operations that the implementation provides.
+ *
+ * This enum is used in old sink API and in the new sink API we will use
+ * {@link org.apache.flink.connector.base.DeliveryGuarantee} provided by Flink.
  */
 public enum PravegaWriterMode implements Serializable {
     /*

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaCommitter.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaCommitter.java
@@ -26,10 +26,10 @@ import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.TransactionalEventStreamWriter;
 import io.pravega.client.stream.TxnFailedException;
-import io.pravega.connectors.flink.PravegaWriterMode;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +39,7 @@ import java.util.Collection;
 import java.util.UUID;
 
 /**
- * This committer only works under {@link PravegaWriterMode#EXACTLY_ONCE} and
+ * This committer only works under {@link DeliveryGuarantee#EXACTLY_ONCE} and
  * handles the final commit stage for the transaction.
  *
  * <p>The transaction is resumed via {@link PravegaTransactionState#getTransactionId()}

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaEventSink.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaEventSink.java
@@ -27,7 +27,7 @@ import org.apache.flink.util.Preconditions;
 import java.io.IOException;
 
 /**
- * A Pravega sink for {@link DeliveryGuarantee#NONE} and {@link DeliveryGuarantee#AT_LEAST_ONCE} writer mode.
+ * A Pravega sink for {@link DeliveryGuarantee#NONE} and {@link DeliveryGuarantee#AT_LEAST_ONCE} delivery guarantee.
  *
  * <p>Use {@link PravegaSinkBuilder} to construct a {@link PravegaEventSink}.
  *
@@ -39,7 +39,7 @@ import java.io.IOException;
 @Experimental
 public class PravegaEventSink<T> extends PravegaSink<T> {
     // The sink's mode of operation. This is used to provide different guarantees for the written events.
-    private final DeliveryGuarantee writerMode;
+    private final DeliveryGuarantee deliveryGuarantee;
 
     /**
      * Creates a new Pravega Event Sink instance which can be added as a sink to a Flink job.
@@ -48,15 +48,15 @@ public class PravegaEventSink<T> extends PravegaSink<T> {
      *
      * @param clientConfig          The Pravega client configuration.
      * @param stream                The destination stream.
-     * @param writerMode            The writer mode of the sink.
+     * @param deliveryGuarantee     The delivery guarantee.
      * @param serializationSchema   The implementation for serializing every event into pravega's storage format.
      * @param eventRouter           The implementation to extract the partition key from the event.
      */
     public PravegaEventSink(ClientConfig clientConfig,
-                            Stream stream, DeliveryGuarantee writerMode,
+                            Stream stream, DeliveryGuarantee deliveryGuarantee,
                             SerializationSchema<T> serializationSchema, PravegaEventRouter<T> eventRouter) {
         super(clientConfig, stream, serializationSchema, eventRouter);
-        this.writerMode = Preconditions.checkNotNull(writerMode, "writerMode");
+        this.deliveryGuarantee = Preconditions.checkNotNull(deliveryGuarantee, "deliveryGuarantee");
     }
 
     @Override
@@ -65,7 +65,7 @@ public class PravegaEventSink<T> extends PravegaSink<T> {
                 context,
                 clientConfig,
                 stream,
-                writerMode,
+                deliveryGuarantee,
                 serializationSchema,
                 eventRouter);
     }

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaEventSink.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaEventSink.java
@@ -18,16 +18,16 @@ package io.pravega.connectors.flink.sink;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.stream.Stream;
 import io.pravega.connectors.flink.PravegaEventRouter;
-import io.pravega.connectors.flink.PravegaWriterMode;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 
 /**
- * A Pravega sink for {@link PravegaWriterMode#BEST_EFFORT} and {@link PravegaWriterMode#ATLEAST_ONCE} writer mode.
+ * A Pravega sink for {@link DeliveryGuarantee#NONE} and {@link DeliveryGuarantee#AT_LEAST_ONCE} writer mode.
  *
  * <p>Use {@link PravegaSinkBuilder} to construct a {@link PravegaEventSink}.
  *
@@ -39,7 +39,7 @@ import java.io.IOException;
 @Experimental
 public class PravegaEventSink<T> extends PravegaSink<T> {
     // The sink's mode of operation. This is used to provide different guarantees for the written events.
-    private final PravegaWriterMode writerMode;
+    private final DeliveryGuarantee writerMode;
 
     /**
      * Creates a new Pravega Event Sink instance which can be added as a sink to a Flink job.
@@ -53,7 +53,7 @@ public class PravegaEventSink<T> extends PravegaSink<T> {
      * @param eventRouter           The implementation to extract the partition key from the event.
      */
     public PravegaEventSink(ClientConfig clientConfig,
-                            Stream stream, PravegaWriterMode writerMode,
+                            Stream stream, DeliveryGuarantee writerMode,
                             SerializationSchema<T> serializationSchema, PravegaEventRouter<T> eventRouter) {
         super(clientConfig, stream, serializationSchema, eventRouter);
         this.writerMode = Preconditions.checkNotNull(writerMode, "writerMode");

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaEventWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaEventWriter.java
@@ -226,20 +226,4 @@ public class PravegaEventWriter<T> implements SinkWriter<T> {
             throw exception;
         }
     }
-
-    @VisibleForTesting
-    protected DeliveryGuarantee getDeliveryGuarantee() {
-        return deliveryGuarantee;
-    }
-
-    @VisibleForTesting
-    @Nullable
-    protected PravegaEventRouter<T> getEventRouter() {
-        return eventRouter;
-    }
-
-    @VisibleForTesting
-    protected EventStreamWriter<T> getInternalWriter() {
-        return writer;
-    }
 }

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaEventWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaEventWriter.java
@@ -77,7 +77,7 @@ public class PravegaEventWriter<T> implements SinkWriter<T> {
     private final Stream stream;
 
     // The sink's mode of operation. This is used to provide different guarantees for the written events.
-    private final DeliveryGuarantee writerMode;
+    private final DeliveryGuarantee deliveryGuarantee;
 
     // The supplied event serializer.
     private final SerializationSchema<T> serializationSchema;
@@ -94,24 +94,24 @@ public class PravegaEventWriter<T> implements SinkWriter<T> {
 
     /**
      * A Pravega non-transactional writer that handles {@link DeliveryGuarantee#NONE} and
-     * {@link DeliveryGuarantee#AT_LEAST_ONCE} writer mode.
+     * {@link DeliveryGuarantee#AT_LEAST_ONCE} delivery guarantee.
      *
      * @param context               Some runtime info from sink.
      * @param clientConfig          The Pravega client configuration.
      * @param stream                The destination stream.
-     * @param writerMode            The Pravega writer mode.
+     * @param deliveryGuarantee     The delivery guarantee.
      * @param serializationSchema   The implementation for serializing every event into pravega's storage format.
      * @param eventRouter           The implementation to extract the partition key from the event.
      */
     public PravegaEventWriter(Sink.InitContext context,
                               ClientConfig clientConfig,
                               Stream stream,
-                              DeliveryGuarantee writerMode,
+                              DeliveryGuarantee deliveryGuarantee,
                               SerializationSchema<T> serializationSchema,
                               PravegaEventRouter<T> eventRouter) {
         this.clientConfig = clientConfig;
         this.stream = stream;
-        this.writerMode = writerMode;
+        this.deliveryGuarantee = deliveryGuarantee;
         this.serializationSchema = serializationSchema;
         this.eventRouter = eventRouter;
         this.writer = initializeInternalWriter();
@@ -162,7 +162,7 @@ public class PravegaEventWriter<T> implements SinkWriter<T> {
 
     @Override
     public void flush(boolean endOfInput) throws IOException, InterruptedException {
-        if (writerMode == DeliveryGuarantee.AT_LEAST_ONCE) {
+        if (deliveryGuarantee == DeliveryGuarantee.AT_LEAST_ONCE) {
             flushAndVerify();
         }
     }
@@ -228,8 +228,8 @@ public class PravegaEventWriter<T> implements SinkWriter<T> {
     }
 
     @VisibleForTesting
-    protected DeliveryGuarantee getWriterMode() {
-        return writerMode;
+    protected DeliveryGuarantee getDeliveryGuarantee() {
+        return deliveryGuarantee;
     }
 
     @VisibleForTesting

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaSink.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaSink.java
@@ -27,7 +27,7 @@ import org.apache.flink.util.Preconditions;
 import javax.annotation.Nullable;
 
 /**
- * Pravega Sink writes data into a Pravega stream. It supports all writer mode
+ * Pravega Sink writes data into a Pravega stream. It supports all delivery guarantee
  * described by {@link DeliveryGuarantee}.
  *
  * <p>For {@link DeliveryGuarantee#AT_LEAST_ONCE} and {@link DeliveryGuarantee#AT_LEAST_ONCE},

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaSink.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaSink.java
@@ -18,22 +18,22 @@ package io.pravega.connectors.flink.sink;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.stream.Stream;
 import io.pravega.connectors.flink.PravegaEventRouter;
-import io.pravega.connectors.flink.PravegaWriterMode;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
 /**
  * Pravega Sink writes data into a Pravega stream. It supports all writer mode
- * described by {@link PravegaWriterMode}.
+ * described by {@link DeliveryGuarantee}.
  *
- * <p>For {@link PravegaWriterMode#ATLEAST_ONCE} and {@link PravegaWriterMode#ATLEAST_ONCE},
+ * <p>For {@link DeliveryGuarantee#AT_LEAST_ONCE} and {@link DeliveryGuarantee#AT_LEAST_ONCE},
  * a {@link PravegaEventSink} will be returned after {@link PravegaSinkBuilder#build()}.
  *
- * <p>For {@link PravegaWriterMode#EXACTLY_ONCE}, a {@link PravegaTransactionalSink}
+ * <p>For {@link DeliveryGuarantee#EXACTLY_ONCE}, a {@link PravegaTransactionalSink}
  * will be returned after {@link PravegaSinkBuilder#build()}.
  *
  * @param <T> The type of the event to be written.

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaSinkBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaSinkBuilder.java
@@ -18,9 +18,9 @@ package io.pravega.connectors.flink.sink;
 import io.pravega.client.stream.Stream;
 import io.pravega.connectors.flink.PravegaConfig;
 import io.pravega.connectors.flink.PravegaEventRouter;
-import io.pravega.connectors.flink.PravegaWriterMode;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -36,7 +36,7 @@ public class PravegaSinkBuilder<T> {
 
     private PravegaConfig pravegaConfig = PravegaConfig.fromDefaults();
     private String stream;
-    private PravegaWriterMode writerMode = PravegaWriterMode.ATLEAST_ONCE;
+    private DeliveryGuarantee writerMode = DeliveryGuarantee.AT_LEAST_ONCE;
     private Time txnLeaseRenewalPeriod = Time.milliseconds(DEFAULT_TXN_LEASE_RENEWAL_PERIOD_MILLIS);
     private SerializationSchema<T> serializationSchema;
     @Nullable
@@ -86,7 +86,7 @@ public class PravegaSinkBuilder<T> {
      * @param writerMode The writer mode of {@code BEST_EFFORT}, {@code ATLEAST_ONCE}, or {@code EXACTLY_ONCE}.
      * @return A builder to configure and create a sink.
      */
-    public PravegaSinkBuilder<T> withWriterMode(PravegaWriterMode writerMode) {
+    public PravegaSinkBuilder<T> withWriterMode(DeliveryGuarantee writerMode) {
         this.writerMode = writerMode;
         return this;
     }
@@ -147,14 +147,14 @@ public class PravegaSinkBuilder<T> {
      * @return An instance of either {@link PravegaEventSink} or {@link PravegaTransactionalSink}.
      */
     public PravegaSink<T> build() {
-        if (writerMode == PravegaWriterMode.BEST_EFFORT || writerMode == PravegaWriterMode.ATLEAST_ONCE) {
+        if (writerMode == DeliveryGuarantee.NONE || writerMode == DeliveryGuarantee.AT_LEAST_ONCE) {
             return new PravegaEventSink<>(
                     pravegaConfig.getClientConfig(),
                     resolveStream(),
                     writerMode,
                     serializationSchema,
                     eventRouter);
-        } else if (writerMode == PravegaWriterMode.EXACTLY_ONCE) {
+        } else if (writerMode == DeliveryGuarantee.EXACTLY_ONCE) {
             return new PravegaTransactionalSink<>(
                     pravegaConfig.getClientConfig(),
                     resolveStream(),

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaSinkBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaSinkBuilder.java
@@ -147,14 +147,7 @@ public class PravegaSinkBuilder<T> {
      * @return An instance of either {@link PravegaEventSink} or {@link PravegaTransactionalSink}.
      */
     public PravegaSink<T> build() {
-        if (deliveryGuarantee == DeliveryGuarantee.NONE || deliveryGuarantee == DeliveryGuarantee.AT_LEAST_ONCE) {
-            return new PravegaEventSink<>(
-                    pravegaConfig.getClientConfig(),
-                    resolveStream(),
-                    deliveryGuarantee,
-                    serializationSchema,
-                    eventRouter);
-        } else if (deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
+        if (deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
             return new PravegaTransactionalSink<>(
                     pravegaConfig.getClientConfig(),
                     resolveStream(),
@@ -162,7 +155,12 @@ public class PravegaSinkBuilder<T> {
                     serializationSchema,
                     eventRouter);
         } else {
-            throw new IllegalStateException("Failed to build Pravega sink with unknown delivery guarantee: " + deliveryGuarantee);
+            return new PravegaEventSink<>(
+                    pravegaConfig.getClientConfig(),
+                    resolveStream(),
+                    deliveryGuarantee,
+                    serializationSchema,
+                    eventRouter);
         }
     }
 }

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaSinkBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaSinkBuilder.java
@@ -94,11 +94,12 @@ public class PravegaSinkBuilder<T> {
 
     /**
      * Sets the delivery guarantee from writer mode to provide at-least-once or exactly-once guarantees.
-     * This method is to keep the compatibility with the old {@code PravegaWriterMode} enum that will be deprecated soon.
+     * @deprecated This method is to keep the compatibility with the old {@code PravegaWriterMode} enum that will be deprecated soon.
      *
      * @param writerMode The writer mode of {@code BEST_EFFORT}, {@code ATLEAST_ONCE}, or {@code EXACTLY_ONCE}.
      * @return A builder to configure and create a sink.
      */
+    @Deprecated
     public PravegaSinkBuilder<T> withWriterMode(PravegaWriterMode writerMode) {
         switch (writerMode) {
             case EXACTLY_ONCE:

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaSinkBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaSinkBuilder.java
@@ -18,6 +18,7 @@ package io.pravega.connectors.flink.sink;
 import io.pravega.client.stream.Stream;
 import io.pravega.connectors.flink.PravegaConfig;
 import io.pravega.connectors.flink.PravegaEventRouter;
+import io.pravega.connectors.flink.PravegaWriterMode;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.connector.base.DeliveryGuarantee;
@@ -88,6 +89,28 @@ public class PravegaSinkBuilder<T> {
      */
     public PravegaSinkBuilder<T> withDeliveryGuarantee(DeliveryGuarantee deliveryGuarantee) {
         this.deliveryGuarantee = deliveryGuarantee;
+        return this;
+    }
+
+    /**
+     * Sets the delivery guarantee from writer mode to provide at-least-once or exactly-once guarantees.
+     * This method is to keep the compatibility with the old {@code PravegaWriterMode} enum that will be deprecated soon.
+     *
+     * @param writerMode The writer mode of {@code BEST_EFFORT}, {@code ATLEAST_ONCE}, or {@code EXACTLY_ONCE}.
+     * @return A builder to configure and create a sink.
+     */
+    public PravegaSinkBuilder<T> withWriterMode(PravegaWriterMode writerMode) {
+        switch (writerMode) {
+            case EXACTLY_ONCE:
+                this.deliveryGuarantee = DeliveryGuarantee.EXACTLY_ONCE;
+                break;
+            case BEST_EFFORT:
+                this.deliveryGuarantee = DeliveryGuarantee.NONE;
+                break;
+            default:
+                this.deliveryGuarantee = DeliveryGuarantee.AT_LEAST_ONCE;
+                break;
+        }
         return this;
     }
 

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaSinkBuilder.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaSinkBuilder.java
@@ -94,7 +94,7 @@ public class PravegaSinkBuilder<T> {
 
     /**
      * Sets the delivery guarantee from writer mode to provide at-least-once or exactly-once guarantees.
-     * @deprecated This method is to keep the compatibility with the old {@code PravegaWriterMode} enum that will be deprecated soon.
+     * @deprecated use {@link #withDeliveryGuarantee} instead.
      *
      * @param writerMode The writer mode of {@code BEST_EFFORT}, {@code ATLEAST_ONCE}, or {@code EXACTLY_ONCE}.
      * @return A builder to configure and create a sink.

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaTransactionalSink.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaTransactionalSink.java
@@ -30,7 +30,7 @@ import org.apache.flink.util.Preconditions;
 import java.io.IOException;
 
 /**
- * A Pravega sink for {@link DeliveryGuarantee#EXACTLY_ONCE} writer mode.
+ * A Pravega sink for {@link DeliveryGuarantee#EXACTLY_ONCE} delivery guarantee.
  *
  * <p>Use {@link PravegaSinkBuilder} to construct a {@link PravegaTransactionalSink}.
  *

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaTransactionalSink.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaTransactionalSink.java
@@ -19,18 +19,18 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.Transaction;
 import io.pravega.connectors.flink.PravegaEventRouter;
-import io.pravega.connectors.flink.PravegaWriterMode;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 
 /**
- * A Pravega sink for {@link PravegaWriterMode#EXACTLY_ONCE} writer mode.
+ * A Pravega sink for {@link DeliveryGuarantee#EXACTLY_ONCE} writer mode.
  *
  * <p>Use {@link PravegaSinkBuilder} to construct a {@link PravegaTransactionalSink}.
  *

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaTransactionalWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaTransactionalWriter.java
@@ -228,15 +228,4 @@ public class PravegaTransactionalWriter<T>
         assert transaction != null;
         return transaction.getTxnId().toString();
     }
-
-    @VisibleForTesting
-    @Nullable
-    protected PravegaEventRouter<T> getEventRouter() {
-        return eventRouter;
-    }
-
-    @VisibleForTesting
-    protected TransactionalEventStreamWriter<T> getInternalWriter() {
-        return transactionalWriter;
-    }
 }

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaTransactionalWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaTransactionalWriter.java
@@ -25,11 +25,11 @@ import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.TransactionalEventStreamWriter;
 import io.pravega.client.stream.TxnFailedException;
 import io.pravega.connectors.flink.PravegaEventRouter;
-import io.pravega.connectors.flink.PravegaWriterMode;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +43,7 @@ import java.util.UUID;
 
 /**
  * A Pravega {@link TwoPhaseCommittingSink.PrecommittingSinkWriter} implementation that is suitable
- * for the {@link PravegaWriterMode#EXACTLY_ONCE} mode.
+ * for the {@link DeliveryGuarantee#EXACTLY_ONCE} mode.
  *
  * <p>Note that the transaction is committed in a reconstructed one from the {@link PravegaCommitter} and
  * this writer only deals with the {@link PravegaTransactionalWriter#beginTransaction},
@@ -88,7 +88,7 @@ public class PravegaTransactionalWriter<T>
     private transient Transaction<T> transaction;
 
     /**
-     * A Pravega writer that handles {@link PravegaWriterMode#EXACTLY_ONCE} writer mode.
+     * A Pravega writer that handles {@link DeliveryGuarantee#EXACTLY_ONCE} writer mode.
      *
      * @param context               Some runtime info from sink.
      * @param clientConfig          The Pravega client configuration.

--- a/src/main/java/io/pravega/connectors/flink/sink/PravegaTransactionalWriter.java
+++ b/src/main/java/io/pravega/connectors/flink/sink/PravegaTransactionalWriter.java
@@ -88,7 +88,7 @@ public class PravegaTransactionalWriter<T>
     private transient Transaction<T> transaction;
 
     /**
-     * A Pravega writer that handles {@link DeliveryGuarantee#EXACTLY_ONCE} writer mode.
+     * A Pravega writer that handles {@link DeliveryGuarantee#EXACTLY_ONCE} delivery guarantee.
      *
      * @param context               Some runtime info from sink.
      * @param clientConfig          The Pravega client configuration.

--- a/src/test/java/io/pravega/connectors/flink/sink/PravegaSinkBuilderTest.java
+++ b/src/test/java/io/pravega/connectors/flink/sink/PravegaSinkBuilderTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.connectors.flink.sink;
+
+import io.pravega.connectors.flink.PravegaConfig;
+import io.pravega.connectors.flink.PravegaWriterMode;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PravegaSinkBuilderTest {
+
+    private static final String DEFAULT_SCOPE = "scope1";
+    private static final String DEFAULT_STREAM_NAME = "stream1";
+
+    @Test
+    public void testValidBuilder() {
+        PravegaSinkBuilder<String> builder = new PravegaSinkBuilder<String>()
+                .withPravegaConfig(PravegaConfig.fromDefaults().withScope(DEFAULT_SCOPE))
+                .forStream(DEFAULT_STREAM_NAME)
+                .withSerializationSchema(new SimpleStringSchema());
+        PravegaSink<String> sink = builder.build();
+        assertThat(sink).isNotNull();
+    }
+
+    @Test
+    public void testValidBuilderWithWriterMode() {
+        PravegaSinkBuilder<String> builder = new PravegaSinkBuilder<String>()
+                .withPravegaConfig(PravegaConfig.fromDefaults().withScope(DEFAULT_SCOPE))
+                .forStream(DEFAULT_STREAM_NAME)
+                .withSerializationSchema(new SimpleStringSchema())
+                .withWriterMode(PravegaWriterMode.EXACTLY_ONCE);
+        PravegaSink<String> sink = builder.build();
+        assertThat(sink).isNotNull();
+        assertThat(sink.getClass()).isEqualTo(PravegaTransactionalSink.class);
+    }
+
+    @Test
+    public void testThrowsExceptionWhenStreamIsNotSet() {
+        PravegaSinkBuilder<String> builder = new PravegaSinkBuilder<String>()
+                .withPravegaConfig(PravegaConfig.fromDefaults().withScope(DEFAULT_SCOPE))
+                .withSerializationSchema(new SimpleStringSchema())
+                .withWriterMode(PravegaWriterMode.EXACTLY_ONCE);
+        assertThatThrownBy(builder::build).isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/io/pravega/connectors/flink/sink/PravegaSinkITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/sink/PravegaSinkITCase.java
@@ -17,7 +17,6 @@ package io.pravega.connectors.flink.sink;
 
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
-import io.pravega.connectors.flink.PravegaWriterMode;
 import io.pravega.connectors.flink.utils.FailingMapper;
 import io.pravega.connectors.flink.utils.IntegerSerializer;
 import io.pravega.connectors.flink.utils.PravegaTestEnvironment;
@@ -27,6 +26,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.AbstractTestBase;
@@ -82,7 +82,7 @@ public class PravegaSinkITCase extends AbstractTestBase {
                 .withPravegaConfig(PRAVEGA.operator().getPravegaConfig())
                 .withSerializationSchema(new IntSerializer())
                 .withEventRouter(event -> "fixedkey")
-                .withWriterMode(PravegaWriterMode.ATLEAST_ONCE)
+                .withWriterMode(DeliveryGuarantee.AT_LEAST_ONCE)
                 .withTxnLeaseRenewalPeriod(Time.seconds(30))
                 .build();
 
@@ -111,7 +111,7 @@ public class PravegaSinkITCase extends AbstractTestBase {
                 .withPravegaConfig(PRAVEGA.operator().getPravegaConfig())
                 .withSerializationSchema(new IntSerializer())
                 .withEventRouter(event -> "fixedkey")
-                .withWriterMode(PravegaWriterMode.EXACTLY_ONCE)
+                .withWriterMode(DeliveryGuarantee.EXACTLY_ONCE)
                 .withTxnLeaseRenewalPeriod(Time.seconds(30))
                 .build();
 
@@ -139,7 +139,7 @@ public class PravegaSinkITCase extends AbstractTestBase {
                 .forStream(streamName)
                 .withPravegaConfig(PRAVEGA.operator().getPravegaConfig())
                 .withSerializationSchema(new IntSerializer())
-                .withWriterMode(PravegaWriterMode.EXACTLY_ONCE)
+                .withWriterMode(DeliveryGuarantee.EXACTLY_ONCE)
                 .withTxnLeaseRenewalPeriod(Time.seconds(30))
                 .build();
 
@@ -168,7 +168,7 @@ public class PravegaSinkITCase extends AbstractTestBase {
                 .withPravegaConfig(PRAVEGA.operator().getPravegaConfig())
                 .withSerializationSchema(new IntSerializer())
                 .withEventRouter(event -> "fixedkey")
-                .withWriterMode(PravegaWriterMode.EXACTLY_ONCE)
+                .withWriterMode(DeliveryGuarantee.EXACTLY_ONCE)
                 .withTxnLeaseRenewalPeriod(Time.seconds(30))
                 .build();
 
@@ -198,7 +198,7 @@ public class PravegaSinkITCase extends AbstractTestBase {
                 .withPravegaConfig(PRAVEGA.operator().getPravegaConfig())
                 .withSerializationSchema(new IntSerializer())
                 .withEventRouter(event -> "fixedkey")
-                .withWriterMode(PravegaWriterMode.EXACTLY_ONCE)
+                .withWriterMode(DeliveryGuarantee.EXACTLY_ONCE)
                 .withTxnLeaseRenewalPeriod(Time.seconds(30))
                 .build();
 

--- a/src/test/java/io/pravega/connectors/flink/sink/PravegaSinkITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/sink/PravegaSinkITCase.java
@@ -82,7 +82,7 @@ public class PravegaSinkITCase extends AbstractTestBase {
                 .withPravegaConfig(PRAVEGA.operator().getPravegaConfig())
                 .withSerializationSchema(new IntSerializer())
                 .withEventRouter(event -> "fixedkey")
-                .withWriterMode(DeliveryGuarantee.AT_LEAST_ONCE)
+                .withDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
                 .withTxnLeaseRenewalPeriod(Time.seconds(30))
                 .build();
 
@@ -111,7 +111,7 @@ public class PravegaSinkITCase extends AbstractTestBase {
                 .withPravegaConfig(PRAVEGA.operator().getPravegaConfig())
                 .withSerializationSchema(new IntSerializer())
                 .withEventRouter(event -> "fixedkey")
-                .withWriterMode(DeliveryGuarantee.EXACTLY_ONCE)
+                .withDeliveryGuarantee(DeliveryGuarantee.EXACTLY_ONCE)
                 .withTxnLeaseRenewalPeriod(Time.seconds(30))
                 .build();
 
@@ -139,7 +139,7 @@ public class PravegaSinkITCase extends AbstractTestBase {
                 .forStream(streamName)
                 .withPravegaConfig(PRAVEGA.operator().getPravegaConfig())
                 .withSerializationSchema(new IntSerializer())
-                .withWriterMode(DeliveryGuarantee.EXACTLY_ONCE)
+                .withDeliveryGuarantee(DeliveryGuarantee.EXACTLY_ONCE)
                 .withTxnLeaseRenewalPeriod(Time.seconds(30))
                 .build();
 
@@ -168,7 +168,7 @@ public class PravegaSinkITCase extends AbstractTestBase {
                 .withPravegaConfig(PRAVEGA.operator().getPravegaConfig())
                 .withSerializationSchema(new IntSerializer())
                 .withEventRouter(event -> "fixedkey")
-                .withWriterMode(DeliveryGuarantee.EXACTLY_ONCE)
+                .withDeliveryGuarantee(DeliveryGuarantee.EXACTLY_ONCE)
                 .withTxnLeaseRenewalPeriod(Time.seconds(30))
                 .build();
 
@@ -198,7 +198,7 @@ public class PravegaSinkITCase extends AbstractTestBase {
                 .withPravegaConfig(PRAVEGA.operator().getPravegaConfig())
                 .withSerializationSchema(new IntSerializer())
                 .withEventRouter(event -> "fixedkey")
-                .withWriterMode(DeliveryGuarantee.EXACTLY_ONCE)
+                .withDeliveryGuarantee(DeliveryGuarantee.EXACTLY_ONCE)
                 .withTxnLeaseRenewalPeriod(Time.seconds(30))
                 .build();
 


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Flink has already provided a enum `DeliveryGuarantee` to describe the delivery guarantee. We will use it instead of `PravegaWriterMode` in our new sink API introduced in #460 

**Purpose of the change**
Fix #709 

**What the code does**
Replace `PravegaWriterMode` with `DeliveryGuarantee` in new sink API.

**How to verify it**
`./gradlew clean build` should pass
