### PR TITLE
[issue-717] Let Pravega internal thread pool deal with checkpoint

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ testcontainersVersion=1.15.3
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.13.0-SNAPSHOT
-pravegaVersion=0.13.0-3151.28c485f-SNAPSHOT
+pravegaVersion=0.13.0-3181.f1783dd-SNAPSHOT
 schemaRegistryVersion=0.6.0-88.65039cd-SNAPSHOT
 apacheCommonsVersion=3.7
 

--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -113,7 +113,7 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
         final String checkpointName = createCheckpointName(checkpointId);
 
         final CompletableFuture<Checkpoint> checkpointResult =
-                this.readerGroup.initiateCheckpoint(checkpointName, scheduledExecutorService);
+                this.readerGroup.initiateCheckpoint(checkpointName);
 
         // Add a timeout to the future, to prevent long blocking calls
         scheduledExecutorService.schedule(() -> checkpointResult.cancel(false), triggerTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);

--- a/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
+++ b/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
@@ -65,10 +65,10 @@ public class ReaderCheckpointHookTest {
         CompletableFuture<Checkpoint> checkpointPromise = new CompletableFuture<>();
         TestableReaderCheckpointHook hook = new TestableReaderCheckpointHook(HOOK_UID, READER_GROUP_NAME, SCOPE, Time.minutes(1), clientConfig, readerGroupConfig);
 
-        when(hook.readerGroup.initiateCheckpoint(anyString(), any())).thenReturn(checkpointPromise);
+        when(hook.readerGroup.initiateCheckpoint(anyString())).thenReturn(checkpointPromise);
         CompletableFuture<Checkpoint> checkpointFuture = hook.triggerCheckpoint(1L, 1L, Executors.directExecutor());
         assertThat(checkpointFuture).isNotNull();
-        verify(hook.readerGroup).initiateCheckpoint(anyString(), any());
+        verify(hook.readerGroup).initiateCheckpoint(anyString());
 
         // complete the checkpoint promise
         Checkpoint expectedCheckpoint = mock(Checkpoint.class);
@@ -84,11 +84,11 @@ public class ReaderCheckpointHookTest {
         CompletableFuture<Checkpoint> checkpointPromise = new CompletableFuture<>();
 
         TestableReaderCheckpointHook hook = new TestableReaderCheckpointHook(HOOK_UID, READER_GROUP_NAME, SCOPE, Time.minutes(1), clientConfig, readerGroupConfig);
-        when(hook.readerGroup.initiateCheckpoint(anyString(), any())).thenReturn(checkpointPromise);
+        when(hook.readerGroup.initiateCheckpoint(anyString())).thenReturn(checkpointPromise);
 
         CompletableFuture<Checkpoint> checkpointFuture = hook.triggerCheckpoint(1L, 1L, Executors.directExecutor());
         assertThat(checkpointFuture).isNotNull();
-        verify(hook.readerGroup).initiateCheckpoint(anyString(), any());
+        verify(hook.readerGroup).initiateCheckpoint(anyString());
 
         // invoke the timeout callback
         hook.invokeScheduledCallables();

--- a/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
+++ b/src/test/java/io/pravega/connectors/flink/ReaderCheckpointHookTest.java
@@ -104,11 +104,11 @@ public class ReaderCheckpointHookTest {
         checkpointPromise.completeExceptionally(new MaxNumberOfCheckpointsExceededException("test"));
 
         TestableReaderCheckpointHook hook = new TestableReaderCheckpointHook(HOOK_UID, READER_GROUP_NAME, SCOPE, Time.minutes(1), clientConfig, readerGroupConfig);
-        when(hook.readerGroup.initiateCheckpoint(anyString(), any())).thenReturn(checkpointPromise);
+        when(hook.readerGroup.initiateCheckpoint(anyString())).thenReturn(checkpointPromise);
 
         CompletableFuture<Checkpoint> checkpointFuture = hook.triggerCheckpoint(1L, 1L, Executors.directExecutor());
         assertThat(checkpointFuture).isNotNull();
-        verify(hook.readerGroup).initiateCheckpoint(anyString(), any());
+        verify(hook.readerGroup).initiateCheckpoint(anyString());
 
         // invoke the cancelOutstandingCheckpoints
         verify(hook.readerGroup).cancelOutstandingCheckpoints();


### PR DESCRIPTION
**Change log description**
Use `ReaderGroup::initiateCheckpoint(checkpointName)` to perform the checkpoint

**Purpose of the change**
Fixes #717 

**What the code does**
Update the method
Update the Pravega version

**How to verify it**
`./gradlew clean build` passes