### PR TITLE
[issue-725] Update connector version to 0.13.1-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,13 @@ supported versions of Flink and Pravega.
 
 | Git Branch                                                                          | Pravega Version | Flink Version | Status            | Artifact Link                                                                        |
 |-------------------------------------------------------------------------------------|-----------------|---------------|-------------------|--------------------------------------------------------------------------------------|
-| [master](https://github.com/pravega/flink-connectors)                               | 0.13            | 1.16          | Under Development | https://github.com/pravega/flink-connectors/packages/1441637                         |
-| [r0.13-flink1.15](https://github.com/pravega/flink-connectors/tree/r0.13-flink1.15) | 0.13            | 1.15          | Under Development | https://github.com/pravega/flink-connectors/packages/1441637                         |
-| [r0.13-flink1.14](https://github.com/pravega/flink-connectors/tree/r0.13-flink1.14) | 0.13            | 1.14          | Under Development | https://github.com/pravega/flink-connectors/packages/1441637                         |
+| [master](https://github.com/pravega/flink-connectors)                               | 0.14            | 1.16          | Under Development | https://github.com/pravega/flink-connectors/packages/1441637                         |
+| [r0.13](https://github.com/pravega/flink-connectors/tree/r0.13)                     | 0.13            | 1.16          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.16_2.12/0.13.0/ |
+| [r0.13-flink1.15](https://github.com/pravega/flink-connectors/tree/r0.13-flink1.15) | 0.13            | 1.15          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.15_2.12/0.13.0/ |
+| [r0.13-flink1.14](https://github.com/pravega/flink-connectors/tree/r0.13-flink1.14) | 0.13            | 1.14          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.14_2.12/0.13.0/ |
 | [r0.12](https://github.com/pravega/flink-connectors/tree/r0.12)                     | 0.12            | 1.15          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.15_2.12/0.12.0/ |
 | [r0.12-flink1.14](https://github.com/pravega/flink-connectors/tree/r0.12-flink1.14) | 0.12            | 1.14          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.14_2.12/0.12.0/ |
 | [r0.12-flink1.13](https://github.com/pravega/flink-connectors/tree/r0.12-flink1.13) | 0.12            | 1.13          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.13_2.12/0.12.0/ |
-| [r0.11](https://github.com/pravega/flink-connectors/tree/r0.11)                     | 0.11            | 1.14          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.14_2.12/0.11.0/ |
-| [r0.11-flink1.13](https://github.com/pravega/flink-connectors/tree/r0.11-flink1.13) | 0.11            | 1.13          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.13_2.12/0.11.0/ |
-| [r0.11-flink1.12](https://github.com/pravega/flink-connectors/tree/r0.11-flink1.12) | 0.11            | 1.12          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.12_2.12/0.11.0/ |
 
 ## How to build
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,9 +39,9 @@ nettyVersion=4.1.65.Final
 testcontainersVersion=1.15.3
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.13.0-SNAPSHOT
-pravegaVersion=0.13.0-3184.23d8ef6-SNAPSHOT
-schemaRegistryVersion=0.6.0-88.65039cd-SNAPSHOT
+connectorVersion=0.13.1-SNAPSHOT
+pravegaVersion=0.13.0
+schemaRegistryVersion=0.6.0
 apacheCommonsVersion=3.7
 
 # These properties are only needed for publishing to maven central


### PR DESCRIPTION
**Change log description**
Update connector to `0.13.1-SNAPSHOT` on `r0.13` branch

**Purpose of the change**
Fix #725  

**What the code does**
Update `connectorVersion` in `gradle.properties`
Update compatibility matrix in `README.md`

**How to verify it**
`./gradlew clean build` passed
