### PR TITLE
[issue-730] Upgrade to flink 1.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ supported versions of Flink and Pravega.
 
 | Git Branch                                                                          | Pravega Version | Flink Version | Status            | Artifact Link                                                                        |
 |-------------------------------------------------------------------------------------|-----------------|---------------|-------------------|--------------------------------------------------------------------------------------|
-| [master](https://github.com/pravega/flink-connectors)                               | 0.14            | 1.17          | Under Development | https://github.com/pravega/flink-connectors/packages/1441637                         |
+| [master](https://github.com/pravega/flink-connectors)                               | 0.14            | 1.18          | Under Development | https://github.com/pravega/flink-connectors/packages/19676441                        |
+| [r0.14-flink1.17](https://github.com/pravega/flink-connectors/tree/r0.14-flink1.17) | 0.14		| 1.17		| Under Development | https://github.com/pravega/flink-connectors/packages/1441637			   |
 | [r0.14-flink1.16](https://github.com/pravega/flink-connectors/tree/r0.14-flink1.16) | 0.14            | 1.16          | Under Development | https://github.com/pravega/flink-connectors/packages/1704300                         |
 | [r0.13](https://github.com/pravega/flink-connectors/tree/r0.13)                     | 0.13            | 1.16          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.16_2.12/0.13.0/ |
 | [r0.13-flink1.15](https://github.com/pravega/flink-connectors/tree/r0.13-flink1.15) | 0.13            | 1.15          | Released          | https://repo1.maven.org/maven2/io/pravega/pravega-connectors-flink-1.15_2.12/0.13.0/ |

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # 3rd party Versions.
 assertjVersion=3.23.1
 checkstyleToolVersion=7.1
-flinkVersion=1.17.1
+flinkVersion=1.18.1
 flinkScalaVersion=2.12
 jacksonVersion=2.8.9
 twitterMvnRepoVersion=4.3.4-TWTTR

--- a/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
@@ -135,7 +135,7 @@ public class PravegaCatalogITCase {
         assertThat(actualCatalog instanceof PravegaCatalog).isTrue();
         assertThat(((PravegaCatalog) actualCatalog).getName()).isEqualTo(CATALOG.getName());
         assertThat(((PravegaCatalog) actualCatalog).getDefaultDatabase()).isEqualTo(CATALOG.getDefaultDatabase());
-        org.assertj.core.api.Assertions.assertThat((Map) Whitebox.getInternalState(actualCatalog, "properties"))
+        assertThat((Map) Whitebox.getInternalState(actualCatalog, "properties"))
                 .isEqualTo(Whitebox.getInternalState(CATALOG, "properties"));
     }
 

--- a/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/PravegaCatalogITCase.java
@@ -135,7 +135,7 @@ public class PravegaCatalogITCase {
         assertThat(actualCatalog instanceof PravegaCatalog).isTrue();
         assertThat(((PravegaCatalog) actualCatalog).getName()).isEqualTo(CATALOG.getName());
         assertThat(((PravegaCatalog) actualCatalog).getDefaultDatabase()).isEqualTo(CATALOG.getDefaultDatabase());
-        assertThat(Whitebox.getInternalState(actualCatalog, "properties"))
+        org.assertj.core.api.Assertions.assertThat((Map) Whitebox.getInternalState(actualCatalog, "properties"))
                 .isEqualTo(Whitebox.getInternalState(CATALOG, "properties"));
     }
 

--- a/src/test/java/io/pravega/connectors/flink/sink/PravegaSinkWriterITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/sink/PravegaSinkWriterITCase.java
@@ -148,7 +148,7 @@ public class PravegaSinkWriterITCase {
         SinkInitContext(
                 SinkWriterMetricGroup metricGroup) {
             this.metricGroup = metricGroup;
-                }
+        }
 
         @Override
         public JobID getJobId() {

--- a/src/test/java/io/pravega/connectors/flink/sink/PravegaSinkWriterITCase.java
+++ b/src/test/java/io/pravega/connectors/flink/sink/PravegaSinkWriterITCase.java
@@ -21,10 +21,12 @@ import io.pravega.connectors.flink.utils.PravegaTestEnvironment;
 import io.pravega.connectors.flink.utils.runtime.PravegaRuntime;
 import io.pravega.connectors.flink.utils.runtime.PravegaRuntimeOperator;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.connector.base.DeliveryGuarantee;
@@ -146,6 +148,21 @@ public class PravegaSinkWriterITCase {
         SinkInitContext(
                 SinkWriterMetricGroup metricGroup) {
             this.metricGroup = metricGroup;
+                }
+
+        @Override
+        public JobID getJobId() {
+            return null;
+        }
+
+        @Override
+        public <T> TypeSerializer<T> createInputSerializer() {
+            return null;
+        }
+
+        @Override
+        public boolean isObjectReuseEnabled() {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
**Change log description**
1. Upgrade of Flink version to 1.18.1 on master branch
2. Changes w.r.t [FLINK_32376](https://github.com/apache/flink/pull/22840/commits/b14aae6c197d3b34021286b1d882af14930d4cb5) for Sink Init Context
3. Changes w.r.t [FLINK-31972](https://github.com/apache/flink/pull/22503/files) for fixing the ambiguous usage of `assertThat`


**Purpose of the change**
Fix: #730 

**What the code does**
Upgrade flinkVersion to 1.18.1 in gradle.properties

**How to verify it**
./gradlew clean build should pass