### PR TITLE
[issue-719] Explicitly cancel outstanding checkpoints when checkpoints get stuck

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ testcontainersVersion=1.15.3
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.13.0-SNAPSHOT
-pravegaVersion=0.13.0-3151.28c485f-SNAPSHOT
+pravegaVersion=0.13.0-3184.23d8ef6-SNAPSHOT
 schemaRegistryVersion=0.6.0-88.65039cd-SNAPSHOT
 apacheCommonsVersion=3.7
 


### PR DESCRIPTION
**Change log description**
Add a `cancelOutstandingCheckpoints` call when the checkpoint hits `MaxNumberOfCheckpointsExceededException`

**Purpose of the change**
Fixes #719

**What the code does**
Add a `cancelOutstandingCheckpoints` call when the checkpoint hits `MaxNumberOfCheckpointsExceededException`

**How to verify it**
`./gradlew clean build` passes